### PR TITLE
ABW-1715 Simplify Ledger Screen Variants

### DIFF
--- a/Sources/Features/CreateAccount/Children/CreationOfAccount/CreationOfAccount+Reducer.swift
+++ b/Sources/Features/CreateAccount/Children/CreationOfAccount/CreationOfAccount+Reducer.swift
@@ -27,7 +27,7 @@ public struct CreationOfAccount: Sendable, FeatureReducer {
 			self.isCreatingLedgerAccount = isCreatingLedgerAccount
 
 			if isCreatingLedgerAccount {
-				self.step = .step0_chooseLedger(.init(allowSelection: true, context: .ledgerSelection))
+				self.step = .step0_chooseLedger(.init(context: .createHardwareAccount))
 			} else {
 				self.step = .step1_derivePublicKeys(
 					.init(

--- a/Sources/Features/CreateAccount/Children/CreationOfAccount/CreationOfAccount+View.swift
+++ b/Sources/Features/CreateAccount/Children/CreationOfAccount/CreationOfAccount+View.swift
@@ -13,7 +13,7 @@ extension CreationOfAccount {
 
 		public var body: some SwiftUI.View {
 			ZStack {
-				SwitchStore(store.scope(state: \.step)) {
+				SwitchStore(store.scope(state: \.step, action: { $0 })) {
 					CaseLet(
 						state: /CreationOfAccount.State.Step.step0_chooseLedger,
 						action: { CreationOfAccount.Action.child(.step0_chooseLedger($0)) },

--- a/Sources/Features/ImportOlympiaLedgerAccountsAndFactorSources/ImportOlympiaLedgerAccountsAndFactorSources.swift
+++ b/Sources/Features/ImportOlympiaLedgerAccountsAndFactorSources/ImportOlympiaLedgerAccountsAndFactorSources.swift
@@ -50,7 +50,7 @@ public struct ImportOlympiaLedgerAccountsAndFactorSources: Sendable, FeatureRedu
 			let accountsValidation = OlympiaAccountsValidation(validated: [], unvalidated: Set(hardwareAccounts.elements))
 			self.networkID = networkID
 			self.unmigrated = accountsValidation
-			self.chooseLedger = .init(allowSelection: true, context: .ledgerSelection, showHeaders: false)
+			self.chooseLedger = .init(context: .importOlympia)
 		}
 	}
 

--- a/Sources/Features/LedgerHardwareDevices/LedgerHardwareDevices+Reducer.swift
+++ b/Sources/Features/LedgerHardwareDevices/LedgerHardwareDevices+Reducer.swift
@@ -15,13 +15,12 @@ public struct LedgerHardwareDevices: Sendable, FeatureReducer {
 	// MARK: - State
 
 	public struct State: Sendable, Hashable {
-		public enum Context {
+		public enum Context: Sendable, Hashable {
 			case settings
-			case ledgerSelection
+			case importOlympia
+			case createHardwareAccount
 		}
 
-		public let allowSelection: Bool
-		public let showHeaders: Bool
 		public let context: Context
 
 		public var hasAConnectorExtension: Bool = false
@@ -37,10 +36,8 @@ public struct LedgerHardwareDevices: Sendable, FeatureReducer {
 
 		var pendingAction: ActionRequiringP2P? = nil
 
-		public init(allowSelection: Bool, context: Context, showHeaders: Bool = true) {
-			self.allowSelection = allowSelection
+		public init(context: Context) {
 			self.context = context
-			self.showHeaders = showHeaders
 		}
 	}
 

--- a/Sources/Features/LedgerHardwareDevices/LedgerHardwareDevices+View.swift
+++ b/Sources/Features/LedgerHardwareDevices/LedgerHardwareDevices+View.swift
@@ -12,25 +12,25 @@ extension LedgerHardwareDevices.State {
 // MARK: - LedgerHardwareDevice.View
 extension LedgerHardwareDevices {
 	public struct ViewState: Equatable {
-		let allowSelection: Bool
-		let showHeaders: Bool
+		var allowSelection: Bool { context != .settings }
+		var showHeaders: Bool { context != .importOlympia }
+		var showIcon: Bool { context != .settings }
+
 		let ledgers: Loadable<IdentifiedArrayOf<LedgerHardwareWalletFactorSource>>
 		let selectedLedgerID: FactorSourceID.FromHash?
 		let selectedLedgerControlRequirements: SelectedLedgerControlRequirements?
 		let context: State.Context
 
 		init(state: LedgerHardwareDevices.State) {
-			self.allowSelection = state.allowSelection
-			self.showHeaders = state.showHeaders
 			self.ledgers = state.$ledgers
 			self.selectedLedgerID = state.selectedLedgerID
-			self.context = state.context
 
 			if let id = state.selectedLedgerID, let selectedLedger = state.ledgers?[id: id] {
 				self.selectedLedgerControlRequirements = .init(selectedLedger: selectedLedger)
 			} else {
 				self.selectedLedgerControlRequirements = nil
 			}
+			self.context = state.context
 		}
 
 		var ledgersArray: [LedgerHardwareWalletFactorSource]? { .init(ledgers.wrappedValue ?? []) }
@@ -74,12 +74,7 @@ extension LedgerHardwareDevices {
 				ScrollView {
 					VStack(spacing: 0) {
 						Group {
-							if viewStore.context == .settings {
-								Text(L10n.LedgerHardwareDevices.subtitleAllLedgers)
-									.textStyle(.body1HighImportance)
-									.foregroundColor(.app.gray2)
-									.padding(.vertical, .medium1)
-							} else {
+							if viewStore.allowSelection {
 								Image(asset: AssetResource.iconHardwareLedger)
 									.frame(.medium)
 									.padding(.vertical, .medium2)
@@ -88,6 +83,11 @@ extension LedgerHardwareDevices {
 									.textStyle(.sheetTitle)
 									.foregroundColor(.app.gray1)
 									.padding(.bottom, .medium1)
+							} else {
+								Text(L10n.LedgerHardwareDevices.subtitleAllLedgers)
+									.textStyle(.body1HighImportance)
+									.foregroundColor(.app.gray2)
+									.padding(.vertical, .medium1)
 							}
 
 							if viewStore.showHeaders {
@@ -120,10 +120,7 @@ extension LedgerHardwareDevices {
 						Spacer(minLength: 0)
 					}
 				}
-				.frame(
-					minWidth: 0,
-					maxWidth: .infinity
-				)
+				.frame(minWidth: 0, maxWidth: .infinity)
 				.footer(visible: viewStore.allowSelection) {
 					WithControlRequirements(
 						viewStore.selectedLedgerControlRequirements,

--- a/Sources/Features/SettingsFeature/Settings.swift
+++ b/Sources/Features/SettingsFeature/Settings.swift
@@ -190,7 +190,6 @@ public struct AppSettings: Sendable, FeatureReducer {
 			return .none
 
 		case .personasButtonTapped:
-			// TODO: implement
 			state.destination = .personas(.init())
 			return .none
 
@@ -203,7 +202,7 @@ public struct AppSettings: Sendable, FeatureReducer {
 			return .none
 
 		case .ledgerHardwareWalletsButtonTapped:
-			state.destination = .ledgerHardwareWallets(.init(allowSelection: false, context: .settings, showHeaders: true))
+			state.destination = .ledgerHardwareWallets(.init(context: .settings))
 			return .none
 
 		case .mnemonicsButtonTapped:


### PR DESCRIPTION
Jira ticket: [ABW-1715](https://radixdlt.atlassian.net/browse/ABW-1715)

## Description
The Ledger list screen should look differently in different contexts. For example, it should not show the large icon when part of settings. 

Ghenadie already essentially implemented the ticket as part of another PR, so this PR mostly just simplifies it a bit.

## Screenshot
<img src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/1a5465f0-c066-42c7-8a22-023058e46b61" width="250"/>
<img src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/dfcd5973-0bef-414b-bbba-fbd690683a63" width="250"/>

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-1715]: https://radixdlt.atlassian.net/browse/ABW-1715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ