### PR TITLE
fix navigation bug where incoming Dapp requests were ignored and wher…

### DIFF
--- a/Sources/Features/AppFeature/App+View.swift
+++ b/Sources/Features/AppFeature/App+View.swift
@@ -5,8 +5,18 @@ import MainFeature
 import OnboardingFeature
 import SplashFeature
 
+extension App.State {
+	var viewState: App.ViewState {
+		.init(showIsUsingTestnetBanner: showIsUsingTestnetBanner)
+	}
+}
+
 // MARK: - App.View
 extension App {
+	public struct ViewState: Equatable {
+		let showIsUsingTestnetBanner: Bool
+	}
+
 	@MainActor
 	public struct View: SwiftUI.View {
 		private let store: StoreOf<App>
@@ -16,50 +26,48 @@ extension App {
 		}
 
 		public var body: some SwiftUI.View {
-			WithViewStore(store, observe: { $0 }) { viewStore in
-				ZStack {
-					SwitchStore(store.scope(state: \.root, action: Action.child)) { state in
-						switch state {
-						case .main:
-							CaseLet(
-								state: /App.State.Root.main,
-								action: App.ChildAction.main,
-								then: { Main.View(store: $0) }
-							)
+			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
+				SwitchStore(store.scope(state: \.root, action: Action.child)) { state in
+					switch state {
+					case .main:
+						CaseLet(
+							state: /App.State.Root.main,
+							action: App.ChildAction.main,
+							then: { Main.View(store: $0) }
+						)
 
-						case .onboardingCoordinator:
-							CaseLet(
-								state: /App.State.Root.onboardingCoordinator,
-								action: App.ChildAction.onboardingCoordinator,
-								then: { OnboardingCoordinator.View(store: $0) }
-							)
+					case .onboardingCoordinator:
+						CaseLet(
+							state: /App.State.Root.onboardingCoordinator,
+							action: App.ChildAction.onboardingCoordinator,
+							then: { OnboardingCoordinator.View(store: $0) }
+						)
 
-						case .splash:
-							CaseLet(
-								state: /App.State.Root.splash,
-								action: App.ChildAction.splash,
-								then: { Splash.View(store: $0) }
-							)
-						case .onboardTestnetUserToMainnet:
-							CaseLet(
-								state: /App.State.Root.onboardTestnetUserToMainnet,
-								action: App.ChildAction.onboardTestnetUserToMainnet,
-								then: { CreateAccountCoordinator.View(store: $0) }
-							)
-						}
+					case .splash:
+						CaseLet(
+							state: /App.State.Root.splash,
+							action: App.ChildAction.splash,
+							then: { Splash.View(store: $0) }
+						)
+					case .onboardTestnetUserToMainnet:
+						CaseLet(
+							state: /App.State.Root.onboardTestnetUserToMainnet,
+							action: App.ChildAction.onboardTestnetUserToMainnet,
+							then: { CreateAccountCoordinator.View(store: $0) }
+						)
 					}
-					.tint(.app.gray1)
-					.alert(
-						store: store.scope(state: \.$alert, action: { .view(.alert($0)) }),
-						state: /App.Alerts.State.incompatibleProfileErrorAlert,
-						action: App.Alerts.Action.incompatibleProfileErrorAlert
-					)
-					.task { @MainActor in
-						await viewStore.send(.view(.task)).finish()
-					}
-					.showDeveloperDisclaimerBanner(viewStore.showIsUsingTestnetBanner)
-					.presentsLoadingViewOverlay()
 				}
+				.tint(.app.gray1)
+				.alert(
+					store: store.scope(state: \.$alert, action: { .view(.alert($0)) }),
+					state: /App.Alerts.State.incompatibleProfileErrorAlert,
+					action: App.Alerts.Action.incompatibleProfileErrorAlert
+				)
+				.task { @MainActor in
+					await viewStore.send(.task).finish()
+				}
+				.showDeveloperDisclaimerBanner(viewStore.showIsUsingTestnetBanner)
+				.presentsLoadingViewOverlay()
 			}
 		}
 	}


### PR DESCRIPTION
…e user could not select assets to transfer in Asset transfer view.

The mainnet switching PR introduced a bug, by introducing a `WithViewStore` that observed the whole state: https://github.com/radixdlt/babylon-wallet-ios/pull/710/files#diff-50c9a079a1648e57f1b56e1f506501b05457d9227b71b44c2abc845189d38d3fR19

This broke navigation.... 🤷‍♂️ 

I've fixed it by adding a ViewState for app.

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
