### PR TITLE
[ABW-2229] Show error when Gateway failed to generate preview of transaction

### DIFF
--- a/Sources/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/Sources/Features/TransactionReviewFeature/TransactionReview.swift
@@ -1080,7 +1080,7 @@ extension NonFungibleLocalIdVecSource {
 public struct TransactionReviewFailure: LocalizedError {
 	public let underylying: Swift.Error
 	public var errorDescription: String? {
-		var msg = "A proposed transaction could not be processed"
+		var msg = "A proposed transaction could not be processed" // FIXME: Strings source: https://rdxworks.slack.com/archives/C031A0V1A1W/p1694087946050189?thread_ts=1694085688.749539&cid=C031A0V1A1W
 		#if DEBUG
 		msg += "\n\n[DEBUG] Underlying error: \(String(describing: underylying))"
 		#endif


### PR DESCRIPTION
# Description
Display error if Gateway `preview` endpoint fails - if so we show `"A proposed transaction could not be processed"`, and for DEBUG build we also append "[DEBUG] Underlying error"

# Demo

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/e3d17d1b-7999-49bb-8f1c-9228e85ce66c


# Test
Use Dashboard -> Send Raw Transaction and then send this syntax correct but invalid transaction which will result in gateway preview endpoint returning an error:

```rust
CALL_METHOD
            Address("component_tdx_e_1cqh2vmmz9d5g4lg2fe4zd3cjqyt4l49wrk4efpevrrc0cn3gelwghd")
            "APA"
        ;
```

@kugel3 is fixing slider not being reset bug