### PR TITLE
[ABW-2254] Show PersonaData in PersonaDetails even for Personas which have not been shared.

### DIFF
--- a/Sources/Features/PersonaDetailsFeature/PersonaDetails+View.swift
+++ b/Sources/Features/PersonaDetailsFeature/PersonaDetails+View.swift
@@ -287,15 +287,6 @@ private extension PersonaDetails.State {
 	}
 }
 
-private extension PersonaDetails.View.InfoSection.ViewState {
-	init(
-		dAppInfo: DappInfo?,
-		personaName: String
-	) {
-		fatalError()
-	}
-}
-
 // MARK: - PersonaDetails.View.InfoSection
 extension PersonaDetails.View {
 	@MainActor
@@ -358,31 +349,31 @@ extension PersonaDetails.View {
 						} else {
 							Text(L10n.AuthorizedDapps.PersonaDetails.personalDataSharingDescription(dAppInfo.name))
 								.textBlock
-
-							if let fullName = viewStore.fullName {
-								VPair(
-									heading: L10n.AuthorizedDapps.PersonaDetails.fullName,
-									item: fullName
-								)
-								Separator()
-							}
-
-							if let phoneNumber = viewStore.phoneNumbers?.first {
-								VPair(
-									heading: L10n.AuthorizedDapps.PersonaDetails.phoneNumber,
-									item: phoneNumber
-								)
-								Separator()
-							}
-
-							if let emailAddress = viewStore.emailAddresses?.first {
-								VPair(
-									heading: L10n.AuthorizedDapps.PersonaDetails.emailAddress,
-									item: emailAddress
-								)
-								Separator()
-							}
 						}
+					}
+
+					if let fullName = viewStore.fullName {
+						VPair(
+							heading: L10n.AuthorizedDapps.PersonaDetails.fullName,
+							item: fullName
+						)
+						Separator()
+					}
+
+					if let phoneNumber = viewStore.phoneNumbers?.first {
+						VPair(
+							heading: L10n.AuthorizedDapps.PersonaDetails.phoneNumber,
+							item: phoneNumber
+						)
+						Separator()
+					}
+
+					if let emailAddress = viewStore.emailAddresses?.first {
+						VPair(
+							heading: L10n.AuthorizedDapps.PersonaDetails.emailAddress,
+							item: emailAddress
+						)
+						Separator()
 					}
 				}
 				.padding(.horizontal, .medium1)


### PR DESCRIPTION
[JIRA ABW-2254](https://radixdlt.atlassian.net/browse/ABW-2254)

# Description
I accidentally hid PersonaData in PersonaDetails if the Persona has not been shared with a Dapp before, mea culpa! 

Fix was trivial.

# Screenshots

## Before

![image](https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/ca26220d-50c3-474b-8e21-4ea0ec425324)

## After

![image](https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/9feff8d1-1b07-418d-b8d7-9b91be510869)

## PR submission checklist
- [x] [Gumball Swap](https://rcnet-v3-dashboard.radixdlt.com/transaction/txid_tdx_e_1tkyqq76v8ldh9hu905a55phvk23h7yckyfst2s4mxhenk24vw4csq0jqm3/details)
