### PR TITLE
Check non-zero total supply

### DIFF
--- a/Sources/Core/SharedModels/Assets/AccountPortfolio.swift
+++ b/Sources/Core/SharedModels/Assets/AccountPortfolio.swift
@@ -157,6 +157,10 @@ extension AccountPortfolio.PoolUnitResources {
 				loggerGlobal.error("Missing total supply for \(resource.resourceAddress.address)")
 				return "Missing Total supply - could not calculate redemption value" // FIXME: Strings
 			}
+			guard poolUnitTotalSupply > 0 else {
+				loggerGlobal.error("Zero total supply for \(resource.resourceAddress.address)")
+				return "Zero total supply - could not calculate redemption value" // FIXME: Strings
+			}
 			let redemptionValue = poolUnitResource.amount * (resource.amount / poolUnitTotalSupply)
 			let decimalPlaces = resource.resource.divisibility.map(UInt.init) ?? RETDecimal.maxDivisibility
 			let roundedRedemptionValue = redemptionValue.rounded(decimalPlaces: decimalPlaces)
@@ -193,7 +197,7 @@ extension AccountPortfolio.PoolUnitResources {
 		public let stakeClaimResource: AccountPortfolio.NonFungibleResource?
 
 		public var xrdRedemptionValue: RETDecimal? {
-			guard let stakeUnitResource, let totalSupply = stakeUnitResource.resource.totalSupply else {
+			guard let stakeUnitResource, let totalSupply = stakeUnitResource.resource.totalSupply, totalSupply > .zero else {
 				return nil
 			}
 			return validator.xrdVaultBalance * (stakeUnitResource.amount / totalSupply)

--- a/Sources/Features/AssetsFeature/Components/FungibleAssetList/Components/Details/FungibleTokenDetails+View.swift
+++ b/Sources/Features/AssetsFeature/Components/FungibleAssetList/Components/Details/FungibleTokenDetails+View.swift
@@ -12,7 +12,7 @@ extension FungibleTokenDetails.State {
 				isXRD: isXRD,
 				validatorAddress: nil,
 				resourceName: nil,
-				currentSupply: resource.totalSupply?.formatted(), // FIXME: Check which format
+				currentSupply: resource.totalSupply?.formatted() ?? L10n.AssetDetails.supplyUnkown,
 				behaviors: resource.behaviors,
 				tags: isXRD ? resource.tags + [.officialRadix] : resource.tags
 			)


### PR DESCRIPTION
## Description
This could potentially fix the crashes reported on [here](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1695983208070469)

What this PR does is simply to not calculate the redeemable amount for pool units if the total supply is 0, thus avoiding a potential division-by-zero crash.