### PR TITLE
Debug print for TX

### DIFF
--- a/Sources/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/Sources/Clients/TransactionClient/TransactionClient+Live.swift
@@ -153,6 +153,24 @@ extension TransactionClient {
 				return .failure(.failedToCompileNotarizedTXIntent)
 			}
 
+			func debugPrintTX() {
+				// RET prints when convertManifest is called, when it is removed, this can be moved down
+				// inline inside `print`.
+				let txIntentString = transactionIntent.description(lookupNetworkName: { try? Radix.Network.lookupBy(id: $0).name.rawValue })
+				print("\n\n🔮 DEBUG TRANSACTION START 🔮")
+				print("TXID: \(txID.rawValue)")
+				print("TransactionIntent: \(txIntentString)")
+				print("intentSignatures: \(signedTransactionIntent.intentSignatures.map(\.signature.hex).joined(separator: "\n"))")
+				do {
+					try print("NotarySignature: \(notarySignatureWithPublicKey.signature.serialize().hex)")
+				} catch {}
+				print("Compiled Transaction Intent:\n\n\(compiledTransactionIntent.compiledIntent.hex)\n\n")
+				print("Compiled Notarized Intent:\n\n\(compiledNotarizedTXIntent.compiledIntent.hex)\n\n")
+				print("🔮 DEBUG TRANSACTION END 🔮\n\n")
+			}
+
+			//            debugPrintTX()
+
 			return .success((txID: txID, compiledNotarizedTXIntent: compiledNotarizedTXIntent))
 		}
 

--- a/Sources/EngineToolkit/EngineToolkit/TransactionIntent+CustomDebugStringConvertible.swift
+++ b/Sources/EngineToolkit/EngineToolkit/TransactionIntent+CustomDebugStringConvertible.swift
@@ -1,0 +1,56 @@
+import EngineToolkitModels
+import Prelude
+
+// MARK: - TransactionIntent + CustomStringConvertible
+extension TransactionIntent: CustomStringConvertible {}
+
+// MARK: - TransactionHeader + CustomStringConvertible
+extension TransactionHeader: CustomStringConvertible {}
+
+extension TransactionIntent {
+	public func description(
+		lookupNetworkName: ((NetworkID) -> String?)?
+	) -> String {
+		"""
+		header: \(header.description(lookupNetworkName: lookupNetworkName))
+		manifest:
+		===============================================
+
+		\((try? manifest.toString(
+			preamble: "",
+			instructionsSeparator: "\n",
+			instructionsArgumentSeparator: "\t",
+			networkID: header.networkId
+		)) ?? "\(String(describing: manifest))")
+
+		===============================================
+
+		"""
+	}
+
+	public var description: String {
+		description(lookupNetworkName: nil)
+	}
+}
+
+extension TransactionHeader {
+	public func description(
+		lookupNetworkName: ((NetworkID) -> String?)?
+	) -> String {
+		"""
+		version: \(String(describing: version)),
+		networkId: \(String(describing: networkId))\(lookupNetworkName.map { f in f(networkId).map { " (\($0))" } ?? "" } ?? ""),
+		startEpochInclusive: \(String(describing: startEpochInclusive)),
+		endEpochExclusive: \(String(describing: endEpochExclusive)),
+		nonce: \(String(describing: nonce)),
+		publicKey: \(publicKey.uncompressedRepresentation.hex),
+		notaryAsSignatory: \(String(describing: notaryAsSignatory)),
+		costUnitLimit: \(String(describing: costUnitLimit)),
+		tipPercentage: \(String(describing: tipPercentage)),
+		"""
+	}
+
+	public var description: String {
+		description(lookupNetworkName: nil)
+	}
+}


### PR DESCRIPTION
Adds a debug print usesful for when debugging TX

Output is:

```sh
🔮 DEBUG TRANSACTION START 🔮
TXID: 73dcb4725424503dac2739f0d0e70f74a464e5a971cc9b2c5248663c0121fa40
TransactionIntent: header: version: 1,
networkId: 12 (kisharnet),
startEpochInclusive: 232,
endEpochExclusive: 242,
nonce: 10448620202706496944,
publicKey: 3f0a6d378df0623acb2261f4dafc88bcc3cd88c3a64f7cb1f58a76b30069c952,
notaryAsSignatory: false,
costUnitLimit: 100000000,
tipPercentage: 0,
manifest:
===============================================

CALL_METHOD
	Address("component_tdx_c_1q0kryz5scup945usk39qjc2yjh6l5zsyuh8t7v5pk0tsacmzk0")
	"lock_fee"
	Decimal("10");
CALL_METHOD
	Address("component_tdx_c_1q0kryz5scup945usk39qjc2yjh6l5zsyuh8t7v5pk0tsacmzk0")
	"free";
CALL_METHOD
	Address("account_tdx_c_1p9yae04wwc5u2g7eqwl9wx9g95mtasdg7jxwqrp25pls9hw5pp")
	"deposit_batch"
	Expression("ENTIRE_WORKTOP");

===============================================

intentSignatures: 6ee3137555ed7b28f263aaa6d10424f5a2e544b481c8b923a2702be44436b109b1d3c39a790b73b6c5bf3bd1c4095e1bc7ec984be9a91512c6f3999bfe914c04
NotarySignature: 70345680e5da79fae59cec4183449fa0eb4369591ae62f3ec16c6c22875110d5c14882c9a70094cf3e5f9438c17e9878d8150145ca3bd7f32fc6647bb9cbd108
Compiled Transaction Intent:

4d210221090701070c0ae8000000000000000af2000000000000000ab06d4a17b7f400912201012007203f0a6d378df0623acb2261f4dafc88bcc3cd88c3a64f7cb1f58a76b30069c95201000900e1f505080000210220220321038003ec320a90c7025ad390b44a09614495f5fa0a04e5cebf3281b3d70c086c6f636b5f6665652101850000e8890423c78a00000000000000000000000000000000000000000000000021038003ec320a90c7025ad390b44a09614495f5fa0a04e5cebf3281b3d70c046672656521002103800949dcbeae7629c523d903be5718a82d36bec1a8f48ce00c2aa07f0c0d6465706f7369745f626174636821018300202000


Compiled Notarized Intent:

4d21022102210221090701070c0ae8000000000000000af2000000000000000ab06d4a17b7f400912201012007203f0a6d378df0623acb2261f4dafc88bcc3cd88c3a64f7cb1f58a76b30069c95201000900e1f505080000210220220321038003ec320a90c7025ad390b44a09614495f5fa0a04e5cebf3281b3d70c086c6f636b5f6665652101850000e8890423c78a00000000000000000000000000000000000000000000000021038003ec320a90c7025ad390b44a09614495f5fa0a04e5cebf3281b3d70c046672656521002103800949dcbeae7629c523d903be5718a82d36bec1a8f48ce00c2aa07f0c0d6465706f7369745f62617463682101830020200020220101022007203f0a6d378df0623acb2261f4dafc88bcc3cd88c3a64f7cb1f58a76b30069c95221012007406ee3137555ed7b28f263aaa6d10424f5a2e544b481c8b923a2702be44436b109b1d3c39a790b73b6c5bf3bd1c4095e1bc7ec984be9a91512c6f3999bfe914c04220101210120074070345680e5da79fae59cec4183449fa0eb4369591ae62f3ec16c6c22875110d5c14882c9a70094cf3e5f9438c17e9878d8150145ca3bd7f32fc6647bb9cbd108


🔮 DEBUG TRANSACTION END 🔮
```