### PR TITLE
Highlight Part of String

### DIFF
--- a/Sources/Core/FeaturePrelude/AttributedString+Extra.swift
+++ b/Sources/Core/FeaturePrelude/AttributedString+Extra.swift
@@ -8,31 +8,27 @@ extension AttributedString {
 		self = with(AttributedString(string)) { $0.foregroundColor = foregroundColor }
 	}
 
-	public init(markdown: some StringProtocol, emphasizedColor: Color) {
+	public init(markdown: some StringProtocol, replaceItalicsWith italicsColor: Color) {
 		let string = String(markdown)
 		guard let attributed = try? AttributedString(markdown: string) else {
 			self.init(string)
 			return
 		}
 
-		self = attributed.replacingAttributes(.italic, with: .foregroundColor(emphasizedColor))
+		self = attributed.replacingAttributes(.italics, with: .foregroundColor(italicsColor))
 	}
 }
 
 extension AttributeContainer {
-	static let italic: AttributeContainer = {
-		var result = AttributeContainer()
-		result.inlinePresentationIntent = .emphasized
-		return result
-	}()
+	public static let italics: AttributeContainer = intent(.emphasized)
 
-	static let bold: AttributeContainer = {
+	public static func intent(_ intent: InlinePresentationIntent) -> AttributeContainer {
 		var result = AttributeContainer()
-		result.inlinePresentationIntent = .stronglyEmphasized
+		result.inlinePresentationIntent = intent
 		return result
-	}()
+	}
 
-	static func foregroundColor(_ color: Color) -> AttributeContainer {
+	public static func foregroundColor(_ color: Color) -> AttributeContainer {
 		var result = AttributeContainer()
 		result.foregroundColor = color
 		return result


### PR DESCRIPTION
## Description
There are already several places in the app where we want to do this:

- Create strings where some parts come as parameters
- Highlight only some of the parts in a certain color

An example would in a dApp request: "The dApp named [dAppName] wants to connect" where the dAppName is of course a parameter. This can easily be handled with our existing localization scheme:

"The dApp named %s wants to connect"

The problem comes when we want to e.g. highlight part of this string, for example the dApp name, in a different color. The way it was solved is to split this in three strings:

"The dApp named"
[dApp name]
"wants to connect"

color them in different colors, and then assemble the result. This works for English, but won't work in other languages with different word order.

The solution in this PR is to use the ability of markdown to mark parts of a text as bold or italic. The PR then adds functionality to convert e.g. italic text to a certain color. Markdown is supported in localized strings, and it's easy for translators to understand. 

Concretely, if we wanted to highlight the words "wants to connect" above in pink, we would make this our localised string:

```swift
let markdown = "The dApp named %s *wants to connect*"
```

Then in the view code we simply write:

```swift
AttributedString(markdown: markdown, emphasizedColor: .pink)
```

## Screenshot
<img width="236" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/f1bd762b-012a-41a1-93d0-9af54ba9e329">

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
