### PR TITLE
Fix DappInteractor being dismissed

### DIFF
--- a/Sources/Features/AppFeature/App+View.swift
+++ b/Sources/Features/AppFeature/App+View.swift
@@ -8,11 +8,6 @@ import SplashFeature
 extension App {
 	@MainActor
 	public struct View: SwiftUI.View {
-		// N.B. BEWARE we MUST have `scenePhase` here in root view in order for any child
-		// views own `@Environment(\.scenePhase) var scenePhase` to work. See SO comment:
-		// https://stackoverflow.com/a/71596896/1311272
-		@Environment(\.scenePhase) var scenePhase
-
 		private let store: StoreOf<App>
 
 		public init(store: StoreOf<App>) {


### PR DESCRIPTION
`scenePhase` triggers a redraw on change, and having it app level triggered a redraw at the app level. The DappInteractor was dismissed since it was not expected that the root view will ever be redrawn. For now, I did remove the scenePhase from the root in favour of notifications.

If we do want to have schenePhase used we will have to update the DappInteractor state to be kept in the root instead being re-iniatialised on redraw.

