### PR TITLE
Use ResourceAddress in resources

### DIFF
--- a/Sources/Clients/AccountPortfolioFetcherClient/AccountPortfolio+Extensions.swift
+++ b/Sources/Clients/AccountPortfolioFetcherClient/AccountPortfolio+Extensions.swift
@@ -19,12 +19,12 @@ extension AccountPortfolio {
 			.compactMap(\.global)
 			.map { item in
 				let balance = try BigDecimal(fromString: item.amount)
-				let componentAddress = ComponentAddress(address: item.resourceAddress)
-				let isXRD = try engineToolkitClient.isXRD(component: componentAddress, on: networkID)
+				let resourceAddress = ResourceAddress(address: item.resourceAddress)
+				let isXRD = try engineToolkitClient.isXRD(resource: resourceAddress, on: networkID)
 
 				return try FungibleTokenContainer(owner: .init(address: response.details.address),
 				                                  asset: .init(
-				                                  	componentAddress: componentAddress,
+				                                  	resourceAddress: resourceAddress,
 				                                  	isXRD: isXRD
 				                                  ),
 				                                  amount: balance,
@@ -111,7 +111,7 @@ extension FungibleToken {
 		let dict = metadataCollection.asDictionary
 
 		return Self(
-			componentAddress: componentAddress,
+			resourceAddress: resourceAddress,
 			divisibility: divisibility,
 			totalSupply: totalSupply,
 			totalMinted: totalMinted,

--- a/Sources/Clients/AccountPortfolioFetcherClient/Client/AccountPortfolioFetcherClient+Live.swift
+++ b/Sources/Clients/AccountPortfolioFetcherClient/Client/AccountPortfolioFetcherClient+Live.swift
@@ -11,7 +11,7 @@ extension AccountPortfolioFetcherClient: DependencyKey {
 			var accountPortfolio = try AccountPortfolio(owner: accountAddress, response: resourcesResponse)
 
 			let tmpMaxRequestAmount = 999 // TODO: remove once pagination is implemented
-			let fungibleTokenAddresses = Array(accountPortfolio.fungibleTokenContainers.map(\.asset.componentAddress).prefix(tmpMaxRequestAmount))
+			let fungibleTokenAddresses = Array(accountPortfolio.fungibleTokenContainers.map(\.asset.resourceAddress).prefix(tmpMaxRequestAmount))
 			let nonFungibleTokenAddresses = Array(accountPortfolio.nonFungibleTokenContainers.map(\.resourceAddress).prefix(tmpMaxRequestAmount))
 
 			if fungibleTokenAddresses.isEmpty, nonFungibleTokenAddresses.isEmpty {

--- a/Sources/Clients/EngineToolkitClient/EngineToolKitClient+XRD.swift
+++ b/Sources/Clients/EngineToolkitClient/EngineToolKitClient+XRD.swift
@@ -2,8 +2,8 @@ import ClientPrelude
 import EngineToolkit
 
 extension EngineToolkitClient {
-	public func isXRD(component: ComponentAddress, on networkID: NetworkID) throws -> Bool {
-		try isXRD(address: component.address, on: networkID)
+	public func isXRD(resource: ResourceAddress, on networkID: NetworkID) throws -> Bool {
+		try isXRD(address: resource.address, on: networkID)
 	}
 
 	private func isXRD(address: String, on networkID: NetworkID) throws -> Bool {

--- a/Sources/Core/SharedModels/Asset/Assets/Badge.swift
+++ b/Sources/Core/SharedModels/Asset/Assets/Badge.swift
@@ -4,12 +4,12 @@ import Profile
 
 // MARK: - Badge
 public struct Badge: Asset {
-	public let componentAddress: ComponentAddress
+	public let resourceAddress: ResourceAddress
 
 	public init(
-		componentAddress: ComponentAddress
+		resourceAddress: ResourceAddress
 	) {
-		self.componentAddress = componentAddress
+		self.resourceAddress = resourceAddress
 	}
 }
 

--- a/Sources/Core/SharedModels/Asset/Assets/FungibleToken.swift
+++ b/Sources/Core/SharedModels/Asset/Assets/FungibleToken.swift
@@ -4,7 +4,7 @@ import Profile
 
 // MARK: - FungibleToken
 public struct FungibleToken: Sendable, Asset, Token, Hashable {
-	public let componentAddress: ComponentAddress
+	public let resourceAddress: ResourceAddress
 	public let totalSupply: BigDecimal?
 	public let totalMinted: BigDecimal?
 	public let totalBurnt: BigDecimal?
@@ -35,7 +35,7 @@ public struct FungibleToken: Sendable, Asset, Token, Hashable {
 	public let divisibility: Int?
 
 	public init(
-		componentAddress: ComponentAddress,
+		resourceAddress: ResourceAddress,
 		divisibility: Int? = nil,
 		totalSupply: BigDecimal? = nil,
 		totalMinted: BigDecimal? = nil,
@@ -47,7 +47,7 @@ public struct FungibleToken: Sendable, Asset, Token, Hashable {
 		tokenInfoURL: String? = nil,
 		iconURL: URL? = nil
 	) {
-		self.componentAddress = componentAddress
+		self.resourceAddress = resourceAddress
 		self.divisibility = divisibility
 		self.totalSupply = totalSupply
 		self.totalMinted = totalMinted
@@ -87,7 +87,7 @@ public struct FungibleTokenContainer: Sendable, AssetContainer, Hashable {
 extension FungibleToken {
 	/// The native token of the Radix Ledger
 	public static let xrd = Self(
-		componentAddress: "resource_tdx_a_1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqegh4k9",
+		resourceAddress: "resource_tdx_a_1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqegh4k9",
 		divisibility: 18,
 		totalSupply: 24_000_000_000,
 		totalMinted: 0,
@@ -100,7 +100,7 @@ extension FungibleToken {
 	)
 
 	public static let btc = Self(
-		componentAddress: "btc-deadbeef",
+		resourceAddress: "btc-deadbeef",
 		divisibility: 18,
 		totalSupply: 0,
 		totalMinted: 0,
@@ -112,7 +112,7 @@ extension FungibleToken {
 	)
 
 	public static let dot = Self(
-		componentAddress: "dot-deadbeef",
+		resourceAddress: "dot-deadbeef",
 		divisibility: 18,
 		totalSupply: 0,
 		totalMinted: 0,
@@ -124,7 +124,7 @@ extension FungibleToken {
 	)
 
 	public static let eth = Self(
-		componentAddress: "eth-deadbeef",
+		resourceAddress: "eth-deadbeef",
 		divisibility: 18,
 		totalSupply: 0,
 		totalMinted: 0,
@@ -136,7 +136,7 @@ extension FungibleToken {
 	)
 
 	public static let ltc = Self(
-		componentAddress: "ltc-deadbeef",
+		resourceAddress: "ltc-deadbeef",
 		divisibility: 18,
 		totalSupply: 0,
 		totalMinted: 0,
@@ -148,7 +148,7 @@ extension FungibleToken {
 	)
 
 	public static let sol = Self(
-		componentAddress: "sol-deadbeef",
+		resourceAddress: "sol-deadbeef",
 		divisibility: 18,
 		totalSupply: 0,
 		totalMinted: 0,
@@ -160,7 +160,7 @@ extension FungibleToken {
 	)
 
 	public static let usdt = Self(
-		componentAddress: "usdt-deadbeef",
+		resourceAddress: "usdt-deadbeef",
 		divisibility: 18,
 		totalSupply: 0,
 		totalMinted: 0,
@@ -172,7 +172,7 @@ extension FungibleToken {
 	)
 
 	public static let xrp = Self(
-		componentAddress: "xrp-deadbeef",
+		resourceAddress: "xrp-deadbeef",
 		divisibility: 18,
 		totalSupply: 0,
 		totalMinted: 0,

--- a/Sources/Core/SharedModels/Asset/Assets/PoolUnit.swift
+++ b/Sources/Core/SharedModels/Asset/Assets/PoolUnit.swift
@@ -4,12 +4,12 @@ import Profile
 
 // MARK: - PoolUnit
 public struct PoolUnit: Asset {
-	public let componentAddress: ComponentAddress
+	public let resourceAddress: ResourceAddress
 
 	public init(
-		componentAddress: ComponentAddress
+		resourceAddress: ResourceAddress
 	) {
-		self.componentAddress = componentAddress
+		self.resourceAddress = resourceAddress
 	}
 }
 

--- a/Sources/Core/SharedModels/Asset/Protocols/Asset.swift
+++ b/Sources/Core/SharedModels/Asset/Protocols/Asset.swift
@@ -2,13 +2,13 @@ import EngineToolkitModels
 import Prelude
 
 // MARK: - Asset
-public protocol Asset: Sendable, Hashable, Identifiable where ID == ComponentAddress {
+public protocol Asset: Sendable, Hashable, Identifiable {
 	/// The Scrypto Component address of asset.
-	var componentAddress: ComponentAddress { get }
+	var resourceAddress: ResourceAddress { get }
 }
 
 extension Asset {
-	public var id: ID { componentAddress }
+	public var id: ResourceAddress { resourceAddress }
 }
 
 // MARK: - AssetMetadata

--- a/Sources/Features/FungibleTokenDetailsFeature/FungibleTokenDetails+Reducer.swift
+++ b/Sources/Features/FungibleTokenDetailsFeature/FungibleTokenDetails+Reducer.swift
@@ -22,7 +22,7 @@ public struct FungibleTokenDetails: Sendable, FeatureReducer {
 		case .closeButtonTapped:
 			return .send(.delegate(.dismiss))
 		case .copyAddressButtonTapped:
-			return .run { [address = state.asset.componentAddress.address] _ in
+			return .run { [address = state.asset.resourceAddress.address] _ in
 				pasteboardClient.copyString(address)
 			}
 		}

--- a/Sources/Features/FungibleTokenDetailsFeature/FungibleTokenDetails+View.swift
+++ b/Sources/Features/FungibleTokenDetailsFeature/FungibleTokenDetails+View.swift
@@ -9,7 +9,7 @@ extension FungibleTokenDetails.State {
 			amount: amount.format(),
 			symbol: asset.symbol,
 			description: asset.tokenDescription,
-			address: .init(address: asset.componentAddress.address, format: .default),
+			address: .init(address: asset.resourceAddress.address, format: .default),
 			currentSupply: asset.totalMinted
 		)
 	}


### PR DESCRIPTION
Jira ticket: https://radixdlt.atlassian.net/browse/ABW-1245

In some places, like FungibleToken, we use ComponentAddress where we should be using ResourceAddress. This PR fixes that.

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
