### PR TITLE
[ABW-840] Change one usage of the name "nebunet" to "betanet"

### DIFF
--- a/Sources/Features/ManageGatewayAPIEndpointsFeature/ManageGatewayAPIEndpoints+View.swift
+++ b/Sources/Features/ManageGatewayAPIEndpointsFeature/ManageGatewayAPIEndpoints+View.swift
@@ -145,7 +145,7 @@ private extension ManageGatewayAPIEndpoints.View {
 				.textStyle(.secondaryHeader)
 
 			HStack {
-				label(L10n.ManageGateway.networkName, value: networkAndGateway.network.name)
+				label(L10n.ManageGateway.networkName, value: ViewState.resolveName(network: networkAndGateway.network))
 				Spacer()
 				label(L10n.ManageGateway.networkID, value: networkAndGateway.network.id)
 			}
@@ -173,6 +173,14 @@ extension ManageGatewayAPIEndpoints.View {
 			focusedField = state.focusedField
 		}
 	}
+}
+
+extension ManageGatewayAPIEndpoints.View.ViewState {
+	static func resolveName(network: Network) -> String {
+		networkNameMap[network] ?? network.name.rawValue
+	}
+
+	private static let networkNameMap: [Network: String] = [.nebunet: "betanet", .mardunet: "betanet"]
 }
 
 #if DEBUG

--- a/Sources/Profile/ProfileModels/Model/PerNetwork/Network.swift
+++ b/Sources/Profile/ProfileModels/Model/PerNetwork/Network.swift
@@ -23,7 +23,7 @@ public extension Network {
 	typealias Name = Tagged<Self, String>
 
 	static let nebunet = Self(
-		name: "betanet",
+		name: "nebunet",
 		id: .nebunet
 	)
 	static let hammunet = Self(


### PR DESCRIPTION
This discussion mentions a case where the betanet is given the label "nebunet", so this PR tries to correct that:

https://rdxworks.slack.com/archives/C03Q8QK1GLW/p1673959921987609?thread_ts=1673957381.370279&cid=C03Q8QK1GLW