### PR TITLE
[CD] Improve CD ensure Github release action is run for PROD ("Release")

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -13,17 +13,6 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 # Available Actions
 
-### cyon
-
-```sh
-[bundle exec] fastlane cyon
-```
-
-
-
-----
-
-
 ## iOS
 
 ### ios build


### PR DESCRIPTION
* Make "Github Release" for PROD (Release) flavour
* Change so that "Github Release" for BETA are marked with is "pre-release"
* Important: Fix broken `changelog_from_git_commits` action, which listed ALL PRs since #1 instead of diff since last tag
* Remove obsolete listed "core dependencies"
* Add more relevant "core dependencies"
* Fix broken version of listed "core dependencies" - now with support for Package `commit` and `branch` (not only `version`)
* Add hyperlinks for all "core dependencies"! (smart and dynamic enough to work for commits, branch and version (tag))