### PR TITLE
[ABW-2171] Always require image URLs to be sent as URLs

### DIFF
--- a/Sources/Core/SharedModels/Assets/AccountPortfolio.swift
+++ b/Sources/Core/SharedModels/Assets/AccountPortfolio.swift
@@ -354,8 +354,7 @@ extension [AccountPortfolio.NonFungibleResource.NonFungibleToken.NFTData] {
 	}
 
 	public var keyImageURL: URL? {
-		guard let string = self[Field.keyImageURL]?.string else { return nil }
-		return URL(string: string)
+		self[.keyImageURL]?.url
 	}
 
 	public var tokenDescription: String? {


### PR DESCRIPTION
Jira ticket: [ABW-2171](https://radixdlt.atlassian.net/browse/ABW-2171)

## Description
key_image_url in NFTs is currently expected to be a string (because that’s what the sandbox sends), but this is incorrect, we should only accept URL

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works


[ABW-2171]: https://radixdlt.atlassian.net/browse/ABW-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ