### PR TITLE
Remove Transfer button from assets view

### DIFF
--- a/Sources/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
+++ b/Sources/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
@@ -46,6 +46,7 @@ public extension AccountDetails.View {
 					.padding(.bottom, .medium1)
 
 					// TODO: @davdroman take care of proper Asset Transfer implementation
+					// when we have the proper spec and designs
 //					#if DEBUG // FF
 //					Button(
 //						"Transfer",


### PR DESCRIPTION
This is a take it or leave it kinda thing. But seeing as it's [confusing testers](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1676020947450879?thread_ts=1676020335.152919&cid=C03QFAWBRNX) into thinking the feature is available in alpha builds, when it's actually half implemented, is probably not great.

I'll be afk for the next 1.5h but anyone feel free to discuss this PR below, and merge it or close it depending on the outcome of said discussion.