### PR TITLE
Add simplified dApp details under PersonaDetails

### DIFF
--- a/Sources/Features/PersonaDetailsFeature/PersonaDetails.swift
+++ b/Sources/Features/PersonaDetailsFeature/PersonaDetails.swift
@@ -101,6 +101,7 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 		case callDone(updateControlState: WritableKeyPath<State, ControlState>, changeTo: ControlState)
 		case hideLoader(updateControlState: WritableKeyPath<State, ControlState>)
 		case personaToCreateAuthKeyForFetched(Profile.Network.Persona)
+		case dAppLoaded(Profile.Network.AuthorizedDappDetailed)
 	}
 
 	// MARK: - Destination
@@ -109,6 +110,7 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 		public enum State: Equatable, Hashable {
 			case editPersona(EditPersona.State)
 			case createAuthKey(CreateAuthKey.State)
+			case dAppDetails(SimpleDappDetails.State)
 
 			case confirmForgetAlert(AlertState<Action.ConfirmForgetAlert>)
 		}
@@ -116,6 +118,7 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 		public enum Action: Equatable {
 			case editPersona(EditPersona.Action)
 			case createAuthKey(CreateAuthKey.Action)
+			case dAppDetails(SimpleDappDetails.Action)
 
 			case confirmForgetAlert(ConfirmForgetAlert)
 			public enum ConfirmForgetAlert: Sendable, Equatable {
@@ -130,6 +133,9 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 			}
 			Scope(state: /State.createAuthKey, action: /Action.createAuthKey) {
 				CreateAuthKey()
+			}
+			Scope(state: /State.dAppDetails, action: /Action.dAppDetails) {
+				SimpleDappDetails()
 			}
 		}
 	}
@@ -205,6 +211,13 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 			return .none
 
 		case let .dAppTapped(dAppID):
+			return .run { send in
+				let dApp = try await authorizedDappsClient.getDetailedDapp(dAppID)
+				await send(.internal(.dAppLoaded(dApp)))
+			} catch: { error, _ in
+				loggerGlobal.error("Could not get dApp details \(dAppID), error: \(error)")
+				errorQueue.schedule(error)
+			}
 			return .none
 
 		case .editPersonaTapped:
@@ -263,6 +276,10 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 
 		case let .callDone(controlStateKeyPath, newState):
 			state[keyPath: controlStateKeyPath] = newState
+			return .none
+
+		case let .dAppLoaded(dApp):
+			state.destination = .dAppDetails(.init(dApp: dApp))
 			return .none
 		}
 	}
@@ -333,6 +350,226 @@ extension AlertState<PersonaDetails.Destination.Action.ConfirmForgetAlert> {
 			}
 		} message: {
 			TextState(L10n.AuthorizedDapps.RemoveAuthorizationAlert.message)
+		}
+	}
+}
+
+// MARK: - SimpleDappDetails
+// FIXME: Remove and make settings use stacks
+
+public struct SimpleDappDetails: Sendable, FeatureReducer {
+	@Dependency(\.errorQueue) var errorQueue
+	@Dependency(\.gatewayAPIClient) var gatewayAPIClient
+	@Dependency(\.openURL) var openURL
+	@Dependency(\.authorizedDappsClient) var authorizedDappsClient
+	@Dependency(\.cacheClient) var cacheClient
+
+	public struct FailedToLoadMetadata: Error, Hashable {}
+
+	public typealias Store = StoreOf<Self>
+
+	// MARK: State
+
+	public struct State: Sendable, Hashable {
+		public var dApp: Profile.Network.AuthorizedDappDetailed
+
+		@Loadable
+		public var metadata: GatewayAPI.EntityMetadataCollection? = nil
+
+		@Loadable
+		public var resources: Resources? = nil
+
+		@Loadable
+		public var associatedDapps: [AssociatedDapp]? = nil
+
+		public init(
+			dApp: Profile.Network.AuthorizedDappDetailed,
+			metadata: GatewayAPI.EntityMetadataCollection? = nil,
+			resources: Resources? = nil,
+			associatedDapps: [AssociatedDapp]? = nil
+		) {
+			self.dApp = dApp
+			self.metadata = metadata
+			self.resources = resources
+			self.associatedDapps = associatedDapps
+		}
+
+		public struct Resources: Hashable, Sendable {
+			public var fungible: [ResourceDetails]
+			public var nonFungible: [ResourceDetails]
+
+			// TODO: This should be consolidated with other types that represent resources
+			public struct ResourceDetails: Identifiable, Hashable, Sendable {
+				public var id: ResourceAddress { address }
+
+				public let address: ResourceAddress
+				public let fungibility: Fungibility
+				public let name: String
+				public let symbol: String?
+				public let description: String?
+				public let iconURL: URL?
+
+				public enum Fungibility: Hashable, Sendable {
+					case fungible
+					case nonFungible
+				}
+			}
+		}
+
+		// TODO: This should be consolidated with other types that represent resources
+		public struct AssociatedDapp: Identifiable, Hashable, Sendable {
+			public var id: DappDefinitionAddress { address }
+
+			public let address: DappDefinitionAddress
+			public let name: String
+			public let iconURL: URL?
+		}
+	}
+
+	// MARK: Action
+
+	public enum ViewAction: Sendable, Equatable {
+		case appeared
+		case openURLTapped(URL)
+	}
+
+	public enum InternalAction: Sendable, Equatable {
+		case metadataLoaded(Loadable<GatewayAPI.EntityMetadataCollection>)
+		case resourcesLoaded(Loadable<State.Resources>)
+		case associatedDappsLoaded(Loadable<[State.AssociatedDapp]>)
+	}
+
+	// MARK: - Destination
+
+	// MARK: Reducer
+
+	public init() {}
+
+	public func reduce(into state: inout State, viewAction: ViewAction) -> EffectTask<Action> {
+		switch viewAction {
+		case .appeared:
+			state.$metadata = .loading
+			state.$resources = .loading
+			let dAppID = state.dApp.dAppDefinitionAddress
+			return .task {
+				let result = await TaskResult {
+					try await cacheClient.withCaching(
+						cacheEntry: .dAppMetadata(dAppID.address),
+						request: {
+							try await gatewayAPIClient.getEntityMetadata(dAppID.address)
+						}
+					)
+				}
+				return .internal(.metadataLoaded(.init(result: result)))
+			}
+
+		case let .openURLTapped(url):
+			return .fireAndForget {
+				await openURL(url)
+			}
+		}
+	}
+
+	public func reduce(into state: inout State, internalAction: InternalAction) -> EffectTask<Action> {
+		switch internalAction {
+		case let .metadataLoaded(metadata):
+			state.$metadata = metadata
+
+			let dAppDefinitionAddress = state.dApp.dAppDefinitionAddress
+			return .run { send in
+				let resources = await metadata.flatMap { await loadResources(metadata: $0, validated: dAppDefinitionAddress) }
+				await send(.internal(.resourcesLoaded(resources)))
+
+				let associatedDapps = await metadata.flatMap { await loadDapps(metadata: $0, validated: dAppDefinitionAddress) }
+				await send(.internal(.associatedDappsLoaded(associatedDapps)))
+			}
+
+		case let .resourcesLoaded(resources):
+			state.$resources = resources
+			return .none
+
+		case let .associatedDappsLoaded(dApps):
+			state.$associatedDapps = dApps
+			return .none
+		}
+	}
+
+	/// Loads any fungible and non-fungible resources associated with the dApp
+	private func loadResources(
+		metadata: GatewayAPI.EntityMetadataCollection,
+		validated dappDefinitionAddress: DappDefinitionAddress
+	) async -> Loadable<SimpleDappDetails.State.Resources> {
+		guard let claimedEntities = metadata.claimedEntities, !claimedEntities.isEmpty else {
+			return .idle
+		}
+
+		let result = await TaskResult {
+			let allResourceItems = try await gatewayAPIClient.fetchResourceDetails(claimedEntities)
+				.items
+				// FIXME: Uncomment this when when we can rely on dApps conforming to the standards
+				// .filter { $0.metadata.dappDefinition == dAppDefinitionAddress.address }
+				.compactMap(\.resourceDetails)
+
+			return State.Resources(fungible: allResourceItems.filter { $0.fungibility == .fungible },
+			                       nonFungible: allResourceItems.filter { $0.fungibility == .nonFungible })
+		}
+
+		return .init(result: result)
+	}
+
+	/// Loads any other dApps associated with the dApp
+	private func loadDapps(
+		metadata: GatewayAPI.EntityMetadataCollection,
+		validated dappDefinitionAddress: DappDefinitionAddress
+	) async -> Loadable<[State.AssociatedDapp]> {
+		let dAppDefinitions = try? metadata.dappDefinitions?.compactMap(DappDefinitionAddress.init)
+		guard let dAppDefinitions else { return .idle }
+
+		let associatedDapps = await dAppDefinitions.parallelMap { dApp in
+			try? await extractDappInfo(for: dApp, validating: dappDefinitionAddress)
+		}
+		.compactMap { $0 }
+
+		guard !associatedDapps.isEmpty else { return .idle }
+
+		return .success(associatedDapps)
+	}
+
+	/// Helper function that loads and extracts dApp info for a given dApp, validating that it points back to the dApp of this screen
+	private func extractDappInfo(
+		for dApp: DappDefinitionAddress,
+		validating dAppDefinitionAddress: DappDefinitionAddress
+	) async throws -> State.AssociatedDapp {
+		let metadata = try await gatewayAPIClient.getEntityMetadata(dApp.address)
+		// FIXME: Uncomment this when when we can rely on dApps conforming to the standards
+		// .validating(dAppDefinitionAddress: dAppDefinitionAddress)
+		guard let name = metadata.name else {
+			throw GatewayAPI.EntityMetadataCollection.MetadataError.missingName
+		}
+		return .init(address: dApp, name: name, iconURL: metadata.iconURL)
+	}
+}
+
+extension GatewayAPI.StateEntityDetailsResponseItem {
+	var resourceDetails: SimpleDappDetails.State.Resources.ResourceDetails? {
+		guard let fungibility else { return nil }
+		return .init(address: .init(address: address),
+		             fungibility: fungibility,
+		             name: metadata.name ?? L10n.AuthorizedDapps.DAppDetails.unknownTokenName,
+		             symbol: metadata.symbol,
+		             description: metadata.description,
+		             iconURL: metadata.iconURL)
+	}
+
+	private var fungibility: SimpleDappDetails.State.Resources.ResourceDetails.Fungibility? {
+		guard let details else { return nil }
+		switch details {
+		case .fungibleResource:
+			return .fungible
+		case .nonFungibleResource:
+			return .nonFungible
+		case .fungibleVault, .nonFungibleVault, .package, .component:
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
Shows a simplified version of _dApp details_ when pressing a dApp in the list under _Persona Details_.

Until we can remake navigation using stacks, this is done by adding a separate feature called SimpleDappDetails, rather than reusing the existing one. This is because we would otherwise have cyclic dependencies.

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/ff53103d-14b8-42bd-89ff-dbcd63c4b7b7

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
