### PR TITLE
do not display error about unknown version

### DIFF
--- a/Sources/Clients/ProfileClientLive/ProfileClient+Live.swift
+++ b/Sources/Clients/ProfileClientLive/ProfileClient+Live.swift
@@ -166,13 +166,19 @@ extension ProfileClient {
 						jsonDecoder: jsonDecoder()
 					)
 				} catch {
-					return .failure(
-						.decodingFailure(
-							json: profileSnapshotData,
-							.known(.noProfileSnapshotVersionFoundInJSON
-							)
-						)
-					)
+//					return .failure(
+//						.decodingFailure(
+//							json: profileSnapshotData,
+//							.known(.noProfileSnapshotVersionFoundInJSON
+//							)
+//						)
+//					)
+					// FIXME: post betanet v2, remove this and return `failure(.noProfileSnapshotVersionFoundInJSON)`
+					// above instead
+					return .failure(.profileVersionOutdated(
+						json: profileSnapshotData,
+						version: 1 // irrelevant, not show to user.
+					))
 				}
 
 				do {


### PR DESCRIPTION
This PR hides this error alert displayed to all betanet users:
![image](https://user-images.githubusercontent.com/116169792/218730098-2be5ca43-6ed0-4aec-9429-d26ff5d29489.png)

# Correctness reasoning:
This PR **should** fix the alert since the execution path that shows the alert is (was):

```swift
	case let .failure(.decodingFailure(_, error)):
				errorQueue.schedule(error)
				return goToOnboarding(state: &state)
```

i.e. only when `ProfileClient` returns `failure(.decodingFailure)`, which happens since we switch from `String` -> `Int` for `Profile.Snapshot.Version`.

In this PR I temporarily return `.failure(.profileVersionOutdated) instead of `decodingFailure`, which in reducer does not call `errorQueue.schedule`:

```swift
	case let .failure(.profileVersionOutdated(_, version)):
				return incompatibleSnapshotData(version: version, state: &state)
			}
```

hence: it should work.

# Proof of work (pun intended)

https://user-images.githubusercontent.com/116169792/218731561-7944c557-88a1-448b-91b5-746e394d8458.MOV

