### PR TITLE
Add/remove missing/obsolete schemes

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AuthorizedDAppsFeatures.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AuthorizedDAppsFeatures.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AuthorizedDAppsFeatures"
+               BuildableName = "AuthorizedDAppsFeatures"
+               BlueprintName = "AuthorizedDAppsFeatures"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AuthorizedDAppsFeatures"
+            BuildableName = "AuthorizedDAppsFeatures"
+            BlueprintName = "AuthorizedDAppsFeatures"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Unit Tests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Unit Tests.xcscheme
@@ -224,16 +224,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ManageGatewayAPIEndpointsFeatureTests"
-               BuildableName = "ManageGatewayAPIEndpointsFeatureTests"
-               BlueprintName = "ManageGatewayAPIEndpointsFeatureTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "NewConnectionFeatureTests"
                BuildableName = "NewConnectionFeatureTests"
                BlueprintName = "NewConnectionFeatureTests"
@@ -527,6 +517,26 @@
                BlueprintIdentifier = "GatewaySettingsFeatureTests"
                BuildableName = "GatewaySettingsFeatureTests"
                BlueprintName = "GatewaySettingsFeatureTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "P2PLinksClientLiveTests"
+               BuildableName = "P2PLinksClientLiveTests"
+               BlueprintName = "P2PLinksClientLiveTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "P2PLinksFeatureTests"
+               BuildableName = "P2PLinksFeatureTests"
+               BlueprintName = "P2PLinksFeatureTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
We should try to be more diligent with these. Unfortunately it's hard to automate checks for it. Maybe it should be a checkbox in the PR template?