### PR TITLE
ABW-1568 Don't Crash When Importing Zero Olympia Accounts

### DIFF
--- a/Sources/Clients/ImportLegacyWalletClient/ImportLegacyWalletClient+Request+Response.swift
+++ b/Sources/Clients/ImportLegacyWalletClient/ImportLegacyWalletClient+Request+Response.swift
@@ -27,11 +27,11 @@ public struct MigrateOlympiaSoftwareAccountsToBabylonRequest: Sendable, Hashable
 
 // MARK: - MigrateOlympiaHardwareAccountsToBabylonRequest
 public struct MigrateOlympiaHardwareAccountsToBabylonRequest: Sendable, Hashable {
-	public let olympiaAccounts: Set<OlympiaAccountToMigrate>
+	public let olympiaAccounts: NonEmpty<Set<OlympiaAccountToMigrate>>
 	public let ledgerFactorSourceID: FactorSourceID
 
 	public init(
-		olympiaAccounts: Set<OlympiaAccountToMigrate>,
+		olympiaAccounts: NonEmpty<Set<OlympiaAccountToMigrate>>,
 		ledgerFactorSourceID: FactorSourceID
 	) {
 		self.olympiaAccounts = olympiaAccounts

--- a/Sources/Features/ImportOlympiaLedgerAccountsAndFactorSources/ImportOlympiaLedgerAccountsAndFactorSources.swift
+++ b/Sources/Features/ImportOlympiaLedgerAccountsAndFactorSources/ImportOlympiaLedgerAccountsAndFactorSources.swift
@@ -60,7 +60,7 @@ public struct ImportOlympiaLedgerAccountsAndFactorSources: Sendable, FeatureRedu
 
 	public enum InternalAction: Sendable, Equatable {
 		/// Validated public keys against expected, then migrate...
-		case validatedAccounts(Set<OlympiaAccountToMigrate>, LedgerHardwareWalletFactorSource)
+		case validatedAccounts(NonEmpty<Set<OlympiaAccountToMigrate>>, LedgerHardwareWalletFactorSource)
 
 		/// migrated accounts of validated public keys
 		case migratedOlympiaHardwareAccounts(LedgerWithAccounts)
@@ -148,7 +148,7 @@ public struct ImportOlympiaLedgerAccountsAndFactorSources: Sendable, FeatureRedu
 			)
 			return .none
 
-		case let .derivePublicKeys(.presented(.delegate(.failedToDerivePublicKey))):
+		case .derivePublicKeys(.presented(.delegate(.failedToDerivePublicKey))):
 			loggerGlobal.error("ImportOlympiaAccountsAndFactorSource - child derivePublicKeys failed to derive public key")
 			state.derivePublicKeys = nil
 			return .none
@@ -173,7 +173,10 @@ public struct ImportOlympiaLedgerAccountsAndFactorSources: Sendable, FeatureRedu
 		.run { [olympiaAccountsToValidate = state.unmigrated.unvalidated] send in
 			do {
 				let validation = try await validate(derivedPublicKeys: derivedPublicKeys, olympiaAccountsToValidate: olympiaAccountsToValidate)
-				await send(.internal(.validatedAccounts(validation.validated, ledger)))
+				guard let validated = NonEmpty<Set>(validation.validated) else {
+					throw NoValidatedAccountsError()
+				}
+				await send(.internal(.validatedAccounts(validated, ledger)))
 			} catch {
 				loggerGlobal.error("Failed to validate accounts, error: \(error)")
 				errorQueue.schedule(error)
@@ -183,7 +186,7 @@ public struct ImportOlympiaLedgerAccountsAndFactorSources: Sendable, FeatureRedu
 
 	private func convertHardwareAccountsToBabylon(
 		ledger: LedgerHardwareWalletFactorSource,
-		validatedAccountsToMigrate olympiaAccounts: Set<OlympiaAccountToMigrate>,
+		validatedAccountsToMigrate olympiaAccounts: NonEmpty<Set<OlympiaAccountToMigrate>>,
 		_ state: State
 	) -> EffectTask<Action> {
 		loggerGlobal.notice("Converting hardware accounts to babylon...")
@@ -195,7 +198,7 @@ public struct ImportOlympiaLedgerAccountsAndFactorSources: Sendable, FeatureRedu
 			// Migrates and saved all accounts to Profile
 			let migrated = try await importLegacyWalletClient.migrateOlympiaHardwareAccountsToBabylon(
 				.init(
-					olympiaAccounts: Set(olympiaAccounts),
+					olympiaAccounts: olympiaAccounts,
 					ledgerFactorSourceID: ledger.id
 				)
 			)
@@ -274,6 +277,8 @@ public struct ImportOlympiaLedgerAccountsAndFactorSources: Sendable, FeatureRedu
 			unvalidated: olympiaAccountsToValidate
 		)
 	}
+
+	struct NoValidatedAccountsError: Error {}
 }
 
 extension LedgerHardwareWalletFactorSource.DeviceModel {


### PR DESCRIPTION
Jira ticket: [ABW-1568](https://radixdlt.atlassian.net/browse/ABW-1568)

## Description
The app should not crash when importing Olympia accounts, even when there are zero validated accounts to migrate.

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-1568]: https://radixdlt.atlassian.net/browse/ABW-1568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ