### PR TITLE
Bump `Introspect` dependency

### DIFF
--- a/App/BabylonWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/BabylonWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -257,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
-        "revision" : "f2616860a41f9d9932da412a8978fec79c06fe24",
-        "version" : "0.1.4"
+        "revision" : "fc40fb11d4922d6e936a3d2abaa54bcab4fc877e",
+        "version" : "0.2.0"
       }
     },
     {


### PR DESCRIPTION
Fixes `NavigationStack` transition sometimes falling back to system default for dApp flow.

https://user-images.githubusercontent.com/116723827/218705976-629a0a83-70f8-442d-8e16-335e2dd80e1a.mov


