### PR TITLE
Don't show "choose X" when there are no entities to choose

### DIFF
--- a/Sources/Features/DappInteractionFeature/Children/Login/Coordinator/Login+View.swift
+++ b/Sources/Features/DappInteractionFeature/Children/Login/Coordinator/Login+View.swift
@@ -6,6 +6,7 @@ extension Login {
 	struct ViewState: Equatable {
 		let title: String
 		let subtitle: AttributedString
+		let shouldShowChooseAPersonaTitle: Bool
 		let availablePersonas: IdentifiedArrayOf<PersonaRow.State>
 		let selectedPersona: PersonaRow.State?
 		let continueButtonRequirements: ContinueButtonRequirements?
@@ -31,6 +32,8 @@ extension Login {
 
 				return dappName + explanation
 			}()
+
+			shouldShowChooseAPersonaTitle = !state.personas.isEmpty
 
 			availablePersonas = state.personas
 			selectedPersona = state.selectedPersona
@@ -61,9 +64,11 @@ extension Login {
 							subtitle: viewStore.subtitle
 						)
 
-						Text(L10n.DApp.Login.chooseAPersonaTitle)
-							.foregroundColor(.app.gray1)
-							.textStyle(.body1Header)
+						if viewStore.shouldShowChooseAPersonaTitle {
+							Text(L10n.DApp.Login.chooseAPersonaTitle)
+								.foregroundColor(.app.gray1)
+								.textStyle(.body1Header)
+						}
 
 						VStack(spacing: .small1) {
 							Selection(

--- a/Sources/Features/DappInteractionFeature/Children/OneTimePersonaData/OneTimePersonaData+View.swift
+++ b/Sources/Features/DappInteractionFeature/Children/OneTimePersonaData/OneTimePersonaData+View.swift
@@ -9,6 +9,7 @@ extension OneTimePersonaData {
 	struct ViewState: Equatable {
 		let title: String
 		let subtitle: AttributedString
+		let shouldShowChooseDataToProvideTitle: Bool
 		let availablePersonas: IdentifiedArrayOf<PersonaDataPermissionBox.State>
 		let selectedPersona: PersonaDataPermissionBox.State?
 		let output: IdentifiedArrayOf<Profile.Network.Persona.Field>?
@@ -33,6 +34,7 @@ extension OneTimePersonaData {
 
 				return dappName + explanation
 			}()
+			shouldShowChooseDataToProvideTitle = !state.personas.isEmpty
 			availablePersonas = state.personas
 			selectedPersona = state.selectedPersona
 			output = {
@@ -67,9 +69,11 @@ extension OneTimePersonaData {
 							subtitle: viewStore.subtitle
 						)
 
-						Text(L10n.DApp.OneTimePersonaData.chooseDataToProvide)
-							.foregroundColor(.app.gray1)
-							.textStyle(.body1Header)
+						if viewStore.shouldShowChooseDataToProvideTitle {
+							Text(L10n.DApp.OneTimePersonaData.chooseDataToProvide)
+								.foregroundColor(.app.gray1)
+								.textStyle(.body1Header)
+						}
 
 						Selection(
 							viewStore.binding(


### PR DESCRIPTION
Small one that Matt reported.

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
