### PR TITLE
[skip cd] Deploy alpha build on push to main

### DIFF
--- a/.github/workflows/test_flight_deploy.yml
+++ b/.github/workflows/test_flight_deploy.yml
@@ -10,17 +10,15 @@ on:
           - alpha
           - beta
           # - release
-  pull_request:
+  push:
     branches:
       - main
-    types:
-      - closed
 
 jobs:
 
   testFlightDeploy:
     name: "Test Flight Deploy"
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true && !(contains(github.event.head_commit.message, '[skip cd]') || contains(github.event.head_commit.message, '[cd skip]')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !(contains(github.event.head_commit.message, '[skip cd]') || contains(github.event.head_commit.message, '[cd skip]')) }}
     runs-on: macos-12
 
     steps:


### PR DESCRIPTION
The combination of closed PR and merged seems to not be working as expected, switch instead to `push on main` event, which should be equivalent of merging a PR.