### PR TITLE
Automatically dismiss success screenw hen new DapRequests is made

### DIFF
--- a/Sources/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/Sources/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -179,7 +179,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 
 		switch state.currentModal {
 		case .some(.dappInteractionCompletion):
-			return delayedPresentationEffect(for: .child(.modal(.presented(.dappInteractionCompletion(.delegate(.dismiss))))))
+			return .send(.child(.modal(.presented(.dappInteractionCompletion(.delegate(.dismiss))))))
 		case .none:
 			state.currentModal = .dappInteraction(.relayed(next, with: .init(interaction: next.interaction)))
 			return ensureCurrentModalIsActuallyPresentedEffect(for: &state)


### PR DESCRIPTION
Jira ticket: https://radixdlt.atlassian.net/browse/ABW-1008

## Description
Sometimes it happened that when a new DapRequest is made while the Success Screen is shown, the DapRequest will not be handled after the Success Screen is dismissed.

Updated the code, so the Success Screen is automatically dismissed when a new DapRequest was made.

## How to test

### Happy path (or test variation 1)

1. Make a DapRequest from the dashboard - for example an Account Transfer.
2. Handle the request in Wallet, but do not dismiss the Success Screen.
3. While the Success Screen is shown, make another DapRequest.
4. The Success Screen is automatically dismissed, and the new DapRequest is shown in the Wallet.

## Video


https://user-images.githubusercontent.com/118184705/220127341-c679e511-516f-4fa1-bd02-0bc92fb9d033.mov


## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
