### PR TITLE
[skip cd] Add concurrency to alpha deploy

### DIFF
--- a/.github/workflows/test_flight_deploy.yml
+++ b/.github/workflows/test_flight_deploy.yml
@@ -15,7 +15,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
If a new PR was merged while the deploy for the old one was in progress, cancel the old deploy and do a new one incorporating latest changes.