### PR TITLE
[ABW-2395, ABW-2397] Use keyboard without decimal separator for tip percentage

### DIFF
--- a/Sources/Core/DesignSystem/Components/Hint.swift
+++ b/Sources/Core/DesignSystem/Components/Hint.swift
@@ -9,8 +9,9 @@ public struct Hint: View, Equatable {
 	}
 
 	let kind: Kind
-	let text: Text
-	public init(kind: Kind, text: Text) {
+	let text: Text?
+
+	private init(kind: Kind, text: Text?) {
 		self.kind = kind
 		self.text = text
 	}
@@ -31,15 +32,21 @@ public struct Hint: View, Equatable {
 		.init(kind: .error, text: Text(string))
 	}
 
+	public static func error() -> Self {
+		.init(kind: .error, text: nil)
+	}
+
 	public var body: some View {
-		Label {
-			text.lineSpacing(0).textStyle(.body2Regular)
-		} icon: {
-			if kind == .error {
-				Image(asset: AssetResource.error)
+		if let text {
+			Label {
+				text.lineSpacing(0).textStyle(.body2Regular)
+			} icon: {
+				if kind == .error {
+					Image(asset: AssetResource.error)
+				}
 			}
+			.foregroundColor(foregroundColor)
 		}
-		.foregroundColor(foregroundColor)
 	}
 
 	private var foregroundColor: Color {

--- a/Sources/Features/AssetsFeature/AssetsView+Reducer.swift
+++ b/Sources/Features/AssetsFeature/AssetsView+Reducer.swift
@@ -110,6 +110,8 @@ public struct AssetsView: Sendable, FeatureReducer {
 					guard !Task.isCancelled else { return }
 					await send(.internal(.updatePortfolio(portfolio.nonEmptyVaults)))
 				}
+			} catch: { error, _ in
+				loggerGlobal.error("AssetsView portfolioForAccount failed: \(error)")
 			}
 		case let .didSelectList(kind):
 			state.activeAssetKind = kind
@@ -117,6 +119,8 @@ public struct AssetsView: Sendable, FeatureReducer {
 		case .pullToRefreshStarted:
 			return .run { [address = state.account.address] _ in
 				_ = try await accountPortfoliosClient.fetchAccountPortfolio(address, true)
+			} catch: { error, _ in
+				loggerGlobal.error("AssetsView fetch failed: \(error)")
 			}
 		case let .chooseButtonTapped(items):
 			return .send(.delegate(.handleSelectedAssets(items)))

--- a/Sources/Features/CreateAccount/Children/NameAccount/NameAccount+View.swift
+++ b/Sources/Features/CreateAccount/Children/NameAccount/NameAccount+View.swift
@@ -28,10 +28,11 @@ extension NameAccount {
 			self.useLedgerAsFactorSource = state.useLedgerAsFactorSource
 			self.entityName = state.inputtedName
 			if let sanitizedName = state.sanitizedName {
-				self.sanitizedNameRequirement = .init(sanitizedName: sanitizedName)
 				if sanitizedName.count > Profile.Network.Account.nameMaxLength {
+					self.sanitizedNameRequirement = nil
 					self.hint = .error("Account label too long") // FIXME: Strings (duplicate)
 				} else {
+					self.sanitizedNameRequirement = .init(sanitizedName: sanitizedName)
 					self.hint = nil
 				}
 			} else {

--- a/Sources/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization+View.swift
+++ b/Sources/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization+View.swift
@@ -69,7 +69,7 @@ extension AdvancedFeesCustomization {
 						)
 						.padding(.bottom, .medium1)
 					}
-					.keyboardType(.decimalPad)
+					.keyboardType(.numberPad)
 					.multilineTextAlignment(.trailing)
 					.padding(.horizontal, .medium1)
 

--- a/Sources/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization+View.swift
+++ b/Sources/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization+View.swift
@@ -6,9 +6,21 @@ extension AdvancedFeesCustomization.State {
 		.init(
 			feesViewState: .init(feeViewStates: fees.viewStates, totalFee: fees.total, isAdvancedMode: true),
 			paddingAmount: paddingAmount,
+			paddingAmountHint: paddingAmountHint,
 			tipPercentage: tipPercentage,
+			tipPercentageHint: tipPercentageHint,
 			focusField: focusField
 		)
+	}
+
+	private var paddingAmountHint: Hint? {
+		guard parsedPaddingFee == nil else { return nil }
+		return .error()
+	}
+
+	private var tipPercentageHint: Hint? {
+		guard parsedTipPercentage == nil else { return nil }
+		return .error()
 	}
 }
 
@@ -17,7 +29,9 @@ extension AdvancedFeesCustomization {
 		let feesViewState: FeesView.ViewState
 
 		let paddingAmount: String
+		let paddingAmountHint: Hint?
 		let tipPercentage: String
+		let tipPercentageHint: Hint?
 		let focusField: State.FocusField?
 	}
 
@@ -39,6 +53,7 @@ extension AdvancedFeesCustomization {
 								get: \.paddingAmount,
 								send: ViewAction.paddingAmountChanged
 							),
+							hint: viewStore.paddingAmountHint,
 							focus: .on(
 								.padding,
 								binding: viewStore.binding(
@@ -48,6 +63,7 @@ extension AdvancedFeesCustomization {
 								to: $focusField
 							)
 						)
+						.keyboardType(.decimalPad)
 						.padding(.vertical, .medium1)
 
 						AppTextField(
@@ -58,6 +74,7 @@ extension AdvancedFeesCustomization {
 								get: \.tipPercentage,
 								send: ViewAction.tipPercentageChanged
 							),
+							hint: viewStore.tipPercentageHint,
 							focus: .on(
 								.tipPercentage,
 								binding: viewStore.binding(
@@ -67,9 +84,9 @@ extension AdvancedFeesCustomization {
 								to: $focusField
 							)
 						)
+						.keyboardType(.numberPad)
 						.padding(.bottom, .medium1)
 					}
-					.keyboardType(.numberPad)
 					.multilineTextAlignment(.trailing)
 					.padding(.horizontal, .medium1)
 

--- a/Sources/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization.swift
+++ b/Sources/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization.swift
@@ -11,12 +11,12 @@ public struct AdvancedFeesCustomization: FeatureReducer {
 			case tipPercentage
 		}
 
-		var fees: TransactionFee.AdvancedFeeCustomization
+		public var fees: TransactionFee.AdvancedFeeCustomization
 
-		var paddingAmount: String
-		var tipPercentage: String
+		public var paddingAmount: String
+		public var tipPercentage: String
 
-		var focusField: FocusField?
+		public var focusField: FocusField?
 
 		init(
 			fees: TransactionFee.AdvancedFeeCustomization
@@ -41,11 +41,11 @@ public struct AdvancedFeesCustomization: FeatureReducer {
 		switch viewAction {
 		case let .paddingAmountChanged(amount):
 			state.paddingAmount = amount
-			state.fees.updatePaddingFee(value: amount)
+			state.fees.paddingFee = state.parsedPaddingFee ?? .zero
 			return .send(.delegate(.updated(state.fees)))
 		case let .tipPercentageChanged(percentage):
 			state.tipPercentage = percentage
-			state.fees.updateTipPercentage(value: percentage)
+			state.fees.tipPercentage = state.parsedTipPercentage ?? .zero
 			return .send(.delegate(.updated(state.fees)))
 		case let .focusChanged(field):
 			state.focusField = field
@@ -54,20 +54,12 @@ public struct AdvancedFeesCustomization: FeatureReducer {
 	}
 }
 
-extension TransactionFee.AdvancedFeeCustomization {
-	mutating func updatePaddingFee(value: String) {
-		if value.isEmpty {
-			paddingFee = .zero
-		} else if let amount = try? RETDecimal(value: value) {
-			paddingFee = amount
-		}
+extension AdvancedFeesCustomization.State {
+	var parsedPaddingFee: RETDecimal? {
+		paddingAmount.isEmpty ? .zero : try? RETDecimal(value: paddingAmount)
 	}
 
-	mutating func updateTipPercentage(value: String) {
-		if value.isEmpty {
-			tipPercentage = .zero
-		} else if let amount = UInt16(value) {
-			tipPercentage = amount
-		}
+	var parsedTipPercentage: UInt16? {
+		tipPercentage.isEmpty ? .zero : UInt16(tipPercentage)
 	}
 }

--- a/Sources/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization.swift
+++ b/Sources/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization.swift
@@ -56,7 +56,7 @@ public struct AdvancedFeesCustomization: FeatureReducer {
 
 extension AdvancedFeesCustomization.State {
 	var parsedPaddingFee: RETDecimal? {
-		paddingAmount.isEmpty ? .zero : try? RETDecimal(value: paddingAmount)
+		paddingAmount.isEmpty ? .zero : try? RETDecimal(formattedString: paddingAmount)
 	}
 
 	var parsedTipPercentage: UInt16? {


### PR DESCRIPTION
Jira ticket: [ABW-2395](https://radixdlt.atlassian.net/browse/ABW-2395), [ABW-2397](https://radixdlt.atlassian.net/browse/ABW-2397)

## Description
The ABW-2397 ticket actually describes the expected behaviour, the tip percentage is an integer so the decimals will be ignored. This PR:
- removes the decimal separator from the keyboard for tip percentage
- validates padding fee and tip percentage entry and turns the textfield border red when invalid
- BUGFIX: accepts localised decimal separator for padding
- BUGFIX: now actually disables the Create account button when the name is too long

## How to test
- Initiate a transaction
- Go to Customize [fees]
- Tap View Advanced Mode
- Make the padding fee or percentage fee fields empty
-> The text field should look normal but the value should be interpreted as 0
- Enter an invalid value for padding fee (multiple decimal separators for example) or tip percentage (something above 65535)
-> The respective textfield should receive a red border and the value should be interpreted as 0

## Screenshot
![image](https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/824a00f5-532e-4b2b-aa7e-6820246473e8)

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/14886125-1993-4d0f-bac8-fe6af389a174

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2395]: https://radixdlt.atlassian.net/browse/ABW-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-2397]: https://radixdlt.atlassian.net/browse/ABW-2397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ