### PR TITLE
Revert accidental profile snapshot change

### DIFF
--- a/Sources/Features/GatewaySettingsFeature/Components/GatewayRow/GatewayRow+View.swift
+++ b/Sources/Features/GatewaySettingsFeature/Components/GatewayRow/GatewayRow+View.swift
@@ -2,7 +2,17 @@ import FeaturePrelude
 
 extension Radix.Gateway {
 	var displayName: String {
-		isWellknown ? (name ?? network.displayDescription) : url.absoluteString
+		if isWellknown {
+			if network == .mainnet {
+				return "Mainnet Gateway"
+			} else if network == .stokenet {
+				return "Stokenet (testnet) Gateway"
+			} else {
+				return network.displayDescription
+			}
+		} else {
+			return url.absoluteString
+		}
 	}
 }
 

--- a/Sources/Profile/AppPreferences/Gateway/Radix+Gateway.swift
+++ b/Sources/Profile/AppPreferences/Gateway/Radix+Gateway.swift
@@ -14,17 +14,14 @@ extension Radix {
 		public let network: Network
 		/// The URL to the gateways API endpoint
 		public let url: URL
-		public let name: String?
 		public var id: ID { url }
 
 		public init(
 			network: Network,
-			url: URL,
-			name: String? = nil
+			url: URL
 		) {
 			self.network = network
 			self.url = url
-			self.name = name
 		}
 	}
 }
@@ -37,24 +34,21 @@ extension Radix.Gateway {
 	public static var mainnet: Self {
 		.init(
 			network: .mainnet,
-			url: URL(string: "https://mainnet.radixdlt.com/")!,
-			name: "Mainnet Gateway"
+			url: URL(string: "https://mainnet.radixdlt.com/")!
 		)
 	}
 
 	public static var stokenet: Self {
 		.init(
 			network: .stokenet,
-			url: URL(string: "https://babylon-stokenet-gateway.radixdlt.com/")!,
-			name: "Stokenet (testnet) Gateway"
+			url: URL(string: "https://babylon-stokenet-gateway.radixdlt.com/")!
 		)
 	}
 
 	public static var rcnet: Self {
 		.init(
 			network: .zabanet,
-			url: URL(string: "https://rcnet-v3.radixdlt.com/")!,
-			name: "RCnet v3 Gateway"
+			url: URL(string: "https://rcnet-v3.radixdlt.com/")!
 		)
 	}
 


### PR DESCRIPTION
I broke Profile for Android since they do strict JSON key checking.... 

I dont know what I did the other day, adding stored properties into Profile types... this reverts it with the same behaviour.



https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/831dc767-15a2-4bc0-a8f3-345e0ed47bce

