### PR TITLE
Remove "Add another ledger" code

### DIFF
--- a/Sources/Features/AppFeature/App+Reducer.swift
+++ b/Sources/Features/AppFeature/App+Reducer.swift
@@ -141,7 +141,6 @@ public struct App: Sendable, FeatureReducer {
 			state.alert = .userErrorAlert(
 				.init(
 					title: { TextState(L10n.Common.errorAlertTitle) },
-					actions: {},
 					message: { TextState(error.legibleLocalizedDescription) }
 				)
 			)

--- a/Sources/Features/LedgerHardwareDevices/LedgerHardwareDevices+Reducer.swift
+++ b/Sources/Features/LedgerHardwareDevices/LedgerHardwareDevices+Reducer.swift
@@ -182,7 +182,7 @@ public struct LedgerHardwareDevices: Sendable, FeatureReducer {
 
 		case let .destination(.presented(.addNewLedger(.delegate(newLedgerAction)))):
 			switch newLedgerAction {
-			case let .completed(ledger: ledger, isNew: _):
+			case let .completed(ledger):
 				state.destination = nil
 				state.selectedLedgerID = ledger.id
 				return updateLedgersEffekt(state: &state)


### PR DESCRIPTION
When trying to add a ledger and it turns out it was already added, we give the user the option to "add another" or "select the existing one", but it was decided that we just need to explain the situation to them.

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
