### PR TITLE
Remove triplication of account name

### DIFF
--- a/Sources/Features/AccountListFeature/Components/Row/Row+View.swift
+++ b/Sources/Features/AccountListFeature/Components/Row/Row+View.swift
@@ -38,7 +38,7 @@ extension AccountList.Row {
 		}
 
 		init(state: State) {
-			self.name = state.account.displayName.rawValue + state.account.displayName.rawValue + state.account.displayName.rawValue
+			self.name = state.account.displayName.rawValue
 			self.address = state.account.address
 			self.appearanceID = state.account.appearanceID
 			self.isLoadingResources = state.portfolio.isLoading


### PR DESCRIPTION
## Description
I accidentally forgot to remove some test code that shows the account name three times