### PR TITLE
Fix/ABW-739 Account details - Asset view - keep the state after pull to refresh

### DIFF
--- a/Sources/Features/AssetsViewFeature/AssetsView+State.swift
+++ b/Sources/Features/AssetsViewFeature/AssetsView+State.swift
@@ -7,14 +7,16 @@ import NonFungibleTokenListFeature
 public extension AssetsView {
 	// MARK: State
 	struct State: Equatable {
-		public var type: AssetsViewType = .tokens
+		public var type: AssetsViewType
 		public var fungibleTokenList: FungibleTokenList.State
 		public var nonFungibleTokenList: NonFungibleTokenList.State
 
 		public init(
+			type: AssetsViewType = .tokens,
 			fungibleTokenList: FungibleTokenList.State,
 			nonFungibleTokenList: NonFungibleTokenList.State
 		) {
+			self.type = type
 			self.fungibleTokenList = fungibleTokenList
 			self.nonFungibleTokenList = nonFungibleTokenList
 		}

--- a/Sources/Features/HomeFeature/Coordinator/Home+Reducer.swift
+++ b/Sources/Features/HomeFeature/Coordinator/Home+Reducer.swift
@@ -135,6 +135,7 @@ public struct Home: ReducerProtocol {
 				let categories = accountPortfolio.fungibleTokenContainers.elements.sortedIntoCategories()
 
 				state.accountDetails?.assets = .init(
+					type: details.assets.type,
 					fungibleTokenList: .init(
 						sections: .init(uniqueElements: categories.map { category in
 							let rows = category.tokenContainers.map { container in FungibleTokenList.Row.State(container: container, currency: .usd, isCurrencyAmountVisible: true) }


### PR DESCRIPTION
## Description

This PR fixes a bug where state is being reset after pull to refresh, so token tab was displayed after pull to refresh even if NFT tab was selected.

## Video


https://user-images.githubusercontent.com/12729242/208129435-2a2afdd0-c801-4f64-8e6e-cabe4adb32cb.mp4



