### PR TITLE
Fix/ABW1138 - Tick symbol present when gateway is NOT connected

### DIFF
--- a/Sources/Features/GatewaySettingsFeature/Components/GatewayList/GatewayList+Reducer.swift
+++ b/Sources/Features/GatewaySettingsFeature/Components/GatewayList/GatewayList+Reducer.swift
@@ -46,9 +46,6 @@ public struct GatewayList: Sendable, FeatureReducer {
 		case let .gateway(id: id, action: .delegate(action)):
 			switch action {
 			case .didSelect:
-				state.gateways.forEach {
-					state.gateways[id: $0.id]?.isSelected = $0.id == id
-				}
 				guard let gateway = state.gateways[id: id] else { return .none }
 				return .send(.delegate(.switchToGateway(gateway.gateway)))
 

--- a/Sources/Features/GatewaySettingsFeature/GatewaySettings+Reducer.swift
+++ b/Sources/Features/GatewaySettingsFeature/GatewaySettings+Reducer.swift
@@ -191,7 +191,11 @@ public struct GatewaySettings: Sendable, FeatureReducer {
 			)
 			return .none
 
-		case .switchToGatewayResult(.success):
+		case let .switchToGatewayResult(.success(gateway)):
+			state.gatewayList.gateways.forEach {
+				state.gatewayList.gateways[id: $0.id]?.isSelected = $0.id == gateway.id
+			}
+
 			if let gatewayForRemoval = state.gatewayForRemoval {
 				state.gatewayForRemoval = nil
 				return .run { send in


### PR DESCRIPTION
Jira ticket: [paste link here](https://radixdlt.atlassian.net/browse/ABW-1138)

## Description
This PR solves fixes a bug where user dismisses the account creation screen upon switching to the newly created gateway, and the newly created gateway is wrongly selected.

## How to test
Please follow testing steps from the relevant Jira ticket.

## Video (fixed behavior)
https://user-images.githubusercontent.com/12729242/225012524-8c62b813-42d7-48ce-a71d-7f8ddc82a5a2.mov

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
