### PR TITLE
Properly handle deposit instruction

### DIFF
--- a/Sources/EngineKit/ManifestBuilder/ManifestResultBuilder.swift
+++ b/Sources/EngineKit/ManifestBuilder/ManifestResultBuilder.swift
@@ -18,6 +18,7 @@ extension ManifestBuilder {
 	public static let withdrawTokens = flip(withdrawNonFungiblesFromAccount)
 	public static let takeFromWorktop = flip(takeFromWorktop)
 	public static let accountTryDepositOrAbort = flip(accountTryDepositOrAbort)
+	public static let accountDeposit = flip(accountDeposit)
 	public static let takeNonFungiblesFromWorktop = flip(takeNonFungiblesFromWorktop)
 	public static let setOwnerKeys = flip(setOwnerKeys)
 
@@ -40,6 +41,14 @@ extension ManifestBuilder {
 
 		public static func buildOptional(_ component: Instructions?) -> Instructions {
 			component ?? []
+		}
+
+		public static func buildEither(first component: Instructions) -> Instructions {
+			component
+		}
+
+		public static func buildEither(second component: Instructions) -> Instructions {
+			component
 		}
 	}
 

--- a/Sources/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/ReceivingAccount+Reducer.swift
+++ b/Sources/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/ReceivingAccount+Reducer.swift
@@ -111,6 +111,14 @@ extension ReceivingAccount.State.Account {
 			return address
 		}
 	}
+
+	var isUserAccount: Bool {
+		guard case .left = self else {
+			return false
+		}
+
+		return true
+	}
 }
 
 // MARK: - ReceivingAccount.State.Account + Identifiable


### PR DESCRIPTION
With Third-Party Deposit rules being added, now it is crucial to properly handle the deposit instruction, more specifically for the scenarios when the user performs a transfer between his own accounts **Third-Party deposit rules should not apply**.

[deposit](https://radixdlt.atlassian.net/wiki/spaces/S/pages/3079472416/REP-92+Native+Account+Component#deposit) vs [try_deposit_or_abort](https://radixdlt.atlassian.net/wiki/spaces/S/pages/3079472416/REP-92+Native+Account+Component#try_deposit_or_abort)


Demo:
Demonstrating that different instructions are added to the manifest for a transfer made to a foreign account - try_deposit_or_abort; and made to user owned account - deposit.

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/22e5d4d0-a062-4161-a2b5-c6b0e8d7319e

