### PR TITLE
[ABW-2366] Make it possible to import mnemonic controlling MANY accounts 

### DIFF
--- a/Sources/Clients/AccountsClientLive/AccountsClient+Live.swift
+++ b/Sources/Clients/AccountsClientLive/AccountsClient+Live.swift
@@ -45,7 +45,6 @@ extension AccountsClient: DependencyKey {
 			getAccountsOnNetwork: getAccountsOnNetwork,
 			newVirtualAccount: { request in
 				let networkID = request.networkID
-				let profile = await getProfileStore().profile
 				let numberOfExistingAccounts = await nextAccountIndex(networkID)
 				return try Profile.Network.Account(
 					networkID: networkID,

--- a/Sources/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/Sources/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -47,7 +47,6 @@ extension DisplayEntitiesControlledByMnemonic {
 							}
 						}
 					}
-
 					VStack(alignment: .leading, spacing: .small3) {
 						ForEach(viewStore.accountsForDeviceFactorSource.accounts) { account in
 							SmallAccountCard(account: account)

--- a/Sources/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
+++ b/Sources/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
@@ -58,9 +58,11 @@ extension ImportMnemonicControllingAccounts {
 						.cornerRadius(.small2)
 					}
 
-					DisplayEntitiesControlledByMnemonic.View(
-						store: store.scope(state: \.entities, action: { .child(.entities($0)) })
-					)
+					ScrollView {
+						DisplayEntitiesControlledByMnemonic.View(
+							store: store.scope(state: \.entities, action: { .child(.entities($0)) })
+						)
+					}
 				}
 				.padding(.horizontal, .medium3)
 				.footer {


### PR DESCRIPTION
# Description

Before this PR it was impossible to import a mnemonic controlling many accounts, due to lack of `ScrollView`.

![IMG_8697](https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/4926a3cf-3a2e-4255-a595-e00c99678e31)
