### PR TITLE
Fix/ABW-1228 Reject dApp request with invalid number of accounts

### DIFF
--- a/Sources/Core/SharedModels/P2P/Codable/Models/InteractionResponse/WalletInteractionFailureResponse.swift
+++ b/Sources/Core/SharedModels/P2P/Codable/Models/InteractionResponse/WalletInteractionFailureResponse.swift
@@ -49,6 +49,7 @@ extension P2P.ToDapp.WalletInteractionFailureResponse {
 		case radixJsonUnknownFileFormat
 		case unknownDappDefinitionAddress
 		case invalidPersona
+		case invalidRequest
 
 		public var errorDescription: String? {
 			switch self {
@@ -88,6 +89,8 @@ extension P2P.ToDapp.WalletInteractionFailureResponse {
 				return "dApp definition address does not match any well known definition address"
 			case .invalidPersona:
 				return "Invalid persona specified by dApp"
+			case .invalidRequest:
+				return "Invalid request"
 			}
 		}
 	}

--- a/Sources/Profile/AuthorizedDapp/AuthorizedDapp.swift
+++ b/Sources/Profile/AuthorizedDapp/AuthorizedDapp.swift
@@ -77,6 +77,17 @@ extension Profile.Network.AuthorizedDapp {
 				public let quantifier: Quantifier
 				public let quantity: Int
 
+				public var isValid: Bool {
+					switch (quantifier, quantity) {
+					case (.exactly, 0):
+						return false
+					case (_, ..<0):
+						return false
+					default:
+						return true
+					}
+				}
+
 				public static func exactly(_ quantity: Int) -> Self {
 					.init(quantifier: .exactly, quantity: quantity)
 				}


### PR DESCRIPTION
Jira ticket: https://radixdlt.atlassian.net/browse/ABW-1228
Slack thread: https://rdxworks.slack.com/archives/C031A0V1A1W/p1680195550503079

## Description
This fixes handling of incoming dApp request which contains invalid number of accounts:
- number of accounts is less than 0
- number of accounts is 0, and quantifier is exactly

## How to test

### Negative number of accounts

1. Send a dApp request with a negative number of accounts
2. Verify the request is rejected

### Exactly zero number of accounts

1. Send a dApp request with a exactly 0 number of accounts
2. Verify the request is rejected

## Screenshot

| Rejected request |
| - |
| ![Screen Shot 2023-03-31 at 10 49 50](https://user-images.githubusercontent.com/12729242/229078390-b8cefb51-ab8f-446f-aa75-02eb0152f2ad.png) |

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works - [TX](https://rcnet-dashboard.radixdlt.com/transaction/ecb6d2b369d3509187909f8081b0a308ac002f4d7f15b8fc9de5c7fe97e59591)
