### PR TITLE
[NEVER MERGE TO MAIN] Remove `mainnet` for Beta==Preview 

### DIFF
--- a/Sources/Profile/PerNetwork/Radix+Network.swift
+++ b/Sources/Profile/PerNetwork/Radix+Network.swift
@@ -94,7 +94,6 @@ extension Radix.Network {
 
 extension Radix.Network {
 	fileprivate static let lookupSet: Set<Self> = [
-		.mainnet,
 		.stokenet,
 		.nebunet,
 		.kisharnet,


### PR DESCRIPTION
so that community users cannot switch to mainnet.

# Rationale
We do NOT want community users who are already using the `Beta==Preview` Testflight app to be able to use that app on `mainnet` when mainnet goes live. The merged PR https://github.com/radixdlt/babylon-wallet-ios/pull/739 makes sure that when mainnet has been live and users **who have force quit the app**, will not be able to continue to use the app. But for users with the app running who are not force quitting it, they will still be able to manually switch to mainnet., **this PR makes it impossible for those users to switch to mainnet**.