### PR TITLE
[AWAIT Gateway Schema Update PR] make fetch XRD balance non throwing

### DIFF
--- a/Sources/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/Sources/Clients/TransactionClient/TransactionClient+Live.swift
@@ -300,7 +300,8 @@ extension TransactionClient {
 					let accountAddressesSuitableToPayTransactionFeeRef =
 						try engineToolkitClient.accountAddressesSuitableToPayTransactionFee(accountsSuitableToPayForTXFeeRequest)
 
-					let xrdContainers = try await accountAddressesSuitableToPayTransactionFeeRef.concurrentMap { try await accountPortfolioFetcher.fetchXRDBalance(of: $0, on: networkID) }
+					let xrdContainersOptionals = try await accountAddressesSuitableToPayTransactionFeeRef.concurrentMap { try await accountPortfolioFetcher.fetchXRDBalance(of: $0, on: networkID) }
+					let xrdContainers = xrdContainersOptionals.compactMap { $0 }
 					let firstWithEnoughFunds = xrdContainers.first(where: { $0.unsafeFailingAmountWithoutPrecision >= Float(lockFeeAmount) })?.owner
 
 					if let firstWithEnoughFunds = firstWithEnoughFunds {


### PR DESCRIPTION
This PR is hopefully not needed, perhaphs @GhenadieVP s coming PR for ticket https://radixdlt.atlassian.net/browse/ABW-935 fixing this? maybe? but if not, this fixes it.

# Issue:
A Send tokens from account `A` to account `B` sent from Dashboard never is displayed, during presentation it is aborted **IF `B` has no XRD balance**.

# Cause
The cause is that `fetchXRDBalance` throws an error, because it fails to fetch XRDs. 

# Video before fix
Wait 10 sec after having "logged in" to Dashboard dapp, I'm preparing the TX in Dashboard...
https://user-images.githubusercontent.com/116169792/218495232-fcbf3e3b-83d9-44d9-bfd4-3070e93a6cb9.MOV

# Video after fix
https://user-images.githubusercontent.com/116169792/218495063-f8a09a1e-b8b6-4573-8111-f2b10a317e5b.MOV