### PR TITLE
Simplify and modernize navigation

### DIFF
--- a/Sources/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Reducer.swift
+++ b/Sources/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Reducer.swift
@@ -6,7 +6,7 @@ import FeaturePrelude
 // MARK: - CreateAccountCoordinator
 public struct CreateAccountCoordinator: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
-		var root: Path.State
+		var root: NameAccount.State
 		var path: StackState<Path.State> = .init()
 
 		public let config: CreateAccountConfig
@@ -15,7 +15,7 @@ public struct CreateAccountCoordinator: Sendable, FeatureReducer {
 			config: CreateAccountConfig
 		) {
 			self.config = config
-			self.root = .step1_nameAccount(.init(config: config))
+			self.root = .init(config: config)
 		}
 
 		var shouldDisplayNavBar: Bool {
@@ -37,21 +37,16 @@ public struct CreateAccountCoordinator: Sendable, FeatureReducer {
 
 	public struct Path: Sendable, ReducerProtocol {
 		public enum State: Sendable, Hashable {
-			case step1_nameAccount(NameAccount.State)
 			case step2_creationOfAccount(CreationOfAccount.State)
 			case step3_completion(NewAccountCompletion.State)
 		}
 
 		public enum Action: Sendable, Equatable {
-			case step1_nameAccount(NameAccount.Action)
 			case step2_creationOfAccount(CreationOfAccount.Action)
 			case step3_completion(NewAccountCompletion.Action)
 		}
 
 		public var body: some ReducerProtocolOf<Self> {
-			Scope(state: /State.step1_nameAccount, action: /Action.step1_nameAccount) {
-				NameAccount()
-			}
 			Scope(state: /State.step2_creationOfAccount, action: /Action.step2_creationOfAccount) {
 				CreationOfAccount()
 			}
@@ -66,7 +61,7 @@ public struct CreateAccountCoordinator: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case root(Path.Action)
+		case root(NameAccount.Action)
 		case path(StackActionOf<Path>)
 	}
 
@@ -84,7 +79,7 @@ public struct CreateAccountCoordinator: Sendable, FeatureReducer {
 
 	public var body: some ReducerProtocolOf<Self> {
 		Scope(state: \.root, action: /Action.child .. ChildAction.root) {
-			Path()
+			NameAccount()
 		}
 		Reduce(core)
 			.forEach(\.path, action: /Action.child .. ChildAction.path) {
@@ -109,7 +104,7 @@ extension CreateAccountCoordinator {
 
 	public func reduce(into state: inout State, childAction: ChildAction) -> EffectTask<Action> {
 		switch childAction {
-		case let .root(.step1_nameAccount(.delegate(.proceed(accountName, useLedgerAsFactorSource)))):
+		case let .root(.delegate(.proceed(accountName, useLedgerAsFactorSource))):
 			state.path.append(.step2_creationOfAccount(.init(
 				name: accountName,
 				networkID: state.config.specificNetworkID,

--- a/Sources/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
+++ b/Sources/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
@@ -24,22 +24,21 @@ extension CreateAccountCoordinator {
 				NavigationStackStore(
 					store.scope(state: \.path, action: { .child(.path($0)) })
 				) {
-					IfLetStore(
-						store.scope(state: \.root, action: { .child(.root($0)) })
-					) {
-						destination(for: $0, shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
-						#if os(iOS)
-							.toolbar {
-								if viewStore.shouldDisplayNavBar {
-									ToolbarItem(placement: .primaryAction) {
-										CloseButton {
-											ViewStore(store.stateless).send(.view(.closeButtonTapped))
-										}
-									}
+					destination(
+						for: store.scope(state: \.root, action: { .child(.root($0)) }),
+						shouldDisplayNavBar: viewStore.shouldDisplayNavBar
+					)
+					#if os(iOS)
+					.toolbar {
+						if viewStore.shouldDisplayNavBar {
+							ToolbarItem(placement: .primaryAction) {
+								CloseButton {
+									ViewStore(store.stateless).send(.view(.closeButtonTapped))
 								}
 							}
-						#endif
+						}
 					}
+					#endif
 					// This is required to disable the animation of internal components during transition
 					.transaction { $0.animation = nil }
 				} destination: {
@@ -52,24 +51,27 @@ extension CreateAccountCoordinator {
 		}
 
 		private func destination(
-			for store: StoreOf<CreateAccountCoordinator.Destinations>,
+			for store: StoreOf<CreateAccountCoordinator.Path>,
 			shouldDisplayNavBar: Bool
 		) -> some SwiftUI.View {
-			ZStack {
-				SwitchStore(store) {
+			SwitchStore(store) { state in
+				switch state {
+				case .step1_nameAccount:
 					CaseLet(
-						state: /CreateAccountCoordinator.Destinations.State.step1_nameAccount,
-						action: CreateAccountCoordinator.Destinations.Action.step1_nameAccount,
+						state: /CreateAccountCoordinator.Path.State.step1_nameAccount,
+						action: CreateAccountCoordinator.Path.Action.step1_nameAccount,
 						then: { NameAccount.View(store: $0) }
 					)
+				case .step2_creationOfAccount:
 					CaseLet(
-						state: /CreateAccountCoordinator.Destinations.State.step2_creationOfAccount,
-						action: CreateAccountCoordinator.Destinations.Action.step2_creationOfAccount,
+						state: /CreateAccountCoordinator.Path.State.step2_creationOfAccount,
+						action: CreateAccountCoordinator.Path.Action.step2_creationOfAccount,
 						then: { CreationOfAccount.View(store: $0) }
 					)
+				case .step3_completion:
 					CaseLet(
-						state: /CreateAccountCoordinator.Destinations.State.step3_completion,
-						action: CreateAccountCoordinator.Destinations.Action.step3_completion,
+						state: /CreateAccountCoordinator.Path.State.step3_completion,
+						action: CreateAccountCoordinator.Path.Action.step3_completion,
 						then: { NewAccountCompletion.View(store: $0) }
 					)
 				}

--- a/Sources/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
+++ b/Sources/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
@@ -24,23 +24,21 @@ extension CreateAccountCoordinator {
 				NavigationStackStore(
 					store.scope(state: \.path, action: { .child(.path($0)) })
 				) {
-					destination(
-						for: store.scope(state: \.root, action: { .child(.root($0)) }),
-						shouldDisplayNavBar: viewStore.shouldDisplayNavBar
-					)
+					let nameAccountStore = store.scope(state: \.root, action: { .child(.root($0)) })
+					NameAccount.View(store: nameAccountStore)
 					#if os(iOS)
-					.toolbar {
-						if viewStore.shouldDisplayNavBar {
-							ToolbarItem(placement: .primaryAction) {
-								CloseButton {
-									ViewStore(store.stateless).send(.view(.closeButtonTapped))
+						.toolbar {
+							if viewStore.shouldDisplayNavBar {
+								ToolbarItem(placement: .primaryAction) {
+									CloseButton {
+										ViewStore(store.stateless).send(.view(.closeButtonTapped))
+									}
 								}
 							}
 						}
-					}
 					#endif
-					// This is required to disable the animation of internal components during transition
-					.transaction { $0.animation = nil }
+						// This is required to disable the animation of internal components during transition
+						.transaction { $0.animation = nil }
 				} destination: {
 					destination(for: $0, shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
 				}
@@ -56,12 +54,6 @@ extension CreateAccountCoordinator {
 		) -> some SwiftUI.View {
 			SwitchStore(store) { state in
 				switch state {
-				case .step1_nameAccount:
-					CaseLet(
-						state: /CreateAccountCoordinator.Path.State.step1_nameAccount,
-						action: CreateAccountCoordinator.Path.Action.step1_nameAccount,
-						then: { NameAccount.View(store: $0) }
-					)
 				case .step2_creationOfAccount:
 					CaseLet(
 						state: /CreateAccountCoordinator.Path.State.step2_creationOfAccount,

--- a/Sources/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+Reducer.swift
+++ b/Sources/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+Reducer.swift
@@ -6,13 +6,13 @@ import FeaturePrelude
 // MARK: - CreatePersonaCoordinator
 public struct CreatePersonaCoordinator: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
-		var root: Destinations.State?
-		var path: StackState<Destinations.State> = .init()
+		var root: Path.State
+		var path: StackState<Path.State> = .init()
 
 		public let config: CreatePersonaConfig
 
 		public init(
-			root: Destinations.State? = nil,
+			root: Path.State? = nil,
 			config: CreatePersonaConfig
 		) {
 			self.config = config
@@ -41,7 +41,7 @@ public struct CreatePersonaCoordinator: Sendable, FeatureReducer {
 		}
 	}
 
-	public struct Destinations: Sendable, ReducerProtocol {
+	public struct Path: Sendable, ReducerProtocol {
 		public enum State: Sendable, Hashable {
 			case step0_introduction(IntroductionToPersonas.State)
 			case step1_newPersonaInfo(NewPersonaInfo.State)
@@ -77,8 +77,8 @@ public struct CreatePersonaCoordinator: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case root(Destinations.Action)
-		case path(StackActionOf<Destinations>)
+		case root(Path.Action)
+		case path(StackActionOf<Path>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -94,12 +94,12 @@ public struct CreatePersonaCoordinator: Sendable, FeatureReducer {
 
 	public var body: some ReducerProtocolOf<Self> {
 		Reduce(core)
-			.ifLet(\.root, action: /Action.child .. ChildAction.root) {
-				Destinations()
-			}
 			.forEach(\.path, action: /Action.child .. ChildAction.path) {
-				Destinations()
+				Path()
 			}
+		Scope(state: \.root, action: /Action.child .. ChildAction.root) {
+			Path()
+		}
 	}
 }
 

--- a/Sources/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+View.swift
+++ b/Sources/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+View.swift
@@ -25,24 +25,22 @@ extension CreatePersonaCoordinator {
 				NavigationStackStore(
 					store.scope(state: \.path, action: { .child(.path($0)) })
 				) {
-					IfLetStore(
-						store.scope(state: \.root, action: { .child(.root($0)) })
-					) {
-						destination(for: $0, shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
-						#if os(iOS)
-							.toolbar {
-								if viewStore.shouldDisplayNavBar {
-									ToolbarItem(placement: .navigationBarLeading) {
-										CloseButton {
-											ViewStore(store.stateless).send(.view(.closeButtonTapped))
-										}
+					destination(for: store.scope(state: \.root, action: { .child(.root($0)) }),
+					            shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
+					#if os(iOS)
+						.toolbar {
+							if viewStore.shouldDisplayNavBar {
+								ToolbarItem(placement: .navigationBarLeading) {
+									CloseButton {
+										ViewStore(store.stateless).send(.view(.closeButtonTapped))
 									}
 								}
 							}
-						#endif
-					}
-					// This is required to disable the animation of internal components during transition
-					.transaction { $0.animation = nil }
+						}
+					#endif
+
+						// This is required to disable the animation of internal components during transition
+						.transaction { $0.animation = nil }
 				} destination: {
 					destination(for: $0, shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
 				}
@@ -53,29 +51,33 @@ extension CreatePersonaCoordinator {
 		}
 
 		private func destination(
-			for store: StoreOf<CreatePersonaCoordinator.Destinations>,
+			for store: StoreOf<CreatePersonaCoordinator.Path>,
 			shouldDisplayNavBar: Bool
 		) -> some SwiftUI.View {
-			ZStack {
-				SwitchStore(store) {
+			SwitchStore(store) { state in
+				switch state {
+				case .step0_introduction:
 					CaseLet(
-						state: /CreatePersonaCoordinator.Destinations.State.step0_introduction,
-						action: CreatePersonaCoordinator.Destinations.Action.step0_introduction,
+						state: /CreatePersonaCoordinator.Path.State.step0_introduction,
+						action: CreatePersonaCoordinator.Path.Action.step0_introduction,
 						then: { IntroductionToPersonas.View(store: $0) }
 					)
+				case .step1_newPersonaInfo:
 					CaseLet(
-						state: /CreatePersonaCoordinator.Destinations.State.step1_newPersonaInfo,
-						action: CreatePersonaCoordinator.Destinations.Action.step1_newPersonaInfo,
+						state: /CreatePersonaCoordinator.Path.State.step1_newPersonaInfo,
+						action: CreatePersonaCoordinator.Path.Action.step1_newPersonaInfo,
 						then: { NewPersonaInfo.View(store: $0) }
 					)
+				case .step2_creationOfPersona:
 					CaseLet(
-						state: /CreatePersonaCoordinator.Destinations.State.step2_creationOfPersona,
-						action: CreatePersonaCoordinator.Destinations.Action.step2_creationOfPersona,
+						state: /CreatePersonaCoordinator.Path.State.step2_creationOfPersona,
+						action: CreatePersonaCoordinator.Path.Action.step2_creationOfPersona,
 						then: { CreationOfPersona.View(store: $0) }
 					)
+				case .step3_completion:
 					CaseLet(
-						state: /CreatePersonaCoordinator.Destinations.State.step3_completion,
-						action: CreatePersonaCoordinator.Destinations.Action.step3_completion,
+						state: /CreatePersonaCoordinator.Path.State.step3_completion,
+						action: CreatePersonaCoordinator.Path.Action.step3_completion,
 						then: { NewPersonaCompletion.View(store: $0) }
 					)
 				}

--- a/Sources/Features/DappInteractionFeature/Coordinator/DappInteractionFlow+View.swift
+++ b/Sources/Features/DappInteractionFeature/Coordinator/DappInteractionFlow+View.swift
@@ -56,37 +56,37 @@ extension DappInteractionFlow {
 		}
 
 		func destination(
-			for store: StoreOf<DappInteractionFlow.Destinations>
+			for store: StoreOf<DappInteractionFlow.Path>
 		) -> some SwiftUI.View {
-			SwitchStore(store.relay()) {
+			SwitchStore(store) {
 				CaseLet(
-					state: /DappInteractionFlow.Destinations.MainState.login,
-					action: DappInteractionFlow.Destinations.MainAction.login,
+					state: /DappInteractionFlow.Path.State.login,
+					action: DappInteractionFlow.Path.Action.login,
 					then: { Login.View(store: $0) }
 				)
 				CaseLet(
-					state: /DappInteractionFlow.Destinations.MainState.accountPermission,
-					action: DappInteractionFlow.Destinations.MainAction.accountPermission,
+					state: /DappInteractionFlow.Path.State.accountPermission,
+					action: DappInteractionFlow.Path.Action.accountPermission,
 					then: { AccountPermission.View(store: $0) }
 				)
 				CaseLet(
-					state: /DappInteractionFlow.Destinations.MainState.chooseAccounts,
-					action: DappInteractionFlow.Destinations.MainAction.chooseAccounts,
+					state: /DappInteractionFlow.Path.State.chooseAccounts,
+					action: DappInteractionFlow.Path.Action.chooseAccounts,
 					then: { AccountPermissionChooseAccounts.View(store: $0) }
 				)
 				CaseLet(
-					state: /DappInteractionFlow.Destinations.MainState.personaDataPermission,
-					action: DappInteractionFlow.Destinations.MainAction.personaDataPermission,
+					state: /DappInteractionFlow.Path.State.personaDataPermission,
+					action: DappInteractionFlow.Path.Action.personaDataPermission,
 					then: { PersonaDataPermission.View(store: $0) }
 				)
 				CaseLet(
-					state: /DappInteractionFlow.Destinations.MainState.oneTimePersonaData,
-					action: DappInteractionFlow.Destinations.MainAction.oneTimePersonaData,
+					state: /DappInteractionFlow.Path.State.oneTimePersonaData,
+					action: DappInteractionFlow.Path.Action.oneTimePersonaData,
 					then: { OneTimePersonaData.View(store: $0) }
 				)
 				CaseLet(
-					state: /DappInteractionFlow.Destinations.MainState.reviewTransaction,
-					action: DappInteractionFlow.Destinations.MainAction.reviewTransaction,
+					state: /DappInteractionFlow.Path.State.reviewTransaction,
+					action: DappInteractionFlow.Path.Action.reviewTransaction,
 					then: { TransactionReview.View(store: $0) }
 				)
 			}


### PR DESCRIPTION
## Description
Navigation best practices have changed since we started using TCA's navigation beta, and there are also places where we use needlessly complicated constructions - for example, in CreateAccountCoordinator we have architectured the code so that it's possible to start on any step, but in reality we always start with NameAccount. Exploiting that fact lets us simplify both the view and the model.

This PR also gets rid of one usage of Relay, in the DappInteraction. I personally don't think Relay makes things better there, but it adds an extra layer of indirection, a new surface area for bugs.

This PR is meant partly as a starting point for discussions around what we may want to change w.r.t navigation.