### PR TITLE
[ABW-2172] Don't truncate behaviour description

### DIFF
--- a/Sources/Features/AssetsFeature/Components/HelperViews/AssetBehaviorsView.swift
+++ b/Sources/Features/AssetsFeature/Components/HelperViews/AssetBehaviorsView.swift
@@ -33,6 +33,7 @@ struct AssetBehaviorRow: View {
 			Image(asset: behavior.icon)
 
 			Text(behavior.description)
+				.lineLimit(2)
 				.textStyle(.body2Regular)
 				.foregroundColor(.app.gray1)
 		}

--- a/Sources/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
+++ b/Sources/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
@@ -60,16 +60,13 @@ extension NonFungibleTokenDetails {
 						.frame(maxWidth: .infinity, alignment: .leading)
 						.padding(.horizontal, .large2)
 
-						ZStack {
-							Color.app.gray5.edgesIgnoringSafeArea(.bottom)
+						VStack(spacing: .medium1) {
+							NFTThumbnail(viewStore.resourceThumbnail, size: .veryLarge)
 
-							VStack(spacing: .medium1) {
-								NFTThumbnail(viewStore.resourceThumbnail, size: .veryLarge)
-
-								AssetResourceDetailsSection(viewState: viewStore.resourceDetails)
-							}
-							.padding(.vertical, .medium1)
+							AssetResourceDetailsSection(viewState: viewStore.resourceDetails)
 						}
+						.padding(.vertical, .medium1)
+						.background(.app.gray5, ignoresSafeAreaEdges: .bottom)
 					}
 					.padding(.top, .small1)
 				}


### PR DESCRIPTION
Jira ticket: [ABW-2172](https://radixdlt.atlassian.net/browse/ABW-2172)

## Description
Don't truncate behaviour description text for NFTs, let it take two lines if needed

## Screenshot
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/d34458c9-ba72-4706-b593-ec3557426af1">


[ABW-2172]: https://radixdlt.atlassian.net/browse/ABW-2172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ