### PR TITLE
Limit request to entityDetails to 999

### DIFF
--- a/Sources/Clients/AccountPortfolioFetcherClient/Client/AccountPortfolioFetcherClient+Live.swift
+++ b/Sources/Clients/AccountPortfolioFetcherClient/Client/AccountPortfolioFetcherClient+Live.swift
@@ -1,8 +1,6 @@
 import ClientPrelude
 import GatewayAPI
 
-private let tmpMaxRequestAmount = 999
-
 // MARK: - AccountPortfolioFetcherClient + DependencyKey
 extension AccountPortfolioFetcherClient: DependencyKey {
 	public static let liveValue: Self = {
@@ -12,6 +10,7 @@ extension AccountPortfolioFetcherClient: DependencyKey {
 			let resourcesResponse = try await gatewayAPIClient.getAccountDetails(accountAddress)
 			var accountPortfolio = try AccountPortfolio(owner: accountAddress, response: resourcesResponse)
 
+			let tmpMaxRequestAmount = 999 // TODO: remove once pagination is implemented
 			let fungibleTokenAddresses = Array(accountPortfolio.fungibleTokenContainers.map(\.asset.componentAddress).prefix(tmpMaxRequestAmount))
 			let nonFungibleTokenAddresses = Array(accountPortfolio.nonFungibleTokenContainers.map(\.resourceAddress).prefix(tmpMaxRequestAmount))
 


### PR DESCRIPTION
limit number of request for `entityDetails` to `999`.

**Before**
https://user-images.githubusercontent.com/116169792/228887390-38a93f69-cabf-456c-95a0-0218d3fb3eb9.MOV

**After**
https://user-images.githubusercontent.com/116169792/228887487-d2d85a27-64d1-46b1-97ff-6cfe1c72e991.MOV