### PR TITLE
[ABW-889] Load environment in generate_new_dev_certificates lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,6 +67,7 @@ platform :ios do
 
     desc "Generate new dev certificates"
     lane :generate_new_dev_certificates do
+        Dotenv.load ".env.ios.dev"
         code_signing(type: "development", readonly: false)
     end
 


### PR DESCRIPTION
I was not able to run the `bundle exec fastlane ios register_new_iphone_device` command, specifically `get_xcconfig_value` failed because it couldn't find the path to the `iOS/iOS-dev.xcconfig` file, which can be found in the env file.

It turns out that the `register_new_iphone_device` lane was not calling `Dotenv.load`, so this PR fixes this. 

https://radixdlt.atlassian.net/browse/ABW-889