### PR TITLE
FIX: Only submit transaction once

### DIFF
--- a/Sources/Core/FeaturePrelude/OnFirstTaskViewModifier.swift
+++ b/Sources/Core/FeaturePrelude/OnFirstTaskViewModifier.swift
@@ -1,0 +1,27 @@
+// MARK: - OnFirstTaskViewModifier
+struct OnFirstTaskViewModifier: ViewModifier {
+	let priority: TaskPriority
+	let action: @Sendable () async -> Void
+
+	@State private var didFire = false
+
+	func body(content: Content) -> some View {
+		content.task(priority: priority) {
+			guard !didFire else {
+				return
+			}
+			didFire = true
+			await action()
+		}
+	}
+}
+
+extension View {
+	/// Executes a given action only once, when the first `task` is fired by the system.
+	public func onFirstTask(
+		priority: TaskPriority = .userInitiated,
+		_ action: @escaping @Sendable () async -> Void
+	) -> some View {
+		modifier(OnFirstTaskViewModifier(priority: priority, action: action))
+	}
+}

--- a/Sources/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
+++ b/Sources/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
@@ -41,7 +41,9 @@ extension SubmitTransaction {
 					VPair(heading: "Status", item: viewStore.status.display)
 				}
 				.padding(.medium1)
-				.onAppear { viewStore.send(.appeared) }
+				.onFirstTask { @MainActor in
+					viewStore.send(.appeared)
+				}
 				.navigationTitle("Submitting Transaction")
 			}
 		}


### PR DESCRIPTION
Main currently tries to submit transactions twice, because the SubmitTransaction view "appears" twice, due to it being occluded by another view. This PR fixes this, but should be seen as a temporary measure.

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
