### PR TITLE
Add select fee payer button back

### DIFF
--- a/Sources/Features/TransactionReviewFeature/SelectFeePayer/SelectFeePayer+View.swift
+++ b/Sources/Features/TransactionReviewFeature/SelectFeePayer/SelectFeePayer+View.swift
@@ -76,6 +76,15 @@ extension SelectFeePayer {
 					}
 					.navigationTitle(L10n.TransactionReview.CustomizeNetworkFeeSheet.SelectFeePayer.navigationTitle)
 				}
+				.footer {
+					WithControlRequirements(
+						viewStore.selectedPayer,
+						forAction: { viewStore.send(.confirmedFeePayer($0)) }
+					) { action in
+						Button(L10n.TransactionReview.CustomizeNetworkFeeSheet.SelectFeePayer.selectAccountButtonTitle, action: action)
+							.buttonStyle(.primaryRectangular)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Seems to have been removed in some PR merge conflicts.