### PR TITLE
[ABW-2123] Restored Account Preferences UI

### DIFF
--- a/Sources/Features/AccountPreferencesFeature/AccountPreferences+Reducer.swift
+++ b/Sources/Features/AccountPreferencesFeature/AccountPreferences+Reducer.swift
@@ -17,7 +17,7 @@ public struct AccountPreferences: Sendable, FeatureReducer {
 	// MARK: - Action
 
 	public enum ViewAction: Sendable, Equatable {
-		case viewAppeared
+		case task
 		case rowTapped(AccountPreferences.Section.SectionRow)
 	}
 
@@ -69,7 +69,7 @@ public struct AccountPreferences: Sendable, FeatureReducer {
 
 	public func reduce(into state: inout State, viewAction: ViewAction) -> EffectTask<Action> {
 		switch viewAction {
-		case .viewAppeared:
+		case .task:
 			return .run { [address = state.account.address] send in
 				for try await accountUpdate in await accountsClient.accountUpdates(address) {
 					guard !Task.isCancelled else { return }

--- a/Sources/Features/AccountPreferencesFeature/AccountPreferences+View.swift
+++ b/Sources/Features/AccountPreferencesFeature/AccountPreferences+View.swift
@@ -43,7 +43,7 @@ extension AccountPreferences {
 					onRowSelected: { _, rowId in viewStore.send(.rowTapped(rowId)) }
 				)
 				.task {
-					viewStore.send(.viewAppeared)
+					viewStore.send(.task)
 				}
 				.destination(store: store)
 				.background(.app.gray5)

--- a/Sources/Features/AccountPreferencesFeature/Common/PreferenceList.swift
+++ b/Sources/Features/AccountPreferencesFeature/Common/PreferenceList.swift
@@ -28,15 +28,6 @@ struct PreferenceSection<SectionId: Hashable, RowId: Hashable>: View {
 		typealias SelectedRow = RowId
 		case selection(SelectedRow)
 		case disclosure
-
-		func accessory(rowId: RowId) -> ImageAsset? {
-			switch self {
-			case let .selection(selection):
-				return rowId == selection ? AssetResource.check : nil
-			case .disclosure:
-				return AssetResource.chevronRight
-			}
-		}
 	}
 
 	struct ViewState: Equatable {
@@ -79,25 +70,23 @@ struct PreferenceSection<SectionId: Hashable, RowId: Hashable>: View {
 								.padding(.top, .medium3)
 						}
 					}
+					.padding(.vertical, .small1)
 					.frame(minHeight: .settingsRowHeight)
 
-					Group {
-						Spacer()
-						if case let .selection(selection) = viewState.mode {
-							if row.id == selection {
-								Image(asset: AssetResource.check)
-							} else {
-								/// Put a placeholder for unselected items.
-								/// Note: `Spacer(minLength:)` does not work.
-								FixedSpacer(width: .medium1)
-							}
+					Spacer(minLength: 0)
+
+					if case let .selection(selection) = viewState.mode {
+						if row.id == selection {
+							Image(asset: AssetResource.check)
 						} else {
-							Image(asset: AssetResource.chevronRight)
+							/// Put a placeholder for unselected items.
+							FixedSpacer(width: .medium1)
 						}
+					} else {
+						Image(asset: AssetResource.chevronRight)
 					}
 				}
 				.padding(.horizontal, .medium3)
-				.padding(.vertical, .small1)
 				.contentShape(Rectangle())
 				.tappable {
 					onRowSelected(viewState.id, row.id)
@@ -109,8 +98,13 @@ struct PreferenceSection<SectionId: Hashable, RowId: Hashable>: View {
 				Text(title)
 					.textStyle(.body1HighImportance)
 					.foregroundColor(.app.gray2)
+					.listRowInsets(.init(top: .small1, leading: .medium3, bottom: .medium3, trailing: .medium3))
 			}
+		} footer: {
+			Rectangle().fill().frame(height: 0)
+				.listRowInsets(EdgeInsets())
 		}
+		.listSectionSeparator(.hidden)
 		.textCase(nil)
 	}
 }


### PR DESCRIPTION
Jira ticket: [ABW-2123](https://radixdlt.atlassian.net/browse/ABW-2123)

## Description
Restore UI regressions in Account Preferences


## Screenshot
Before / After

<img src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/90890a3c-26ed-4798-8026-816d08ca167a" width="250"/><img src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/d49e6090-e1ef-4042-9818-cde0ac92fe47" width="250"/>

<img src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/89ad0666-2b00-40a7-8090-8a07861c0708" width="250"/>
<img src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/834c9605-d258-4332-b3bd-c48dc7374e30" width="250"/>

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2123]: https://radixdlt.atlassian.net/browse/ABW-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ