### PR TITLE
[BUG FIX] "Double request"-bug fixed

### DIFF
--- a/Sources/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/Sources/Features/TransactionReviewFeature/TransactionReview.swift
@@ -320,11 +320,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 
 		case let .destination(.presented(.submitting(.delegate(.committedSuccessfully(txID))))):
 			state.destination = nil
-
-			return .task {
-				try? await clock.sleep(for: .milliseconds(700)) // bah, we need to to dismiss `state.destination` before proceeding with completion
-				return .delegate(.transactionCompleted(txID))
-			}
+			return .send(.delegate(.transactionCompleted(txID)))
 
 		default:
 			return .none


### PR DESCRIPTION
Jira ticket: paste link here

TX Review never got dismissed due to an attempt to fix another bug, that the Completion slide up is not shown. Completion slide up is still not shown, but at least this fix dismisses TXReview, thus fixing the "double request" bug.

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
