### PR TITLE
[ABW-1797] Tap to dismiss keyboard for transfer message

### DIFF
--- a/Sources/Features/AssetTransferFeature/AssetTransfer+Reducer.swift
+++ b/Sources/Features/AssetTransferFeature/AssetTransfer+Reducer.swift
@@ -23,6 +23,7 @@ public struct AssetTransfer: Sendable, FeatureReducer {
 	public enum ViewAction: Equatable, Sendable {
 		case closeButtonTapped
 		case addMessageTapped
+		case backgroundTapped
 		case sendTransferTapped
 	}
 
@@ -51,7 +52,13 @@ public struct AssetTransfer: Sendable, FeatureReducer {
 			state.message = .empty
 			return .none
 
+		case .backgroundTapped:
+			state.message?.focused = false
+			return .none
+
 		case .sendTransferTapped:
+			state.message?.focused = false
+
 			return .run { [accounts = state.accounts, message = state.message?.message] send in
 				let manifest = try await createManifest(accounts)
 				await dappInteractionClient.addWalletInteraction(

--- a/Sources/Features/AssetTransferFeature/AssetTransfer+View.swift
+++ b/Sources/Features/AssetTransferFeature/AssetTransfer+View.swift
@@ -40,6 +40,12 @@ extension AssetTransfer.View {
 					.padding(.bottom, .medium3)
 				}
 				.padding(.horizontal, .medium3)
+				.background {
+					Color.white
+						.onTapGesture {
+							viewStore.send(.backgroundTapped)
+						}
+				}
 			}
 		}
 		.scrollDismissesKeyboard(.interactively)

--- a/Sources/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+Reducer.swift
+++ b/Sources/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+Reducer.swift
@@ -9,6 +9,7 @@ public struct AssetTransferMessage: Sendable, FeatureReducer {
 
 		public let kind: Kind = .public // only public is supported for now
 		public var message: String
+		public var focused: Bool = true
 
 		@PresentationState
 		public var destination: Destinations.State?
@@ -25,6 +26,7 @@ public struct AssetTransferMessage: Sendable, FeatureReducer {
 	public enum ViewAction: Sendable, Equatable {
 		case messageKindTapped
 		case removeMessageTapped
+		case focusChanged(Bool)
 		case messageChanged(String)
 	}
 
@@ -63,6 +65,10 @@ public struct AssetTransferMessage: Sendable, FeatureReducer {
 		switch viewAction {
 		case .messageKindTapped:
 			state.destination = .messageMode(.init())
+			return .none
+
+		case let .focusChanged(focused):
+			state.focused = focused
 			return .none
 
 		case .removeMessageTapped:

--- a/Sources/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+View.swift
+++ b/Sources/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+View.swift
@@ -15,6 +15,12 @@ extension AssetTransferMessage {
 	}
 }
 
+extension ViewStore<AssetTransferMessage.State, AssetTransferMessage.ViewAction> {
+	var focusedBinding: Binding<Bool> {
+		binding(get: \.focused, send: ViewAction.focusChanged)
+	}
+}
+
 extension AssetTransferMessage.View {
 	public var body: some View {
 		WithViewStore(store, observe: { $0 }, send: { .view($0) }) { viewStore in
@@ -62,6 +68,7 @@ extension AssetTransferMessage.View {
 					.scrollContentBackground(.hidden) // Remove the default background to allow customization
 					.background(Color.containerContentBackground)
 					.roundedCorners(.bottom, strokeColor: focused ? .focusedBorderColor : .borderColor)
+					.bind(viewStore.focusedBinding, to: $focused)
 				}
 			}
 			.sheet(


### PR DESCRIPTION
Jira ticket: [ABW-1797](https://radixdlt.atlassian.net/browse/ABW-1797)

## Description
Make it possible to tap outside the message entry field in Asset Transfer in order to dismiss the keyboard.

## Video
https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/e6415edf-db54-4051-85b7-9515f78b5ce7

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-1797]: https://radixdlt.atlassian.net/browse/ABW-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ