### PR TITLE
Prevent user from going back TX Review

### DIFF
--- a/Sources/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/Sources/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -449,7 +449,7 @@ extension DappInteractionFlow {
 		case let .reviewTransaction(.delegate(.transactionCompleted(txID))):
 			return .send(.delegate(.dismissWithSuccess(state.dappMetadata, txID)))
 
-		case .reviewTransaction(.delegate(.userDismissedTransactionStatus)):
+		case .reviewTransaction(.delegate(.dismiss)):
 			return .send(.delegate(.dismiss))
 
 		case let .reviewTransaction(.delegate(.failed(error))):

--- a/Sources/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
+++ b/Sources/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
@@ -55,9 +55,7 @@ public struct SubmitTransaction: Sendable, FeatureReducer {
 
 	public enum DelegateAction: Sendable, Equatable {
 		case failedToSubmit
-		case failedToReceiveStatusUpdate
 		case submittedButNotCompleted(TXID)
-		case submittedTransactionFailed
 		case committedSuccessfully(TXID)
 		case manuallyDismiss
 	}
@@ -144,8 +142,6 @@ public struct SubmitTransaction: Sendable, FeatureReducer {
 				state.status = stateStatus
 				if stateStatus.isCompletedSuccessfully {
 					return .send(.delegate(.committedSuccessfully(state.notarizedTX.txID)))
-				} else if stateStatus.isCompletedWithFailure {
-					return .send(.delegate(.submittedTransactionFailed))
 				} else if stateStatus.isSubmitted {
 					if !state.hasDelegatedThatTXHasBeenSubmitted {
 						defer { state.hasDelegatedThatTXHasBeenSubmitted = true }


### PR DESCRIPTION
If submitting transaction failed or there is any other issue after submission, user should not be able to go back to TransactionReview.

When user does dismiss the transaction failure screen, the whole TX Review will be also dismissed.

