### PR TITLE
[ABW-2378] Set current gateway to mainnet after import

### DIFF
--- a/Sources/Clients/ProfileStore/ProfileStore.swift
+++ b/Sources/Clients/ProfileStore/ProfileStore.swift
@@ -245,6 +245,7 @@ extension ProfileStore {
 	// Changes the currently used ProfileSnapshot, usually to one from a backup or to one just created.
 	func changeProfileSnapshot(to profileSnapshot: ProfileSnapshot) async throws {
 		var profileSnapshot = profileSnapshot
+		profileSnapshot.changeCurrentToMainnetIfNeeded()
 		try await claimProfileSnapshot(&profileSnapshot)
 		updateHeader(&profileSnapshot)
 

--- a/Sources/Profile/AppPreferences/AppPreferences.swift
+++ b/Sources/Profile/AppPreferences/AppPreferences.swift
@@ -44,6 +44,12 @@ public struct AppPreferences:
 }
 
 extension AppPreferences {
+	public mutating func changeCurrentToMainnetIfNeeded() {
+		gateways.changeCurrentToMainnetIfNeeded()
+	}
+}
+
+extension AppPreferences {
 	public var customDumpMirror: Mirror {
 		.init(
 			self,

--- a/Sources/Profile/AppPreferences/Gateways/Gateways.swift
+++ b/Sources/Profile/AppPreferences/Gateways/Gateways.swift
@@ -69,6 +69,11 @@ extension Gateways {
 		current = newCurrent
 	}
 
+	public mutating func changeCurrentToMainnetIfNeeded() {
+		if current == .mainnet { return }
+		try? changeCurrent(to: .mainnet)
+	}
+
 	/// Adds `newOther` to `other` (if indeed new).
 	fileprivate mutating func add(_ newOther: Radix.Gateway) {
 		other.append(newOther)

--- a/Sources/Profile/Snapshot/ProfileSnapshot.swift
+++ b/Sources/Profile/Snapshot/ProfileSnapshot.swift
@@ -25,7 +25,7 @@ public struct ProfileSnapshot:
 
 	/// Settings for this profile in the app, contains default security configs
 	/// as well as display settings.
-	public let appPreferences: AppPreferences
+	public private(set) var appPreferences: AppPreferences
 
 	/// Effectivly **per network**: a list of accounts, personas and connected dApps.
 	public let networks: Profile.Networks
@@ -37,6 +37,12 @@ public struct ProfileSnapshot:
 		self.appPreferences = profile.appPreferences
 		self.networks = profile.networks
 		self.factorSources = profile.factorSources
+	}
+}
+
+extension ProfileSnapshot {
+	public mutating func changeCurrentToMainnetIfNeeded() {
+		appPreferences.changeCurrentToMainnetIfNeeded()
 	}
 }
 


### PR DESCRIPTION
Jira ticket: [ABW-2378](https://radixdlt.atlassian.net/browse/ABW-2378)

# Description
Change current network (gateway) to `.mainnet` after having finished importing a `Profile` (wallet backup data).

# Prevents

General soundness measure, safe to do since all Profiles should contain `.mainnet` accounts. 

# How to test
You can use [this Profile](https://drive.google.com/file/d/1-4cFc3xfZgu5hJ-Zshq3O90QFh5kh1bF/view?usp=drive_link) (requires RDX Works account)

Mnemonic is:
```
anger dizzy pond category scissors broccoli earth royal palace intact fox engage mix area engage right argue derive promote control hard order silver wait
```

[ABW-2378]: https://radixdlt.atlassian.net/browse/ABW-2378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ