### PR TITLE
[ABW-2231] Go To Account List After Olympia Import

### DIFF
--- a/Sources/Features/AccountListFeature/Coordinator/AccountList+View.swift
+++ b/Sources/Features/AccountListFeature/Coordinator/AccountList+View.swift
@@ -11,7 +11,7 @@ extension AccountList {
 		}
 
 		public var body: some SwiftUI.View {
-			LazyVStack(spacing: .medium3) {
+			VStack(spacing: .medium3) {
 				ForEachStore(
 					store.scope(
 						state: \.accounts,

--- a/Sources/Features/SettingsFeature/AccountSecurity/AccountSecurity+Reducer.swift
+++ b/Sources/Features/SettingsFeature/AccountSecurity/AccountSecurity+Reducer.swift
@@ -46,6 +46,10 @@ public struct AccountSecurity: Sendable, FeatureReducer {
 		case destination(PresentationAction<Destinations.Action>)
 	}
 
+	public enum DelegateAction: Sendable, Equatable {
+		case gotoAccountList
+	}
+
 	public struct Destinations: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case mnemonics(DisplayMnemonics.State)
@@ -142,12 +146,12 @@ public struct AccountSecurity: Sendable, FeatureReducer {
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
 		case let .destination(.presented(.importOlympiaWallet(.delegate(.finishedMigration(gotoAccountList))))):
-			state.destination = nil
 			if gotoAccountList {
-				// FIXME: Probably call delegate in order to dismiss all the way back
-				return .run { _ in await dismiss() }
+				return .send(.delegate(.gotoAccountList))
+			} else {
+				state.destination = nil
+				return .none
 			}
-			return .none
 
 		case .destination(.dismiss):
 			if case let .depositGuarantees(depositGuarantees) = state.destination, let value = depositGuarantees.depositGuarantee {

--- a/Sources/Features/SettingsFeature/Settings+Reducer.swift
+++ b/Sources/Features/SettingsFeature/Settings+Reducer.swift
@@ -166,8 +166,15 @@ public struct Settings: Sendable, FeatureReducer {
 
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
-		case let .destination(.presented(.appSettings(.delegate(.deleteProfileAndFactorSources(keepInICloudIfPresent))))):
-			return .send(.delegate(.deleteProfileAndFactorSources(keepInICloudIfPresent: keepInICloudIfPresent)))
+		case let .destination(.presented(presentedAction)):
+			switch presentedAction {
+			case let .appSettings(.delegate(.deleteProfileAndFactorSources(keepInICloudIfPresent))):
+				return .send(.delegate(.deleteProfileAndFactorSources(keepInICloudIfPresent: keepInICloudIfPresent)))
+			case .accountSecurity(.delegate(.gotoAccountList)):
+				return .run { _ in await dismiss() }
+			default:
+				return .none
+			}
 
 		case .destination(.dismiss):
 			switch state.destination {
@@ -176,9 +183,6 @@ public struct Settings: Sendable, FeatureReducer {
 			default:
 				return .none
 			}
-
-		case .destination:
-			return .none
 		}
 	}
 


### PR DESCRIPTION
Jira ticket: [ABW-2231](https://radixdlt.atlassian.net/browse/ABW-2231)

## Description
- A: After finishing importing Olympia accounts, the "Go to Account list" button now actually takes us to the home screen
- B: Unrelated issue: Fixed the visual glitch in the home screen where things would get weird if you had many accounts and scrolled to the end (see video)

### Notes
Still trying to fix the issue where `migratedOlympiaHardwareAccounts` is not being received.

## How to test
A:
- Import Olympia accounts through the QR process
- When done, press the _Go to account list_ button
-> This should take you back to the home screen

B:
- Have lots of accounts, 10-20
- Scroll to the bottom of the account list in the home screen
-> The scroll view should bounce off the end, and it should not glitch

## Video
**B: Scrolling glitch:**
Before:

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/09ab0d92-552e-487a-bc4c-c55fcb9a498b

After:

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/660894da-0b7d-4425-a15e-8b28dbe18218

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works


[ABW-2231]: https://radixdlt.atlassian.net/browse/ABW-2231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ