### PR TITLE
Interpret the JSON value as a String

### DIFF
--- a/Sources/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
+++ b/Sources/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
@@ -644,7 +644,7 @@ extension AccountPortfolio.NonFungibleResource.NonFungibleToken.NFTData.Value {
 			}
 			self = .url(url)
 		case .u64:
-			guard let u64 = value.uint.map(UInt64.init) else {
+			guard let u64 = value.string.flatMap(UInt64.init) else {
 				return nil
 			}
 			self = .u64(u64)


### PR DESCRIPTION
Jira ticket: [ABW-2089](https://radixdlt.atlassian.net/browse/ABW-2089)

## Description
This PR solves the ready-to-claim token filtering.

### Notes
Brief discussion [here](https://rdxworks.slack.com/archives/C031A0V1A1W/p1692374588073769). It's a global change to the interpretation of JSON values, but should be fine. Confirmed by David [here](https://rdxworks.slack.com/archives/C031A0V1A1W/p1693313383965089?thread_ts=1692374588.073769&cid=C031A0V1A1W).

## How to test

1. Stake some XRD (www.enkinet-dashboard.rdx-works-main.extratools.works)
2. Request unstake
3. Wait five minutes and confirm that tokens are ready to claim

## Screenshot

![IMG_7E326BDB3906-1](https://github.com/radixdlt/babylon-wallet-ios/assets/137085416/ba0a12c0-969b-4b04-a9ab-508902a09616)

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2089]: https://radixdlt.atlassian.net/browse/ABW-2089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ