### PR TITLE
[ABW-1165] Bugfix user could not create account after starting wallet with too old Profile format

### DIFF
--- a/Sources/Clients/ProfileStore/ProfileStore.swift
+++ b/Sources/Clients/ProfileStore/ProfileStore.swift
@@ -390,6 +390,8 @@ extension ProfileStore {
 				factorSource: factorSource
 			))
 
+			loggerGlobal.debug("Created new profile with factorSourceID: \(factorSource.id)")
+
 			return Profile(factorSource: factorSource, creatingDevice: deviceDescription)
 
 		} catch {

--- a/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -118,9 +118,6 @@ extension SecureStorageClient: DependencyKey {
 			},
 			deleteMnemonicByFactorSourceID: deleteMnemonicByFactorSourceID,
 			deleteProfileAndMnemonicsByFactorSourceIDs: {
-				#if DEBUG
-				try await keychainClient.removeAllItems()
-				#else
 				guard let profileSnapshotData = try await loadProfileSnapshotData() else {
 					return
 				}
@@ -129,9 +126,9 @@ extension SecureStorageClient: DependencyKey {
 					return
 				}
 				for factorSourceID in profileSnapshot.factorSources.map(\.id) {
+					loggerGlobal.debug("Deleting factor source with ID: \(factorSourceID)")
 					try await deleteMnemonicByFactorSourceID(factorSourceID)
 				}
-				#endif
 			}
 		)
 	}()

--- a/Sources/Clients/UseFactorSourceClient/UseFactorSourceClient+Live.swift
+++ b/Sources/Clients/UseFactorSourceClient/UseFactorSourceClient+Live.swift
@@ -20,7 +20,7 @@ extension UseFactorSourceClient: DependencyKey {
 					let mnemonicWithPassphrase = try await secureStorageClient
 					.loadMnemonicByFactorSourceID(factorSourceID, .createEntity(kind: request.entityKind))
 				else {
-					loggerGlobal.critical("Failed to find factor source.")
+					loggerGlobal.critical("Failed to find factor source with ID: '\(factorSourceID)'")
 					throw FailedToFindFactorSource()
 				}
 				let hdRoot = try mnemonicWithPassphrase.hdRoot()

--- a/Sources/Profile/Factor/FactorSourceID.swift
+++ b/Sources/Profile/Factor/FactorSourceID.swift
@@ -4,7 +4,7 @@ import Prelude
 // MARK: - FactorSourceID
 /// Double Hash of PublicKey, in case of HD it is the Hash of the public key derived
 /// using CAP26 derivationPath: m/44'/1022'/365'
-public struct FactorSourceID: Sendable, Hashable, CodableViaHexCodable {
+public struct FactorSourceID: Sendable, Hashable, CodableViaHexCodable, CustomStringConvertible {
 	public enum Error: String, Swift.Error, Hashable {
 		case invalidByteCount
 	}
@@ -16,5 +16,11 @@ public struct FactorSourceID: Sendable, Hashable, CodableViaHexCodable {
 			throw Error.invalidByteCount
 		}
 		self.hexCodable = hexCodable
+	}
+}
+
+extension FactorSourceID {
+	public var description: String {
+		hexCodable.hex()
 	}
 }


### PR DESCRIPTION
Jira ticket: [ABW-1165](https://radixdlt.atlassian.net/browse/ABW-1165)

## Description
On DEBUG build only, we accidentally deleted the new ephemeral factor source, which prevented user from proceeding with wallet after having deleted the wallet which had an incompatible version.

### Notes
Additional notes.

## Video
paste link here

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works, [TXID](https://betanet-dashboard.radixdlt.com/transaction/f6b47540631fabf0d6db30076b365800e8f8b64948a99a371eb7b483c2abddf5)


[ABW-1165]: https://radixdlt.atlassian.net/browse/ABW-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ