### PR TITLE
ABW-1386 Edit Persona Fix

### DIFF
--- a/Sources/Core/DesignSystem/Components/AppTextField.swift
+++ b/Sources/Core/DesignSystem/Components/AppTextField.swift
@@ -64,7 +64,7 @@ public struct AppTextField<FocusValue: Hashable, Accessory: View>: View {
 	public var body: some View {
 		HStack(alignment: .textFieldAlignment, spacing: 0) {
 			VStack(alignment: .leading, spacing: .small2) {
-				HStack {
+				HStack(spacing: 0) {
 					if let primaryHeading {
 						Text(primaryHeading)
 							.textStyle(.body1HighImportance)
@@ -72,9 +72,7 @@ public struct AppTextField<FocusValue: Hashable, Accessory: View>: View {
 							.multilineTextAlignment(.leading)
 					}
 
-					if primaryHeading != nil || secondaryHeading != nil {
-						Spacer(minLength: 0)
-					}
+					Spacer(minLength: 0)
 
 					if let secondaryHeading {
 						Text(secondaryHeading)


### PR DESCRIPTION
[ABW-1386](https://radixdlt.atlassian.net/browse/ABW-1386)

## Description
The field name heading in Edit Persona should become red when a field has an error.

## How to test

1. Connect a dApp (that requires at least one field, such as First name) with a persona
2. Go to Settings > Authorized dApps > [some persona]
3. Tap Edit persona
4. Remove the string in a required field
-> The field name heading (upper left) should become red

## Screenshot

<img src="https://user-images.githubusercontent.com/123396602/236703484-973aeb21-11a1-4e44-9282-f8872c4b11f8.jpeg" width="200" />

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-1386]: https://radixdlt.atlassian.net/browse/ABW-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ