### PR TITLE
[ABW-2065] Dont show Cancelled error to user

### DIFF
--- a/Sources/Prelude/ErrorQueue/ErrorQueue+Live.swift
+++ b/Sources/Prelude/ErrorQueue/ErrorQueue+Live.swift
@@ -18,9 +18,10 @@ extension ErrorQueue: DependencyKey {
 
 				if
 					case let nsError = error as NSError,
+					nsError.domain == NSURLErrorDomain,
 					nsError.code == NSURLErrorCancelled
 				{
-					loggerGlobal.warning("Suppressed NSError with code NSURLErrorCancelled, i.e. preventing scheduling of this error on the ErrorQueue")
+					loggerGlobal.warning("Suppressed NSError with domain `NSURLErrorDomain`, i.e. preventing scheduling of this error on the ErrorQueue. \nDetails: code: \(nsError.code) - description: \"\(nsError.localizedDescription)\"")
 					return
 				}
 


### PR DESCRIPTION
Jira ticket: [ABW-2065](https://radixdlt.atlassian.net/browse/ABW-2065)

Yes oooops, I used wrong git branch name, c'est la vie

# Description
Prevent scheduling NSError where code is NSURLErrorCancelled also prevent scheduling of CancellationError


# Video

## BEFORE

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/477ae74e-74c4-4ffc-a8d8-ff7577b8636b

## AFTER

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/0aa8c9b5-a7b3-4c61-8cbe-02a2a919e05d




## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2065]: https://radixdlt.atlassian.net/browse/ABW-2065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ