### PR TITLE
Wallet is allowed to use reserved instructions

### DIFF
--- a/Sources/Clients/DappInteractionClient/DappInteractionClient+Interfce.swift
+++ b/Sources/Clients/DappInteractionClient/DappInteractionClient+Interfce.swift
@@ -42,6 +42,10 @@ extension P2P.Dapp.Request.ID {
 	public var isWalletAccountTransferInteraction: Bool {
 		rawValue.hasPrefix(DappInteractionClient.WalletInteraction.accountTransfer.rawValue)
 	}
+
+	public var isWalletInteraction: Bool {
+		isWalletAccountTransferInteraction || isWalletAccountDepositSettingsInteraction
+	}
 }
 
 extension DappInteractionClient {

--- a/Sources/Clients/TransactionClient/Models/TransactionModels.swift
+++ b/Sources/Clients/TransactionClient/Models/TransactionModels.swift
@@ -198,6 +198,7 @@ public struct ManifestReviewRequest: Sendable {
 	public let makeTransactionHeaderInput: MakeTransactionHeaderInput
 	public let ephemeralNotaryPublicKey: Curve25519.Signing.PublicKey
 	public let signingPurpose: SigningPurpose
+	public let isWalletTransaction: Bool
 
 	public init(
 		manifestToSign: TransactionManifest,
@@ -205,7 +206,8 @@ public struct ManifestReviewRequest: Sendable {
 		nonce: Nonce,
 		makeTransactionHeaderInput: MakeTransactionHeaderInput = .default,
 		ephemeralNotaryPublicKey: Curve25519.Signing.PublicKey,
-		signingPurpose: SigningPurpose
+		signingPurpose: SigningPurpose,
+		isWalletTransaction: Bool
 	) {
 		self.manifestToSign = manifestToSign
 		self.message = message
@@ -213,6 +215,7 @@ public struct ManifestReviewRequest: Sendable {
 		self.makeTransactionHeaderInput = makeTransactionHeaderInput
 		self.ephemeralNotaryPublicKey = ephemeralNotaryPublicKey
 		self.signingPurpose = signingPurpose
+		self.isWalletTransaction = isWalletTransaction
 	}
 }
 

--- a/Sources/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/Sources/Clients/TransactionClient/TransactionClient+Live.swift
@@ -190,7 +190,8 @@ extension TransactionClient {
 			/// Analyze the manifest
 			let analyzedManifestToReview = try request.manifestToSign.analyzeExecution(transactionReceipt: receiptBytes)
 
-			guard analyzedManifestToReview.reservedInstructions.isEmpty else {
+			/// Transactions created outside of the Wallet are not allowed to use reserved instructions
+			if !request.isWalletTransaction, !analyzedManifestToReview.reservedInstructions.isEmpty {
 				throw TransactionFailure.failedToPrepareTXReview(.manifestWithReservedInstructions(analyzedManifestToReview.reservedInstructions))
 			}
 

--- a/Sources/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
+++ b/Sources/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
@@ -301,7 +301,8 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 				transactionManifest: manifest,
 				nonce: .secureRandom(),
 				signTransactionPurpose: .internalManifest(.debugModifyAccount),
-				message: .none
+				message: .none,
+				isWalletTransaction: true
 			))
 			return .none
 

--- a/Sources/Features/CreateAuthKey/CreateAuthKey.swift
+++ b/Sources/Features/CreateAuthKey/CreateAuthKey.swift
@@ -169,7 +169,8 @@ public struct CreateAuthKey: Sendable, FeatureReducer {
 				transactionManifest: manifest,
 				nonce: .secureRandom(),
 				signTransactionPurpose: .internalManifest(.uploadAuthKey),
-				message: .none
+				message: .none,
+				isWalletTransaction: true
 			))
 			state.authenticationSigningFactorInstance = authenticationSigningFactorInstance
 			return .none

--- a/Sources/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/Sources/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -1034,7 +1034,8 @@ extension DappInteractionFlow.Destinations.State {
 				message: item.message.map {
 					Message.plainText(value: .init(mimeType: "text", message: .str(value: $0)))
 				} ?? .none,
-				waitsForTransactionToBeComitted: interaction.id.isWalletAccountDepositSettingsInteraction
+				waitsForTransactionToBeComitted: interaction.id.isWalletAccountDepositSettingsInteraction,
+				isWalletTransaction: interaction.id.isWalletInteraction
 			)))
 		}
 	}

--- a/Sources/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/Sources/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -707,7 +707,8 @@ extension TransactionReview.State {
 		transactionManifest: .previewValue,
 		nonce: .zero,
 		signTransactionPurpose: .manifestFromDapp,
-		message: .none
+		message: .none,
+		isWalletTransaction: false
 	)
 }
 #endif

--- a/Sources/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/Sources/Features/TransactionReviewFeature/TransactionReview.swift
@@ -21,6 +21,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		public let message: Message
 		public let signTransactionPurpose: SigningPurpose.SignTransactionPurpose
 		public let waitsForTransactionToBeComitted: Bool
+		public let isWalletTransaction: Bool
 
 		public var networkID: NetworkID? { reviewedTransaction?.networkId }
 
@@ -76,7 +77,8 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			signTransactionPurpose: SigningPurpose.SignTransactionPurpose,
 			message: Message,
 			ephemeralNotaryPrivateKey: Curve25519.Signing.PrivateKey = .init(),
-			waitsForTransactionToBeComitted: Bool = false
+			waitsForTransactionToBeComitted: Bool = false,
+			isWalletTransaction: Bool
 		) {
 			self.nonce = nonce
 			self.transactionManifest = transactionManifest
@@ -84,6 +86,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			self.message = message
 			self.ephemeralNotaryPrivateKey = ephemeralNotaryPrivateKey
 			self.waitsForTransactionToBeComitted = waitsForTransactionToBeComitted
+			self.isWalletTransaction = isWalletTransaction
 		}
 
 		public enum DisplayMode: Sendable, Hashable {
@@ -220,7 +223,8 @@ public struct TransactionReview: Sendable, FeatureReducer {
 						message: state.message,
 						nonce: state.nonce,
 						ephemeralNotaryPublicKey: state.ephemeralNotaryPrivateKey.publicKey,
-						signingPurpose: .signTransaction(state.signTransactionPurpose)
+						signingPurpose: .signTransaction(state.signTransactionPurpose),
+						isWalletTransaction: state.isWalletTransaction
 					))
 				}
 				await send(.internal(.previewLoaded(preview)))


### PR DESCRIPTION
Allows Wallet to use reserved instructions in transaction manifest.

accountDepositSettings related instructions happen to be part of reservedInstructions set. And we should really allow the Wallet to add any instruction, only the manifests coming from outside should be validated to not contain reserved instructions.