### PR TITLE
[skip cd] Deploy on alpha build

### DIFF
--- a/.github/workflows/test_flight_deploy.yml
+++ b/.github/workflows/test_flight_deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
   testFlightDeploy:
     name: "Test Flight Deploy"
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true && !contains(github.event.head_commit.message, '[skip cd]') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true && !(contains(github.event.head_commit.message, '[skip cd]') || contains(github.event.head_commit.message, '[cd skip]') }}
     runs-on: macos-12
 
     steps:


### PR DESCRIPTION
CD on merge to main:

- Run the TF deploy workflow after a PR is closed and merged to `main` branch, it will publish an alpha flavour build.
- Added `[skip cd]` option to allow skipping the cd.