### PR TITLE
Check if Olympia Mnemonic already added

### DIFF
--- a/Sources/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator.swift
+++ b/Sources/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator.swift
@@ -141,7 +141,8 @@ public struct ImportOlympiaWalletCoordinator: Sendable, FeatureReducer {
 
 				let destination = Destinations.State.importOlympiaMnemonic(.init(
 					shouldPersist: false,
-					expectedWordCount: expectedWordCount
+					expectedWordCount: expectedWordCount,
+					selectedAccounts: accounts.software
 				))
 
 				if state.path.last != destination {
@@ -328,7 +329,10 @@ extension ImportOlympiaWalletCoordinator {
 					)
 
 				} catch {
-					fatalError("todo, handle terrible bad stuff if failed to save factor source (mnemonic) but have already created accounts....")
+					let msg = "Failed to save factor source (mnemonic) but have already created accounts, error: \(error)"
+					loggerGlobal.critical(.init(stringLiteral: msg))
+					assertionFailure(msg)
+					errorQueue.schedule(error)
 				}
 			}
 


### PR DESCRIPTION
## Description
This PR fixes a small bug from last PR where I forgot to send in the selected accounts to `ImportOlympiaMnemonic` feature. 

I've implemented a button "Already imported" which user can press if she knows that she has already imported the mnemonic for the selected software account(s). 

## Video
https://user-images.githubusercontent.com/116169792/231383497-3c936f2c-615b-44e7-88e0-eef095daf67a.MOV

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works, [TXID](https://rcnet-dashboard.radixdlt.com/transaction/a9425a2d65c5b789c8ad703b17c49b11d76549f5088d8e8a99f65cad587b9e13)
