### PR TITLE
[ABW-1983] Fix Broken Image Placeholder

### DIFF
--- a/Sources/Core/DesignSystem/Components/Thumbnails.swift
+++ b/Sources/Core/DesignSystem/Components/Thumbnails.swift
@@ -241,6 +241,7 @@ public struct LoadableImage<Placeholder: View>: View {
 				Image(asset: AssetResource.brokenImagePlaceholder)
 					.resizable()
 					.aspectRatio(1, contentMode: .fit)
+					.frame(minWidth: .medium2, minHeight: .medium2)
 					.frame(maxWidth: .large1, maxHeight: .large1)
 
 				Spacer(minLength: .small2)


### PR DESCRIPTION
Jira ticket: [ABW-1983](https://radixdlt.atlassian.net/browse/ABW-1983)

## Description
Alternative to https://github.com/radixdlt/babylon-wallet-ios/pull/663

## Screenshot
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/9ff5a123-9708-4606-95b6-d1b91ba15ae3">
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/16fc18d2-e3b9-473c-affc-3964317f7459">
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/a5b0380f-4bc0-4776-925b-27a45e2c363a">
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/ee589fc9-5c91-4f5b-a51b-3af484a7ef74">
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/5b4ffce3-14aa-488a-994a-f4d33acc26e5">
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/684b9cce-6f7d-4d21-8a1f-a6245553b0b5">
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/c54163ab-571a-4add-a19b-80f9b80209f1">
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/4ba6b199-2ed2-472b-9878-54bb5ab1952b">
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/ffacec92-6fcc-48bd-b82e-4ce3e084ff0d">
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/2c8465b9-9092-462a-9005-bcb1174e4625">

This is what the validator version of the broken image placeholder actually looks like (ignore the cases above):
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/fe3adb62-cde4-4cf1-9318-9e55b495d5e5">


[ABW-1983]: https://radixdlt.atlassian.net/browse/ABW-1983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ