### PR TITLE
ABW-2048 Handle Reserved Instructions

### DIFF
--- a/Sources/Clients/TransactionClient/Models/TransactionFailure.swift
+++ b/Sources/Clients/TransactionClient/Models/TransactionFailure.swift
@@ -1,5 +1,5 @@
-
 import ClientPrelude
+import EngineKit
 
 // MARK: - TransactionFailure
 public enum TransactionFailure: Sendable, LocalizedError, Equatable {
@@ -51,6 +51,9 @@ extension TransactionFailure {
 		case .failedToSubmit:
 			return (errorKind: .failedToSubmitTransaction, message: nil)
 
+		case .failedToPrepareTXReview(.manifestWithReservedInstructions):
+			return (errorKind: .failedToPrepareTransaction, message: self.errorDescription)
+
 //		case let .failedToSubmit(error):
 //			switch error {
 //			case .failedToSubmitTX:
@@ -82,6 +85,7 @@ extension TransactionFailure {
 		case failedToRetrieveTXReceipt(String)
 		case failedToExtractTXReceiptBytes(Error)
 		case failedToGenerateTXReview(Error)
+		case manifestWithReservedInstructions([ReservedInstruction])
 
 		public var errorDescription: String? {
 			switch self {
@@ -95,6 +99,8 @@ extension TransactionFailure {
 				return "ET failed to generate TX review: \(error.localizedDescription)"
 			case let .failedToRetrieveTXReceipt(message):
 				return "Failed to retrive TX receipt from gateway: \(message)"
+			case .manifestWithReservedInstructions:
+				return "Transaction Manifest contains forbidden instructions"
 			}
 		}
 	}

--- a/Sources/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/Sources/Clients/TransactionClient/TransactionClient+Live.swift
@@ -190,6 +190,10 @@ extension TransactionClient {
 			/// Analyze the manifest
 			let analyzedManifestToReview = try request.manifestToSign.analyzeExecution(transactionReceipt: receiptBytes)
 
+			guard analyzedManifestToReview.reservedInstructions.isEmpty else {
+				throw TransactionFailure.failedToPrepareTXReview(.manifestWithReservedInstructions(analyzedManifestToReview.reservedInstructions))
+			}
+
 			/// Get all of the expected signing factors.
 			let signingFactors = try await {
 				if let nonEmpty = NonEmpty<Set<EntityPotentiallyVirtual>>(transactionSigners.intentSignerEntitiesOrEmpty()) {


### PR DESCRIPTION
[ABW-2048](https://radixdlt.atlassian.net/browse/ABW-2048)

EngineToolkit will not return an error if a transaction manifest contains reserved instructions, such as LockFee instruction.

For now we do reject the manifest right after it was analysed. In the future we may want to those in a different fashion.

[ABW-2048]: https://radixdlt.atlassian.net/browse/ABW-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ