### PR TITLE
Try fix GH release, If not work, we will revert fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -131,7 +131,14 @@ private_lane :create_gh_release do |options|
     flavour = options.fetch(:flavour).delete_prefix('"').delete_suffix('"') # if accidentally included
     
     ipaPath = lane_context[SharedValues::IPA_OUTPUT_PATH]
-    dsymPath = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+    dsymPath = lane_context[SharedValues::DSYM_OUTPUT_PATH] 
+    if dsymPath.nil?
+        puts "\n⚠️ Radix: Warning dsymPath is nil ⚠️ Will be unable to upload dsym\n"
+    end
+    if dsymPath.blank?
+        puts "\n⚠️ Radix: Warning dsymPath is blank ⚠️ Will be unable to upload dsym\n"
+        dsymPath = nil # nil is filtered away below
+    end
 
     sh('git fetch --tags')
     most_recent_tags = sh("git tag | grep #{flavour} | sort -r | head -2").split("\n")


### PR DESCRIPTION
PR https://github.com/radixdlt/babylon-wallet-ios/pull/782 broke Github releases (did NOT break build/upload to TestFlight)

This attempts to fix it.

See failure: https://github.com/radixdlt/babylon-wallet-ios/actions/runs/6270589504/job/17028743774

`[06:09:04]: no implicit conversion of nil into String`

[It failed at line 104 in set_gitub_release](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/set_github_release.rb#L104), which is about uploading of assets