### PR TITLE
Feature/ABW-210 Account Card Asset Icon Row

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,7 @@ let package = Package(
 				"AccountPortfolio",
 				"Address",
 				"Asset",
+				"FungibleTokenListFeature",
 				"Profile",
 				tca,
 			]

--- a/Sources/AccountListFeature/Components/Row/Row+View.swift
+++ b/Sources/AccountListFeature/Components/Row/Row+View.swift
@@ -3,6 +3,7 @@ import Address
 import Asset
 import Common
 import ComposableArchitecture
+import FungibleTokenListFeature
 import SwiftUI
 
 // MARK: - AccountList.Row.View
@@ -49,7 +50,7 @@ public extension AccountList.Row.View {
 					.frame(maxWidth: 160)
 				}
 
-				TokenListView(tokens: viewStore.state.portfolio.fungibleTokenContainers.map(\.asset))
+				TokenListView(containers: viewStore.state.portfolio.fungibleTokenContainers)
 			}
 			.padding(25)
 			.background(Color.app.cardBackgroundLight)
@@ -156,21 +157,25 @@ private struct TokenView: View {
 
 // MARK: - TokenListView
 private struct TokenListView: View {
-	let tokens: [FungibleToken]
+	private let sortedTokens: [FungibleTokenContainer]
 	private let limit = 5
 
+	init(containers: [FungibleTokenContainer]) {
+		sortedTokens = FungibleTokenListSorter.live.sortTokens(containers).map(\.tokenContainers).flatMap { $0 }
+	}
+
 	var body: some View {
-		if tokens.count > limit {
+		if sortedTokens.count > limit {
 			HStack(spacing: -10) {
-				ForEach(tokens[0 ..< limit]) { token in
-					TokenView(code: token.code ?? "")
+				ForEach(sortedTokens[0 ..< limit]) { token in
+					TokenView(code: token.asset.code ?? "")
 				}
-				TokenView(code: "+\(tokens.count - limit)")
+				TokenView(code: "+\(sortedTokens.count - limit)")
 			}
 		} else {
 			HStack(spacing: -10) {
-				ForEach(tokens) { token in
-					TokenView(code: token.code ?? "")
+				ForEach(sortedTokens) { token in
+					TokenView(code: token.asset.code ?? "")
 				}
 			}
 		}


### PR DESCRIPTION
Since this was already done previously, this PR just adds sorting functionality to assets list in the account row, so now it follows the same order like in account details view (XRD first, the rest sorted by value).

Jira: https://radixdlt.atlassian.net/browse/ABW-229

<img width="564" alt="Screenshot 2022-10-04 at 08 22 55" src="https://user-images.githubusercontent.com/12729242/193749975-f2be9aa5-8ab7-4ff7-864d-c2db3147ca07.png">
