### PR TITLE
Fix/ABW-666 Asset fetching

### DIFF
--- a/Sources/Clients/AccountPortfolio/AssetFetcher/AssetFetcher+Live.swift
+++ b/Sources/Clients/AccountPortfolio/AssetFetcher/AssetFetcher+Live.swift
@@ -15,8 +15,12 @@ extension AssetFetcher: DependencyKey {
 			var accountPortfolio = try AccountPortfolio(response: resourcesResponse)
 
 			let fungibleTokenAddresses = accountPortfolio.fungibleTokenContainers.map(\.asset.address)
+			// NOTE: not used currently
 			let nonFungibleTokenAddresses = accountPortfolio.nonFungibleTokenContainers.map(\.asset.address)
 
+			guard !fungibleTokenAddresses.isEmpty else {
+				return .empty
+			}
 			let request = GatewayAPI.EntityOverviewRequest(addresses: fungibleTokenAddresses)
 			let overviewResponse = try await gatewayAPIClient.resourcesOverview(request)
 


### PR DESCRIPTION
This PR fixes fetching of assets when portfolio is empty, since `EntityOverviewRequest` cannot be executed with an empty array (when user has no assets).