### PR TITLE
[ABW-2322] Guarantee bug fix

### DIFF
--- a/Sources/Clients/TransactionClient/Models/TransactionModels.swift
+++ b/Sources/Clients/TransactionClient/Models/TransactionModels.swift
@@ -177,15 +177,18 @@ extension TransactionClient {
 		public var amount: BigDecimal
 		public var instructionIndex: UInt64
 		public var resourceAddress: ResourceAddress
+		public var resourceDivisibility: Int?
 
 		public init(
 			amount: BigDecimal,
 			instructionIndex: UInt64,
-			resourceAddress: ResourceAddress
+			resourceAddress: ResourceAddress,
+			resourceDivisibility: Int?
 		) {
 			self.amount = amount
 			self.instructionIndex = instructionIndex
 			self.resourceAddress = resourceAddress
+			self.resourceDivisibility = resourceDivisibility
 		}
 	}
 }

--- a/Sources/Core/DesignSystem/ViewModifiers/PresentationBackground.swift
+++ b/Sources/Core/DesignSystem/ViewModifiers/PresentationBackground.swift
@@ -49,17 +49,6 @@ private struct PresentationBackgroundModifier: ViewModifier {
 				// add the background view at the very back of the container hierarchy
 				containerView.insertSubview(backgroundView, at: 0)
 
-				// TODO: @davdroman find a way to make this work post betanet v2, otherwise
-				// settle for current workaround which is near perfect anyway.
-//				sheetPresentationController.swizzle(
-//					original: #selector(UIPresentationController.presentationTransitionWillBegin),
-//					swizzled: #selector(UIPresentationController.swizzled_presentationTransitionWillBegin)
-//				)
-//				sheetPresentationController.additionalPresentationAnimation = {
-//					viewController.transitionCoordinator?.animate(alongsideTransition: { context in
-//						backgroundView.alpha = 1
-//					})
-//				}
 				// Workaround for now
 				// rudimentarily dims in background view
 				backgroundView.alpha = 0


### PR DESCRIPTION
[Jira Ticket ABW-2322](https://radixdlt.atlassian.net/browse/ABW-2322)

* Pass along resource divisibility for guarantees, ensure to never try creating a RET.Decimal with more than divisibility (or 18 if nil) many decimals (the root cause of the error) 
* Added human friendly error if wallet fails to Add Lock Fee (has never happened / should never fail)
* Added human friendly error if wallet fails to Add Guarantee (should never fail)
* If any of Add Lock Fee or Add Guarantee fails, ensure the Approve Slider is slidable (reset)

# Demo 

## Successfully fixed underlying 21 decimals error

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/34da9c6a-b59c-4c31-b04c-d02ab983d430


[TXID of successfully added guarantee of `0.0001`](https://rcnet-v3-dashboard.radixdlt.com/transaction/txid_tdx_e_130j8c2yf7h2y4snf0ma2fgnj500lwcjzpcevq4fkadlqmun7g9gqwzc959/details)

## Hardcoding fail add guarantee (with this PR; should never happen)

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/759d05df-a168-4677-a64d-4d4750af53d5

## Hardcoding fail add Lock fee (never seen, should really never happen)


https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/6bd70dc2-adac-445f-bd16-75dd463a8f18


