### PR TITLE
[ABW-2161] Hide Third Party Deposit settings in UI

### DIFF
--- a/Sources/Features/AccountPreferencesFeature/AccountPreferences+View.swift
+++ b/Sources/Features/AccountPreferencesFeature/AccountPreferences+View.swift
@@ -8,11 +8,12 @@ extension AccountPreferences.State {
 				title: "Personalize this account", // FIXME: strings
 				rows: [.accountLabel(account)]
 			),
-			.init(
-				id: .ledgerBehaviour,
-				title: "Set how you want this account to work", // FIXME: strings
-				rows: [.thirdPartyDeposits()]
-			),
+			// FIXME: Re-introduce Third Party Deposit once https://github.com/radixdlt/babylon-wallet-ios/pull/692 PR has fixed the TCA Send bug it introduces
+//			.init(
+//				id: .onLedgerBehaviour,
+//				title: "Set how you want this account to work", // FIXME: strings
+//				rows: [.thirdPartyDeposits()]
+//			),
 			.init(
 				id: .development,
 				title: "Set development preferences", // FIXME: strings
@@ -104,7 +105,7 @@ extension View {
 extension AccountPreferences {
 	public enum Section: Hashable, Sendable {
 		case personalize
-		case ledgerBehaviour
+		case onLedgerBehaviour
 		case development
 
 		public enum SectionRow: Hashable, Sendable {


### PR DESCRIPTION
Hiding the Third Party Deposit settings in Account settings since #692 is not merged nor mergable.

![IMG_EA61C81A3D24-1](https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/c43d83a2-8b58-4011-874f-5b11fef0fed7)
