### PR TITLE
Small fixes

### DIFF
--- a/Sources/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+Reducer.swift
+++ b/Sources/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+Reducer.swift
@@ -52,7 +52,7 @@ public struct FungibleResourceAsset: Sendable, FeatureReducer {
 		case let .amountChanged(transferAmountStr):
 			state.transferAmountStr = transferAmountStr
 
-			if let value = try? BigDecimal(localizedFromString: transferAmountStr) {
+			if let value = try? BigDecimal(localizedFromString: transferAmountStr), value > 0 {
 				state.transferAmount = value
 			} else {
 				state.transferAmount = nil


### PR DESCRIPTION
- Don't deduct 10 when it's not XRD being transferred
- Don't enable the Continue button when the amount is 0 (slightly hacky)