### PR TITLE
update engine toolkit and profile

### DIFF
--- a/App/BabylonWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/BabylonWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:radixdlt/swift-engine-toolkit.git",
       "state" : {
-        "revision" : "870bd8de4aca927b7395ff904233202284b0c985",
-        "version" : "0.1.8"
+        "revision" : "baa5ccd353b076b146ad1fac5e3be221a25ed44d",
+        "version" : "0.1.9"
       }
     },
     {
@@ -248,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:radixdlt/swift-profile.git",
       "state" : {
-        "revision" : "e4913632248116608a485551245dd629fd67b59b",
-        "version" : "0.0.53"
+        "revision" : "74f1f86de66bb55a0439adccaf1fdfbde83573a4",
+        "version" : "0.0.54"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ package.dependencies += [
 	// RDX Works dependencies
 	.package(url: "git@github.com:radixdlt/Bite.git", from: "0.0.1"),
 	.package(url: "git@github.com:radixdlt/Converse.git", from: "0.2.1"),
-	.package(url: "git@github.com:radixdlt/swift-engine-toolkit.git", from: "0.1.8"),
-	.package(url: "git@github.com:radixdlt/swift-profile.git", from: "0.0.53"),
+	.package(url: "git@github.com:radixdlt/swift-engine-toolkit.git", from: "0.1.9"),
+	.package(url: "git@github.com:radixdlt/swift-profile.git", from: "0.0.54"),
 
 	// ~~~ THIRD PARTY ~~~
 	// APPLE


### PR DESCRIPTION
This is related to this message: 
https://rdxworks.slack.com/archives/C04E5DY3R9P/p1670890132572499

After this gets merged we should not create NFTs with the Manifest that contains "LOCKED" but rather "DenyAll"