### PR TITLE
Set timeout for test-and-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
   test-and-build:
     name: "Test and build"
     runs-on: macos-13
+    timeout-minutes: 50
 
     needs:
       - linting


### PR DESCRIPTION
## Description
It avoids situations where [our build gets stuck and we have to pay for idle time](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1689007076910979)... Usually, the CI action takes no more than 38 mins, so setting a ~~60~~ 50 mins timeout is ~~more than~~ just enough. ~~Maybe even 45-50 would be ok?~~