### PR TITLE
[ABW-1219] Fix AssetsView crash and filter Liquid Stake Units

### DIFF
--- a/Sources/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
+++ b/Sources/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
@@ -469,7 +469,7 @@ extension AccountPortfoliosClient {
 			}()
 
 			// Extract the stake claim NFT, which might exist or not
-			let stakeClaimNft: AccountPortfolio.NonFungibleResource? = try await { () -> AccountPortfolio.NonFungibleResource? in
+			let stakeClaimNFT: AccountPortfolio.NonFungibleResource? = try await { () -> AccountPortfolio.NonFungibleResource? in
 				let stakeClaimNFTCandidate = stakeClaimNFTCandidates.first {
 					$0.explicitMetadata?.validator?.address == item.address
 				}
@@ -490,12 +490,13 @@ extension AccountPortfoliosClient {
 
 			}()
 
-			// Either stakeUnit is present or stakeClaimNft
-			if stakeUnitFungibleResource != nil || stakeClaimNft != nil {
-				return .init(validator: validator, stakeUnitResource: stakeUnitFungibleResource, stakeClaimResource: stakeClaimNft)
-			}
+			let hasNonZeroStakeUnitAmount = stakeUnitFungibleResource?.amount.isZero() == false
+			let hasNonZeroStakeClaim = stakeClaimNFT?.tokens.contains { $0.stakeClaimAmount?.isZero() == false } == true
 
-			return nil
+			// Either stakeUnit is present and non-empty or there is a stakeClaimNFT with a non-zero claim
+			guard hasNonZeroStakeUnitAmount || hasNonZeroStakeClaim else { return nil }
+
+			return .init(validator: validator, stakeUnitResource: stakeUnitFungibleResource, stakeClaimResource: stakeClaimNFT)
 		}
 
 		let poolUnits = try await stakeAndPoolUnitDetails.items.asyncCompactMap { item -> AccountPortfolio.PoolUnitResources.PoolUnit? in

--- a/Sources/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
+++ b/Sources/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
@@ -396,7 +396,9 @@ extension AccountPortfoliosClient {
 			+ stakeClaimNFTCandidates.compactMap(\.explicitMetadata?.validator?.address)
 			+ poolUnitCandidates.compactMap(\.explicitMetadata?.pool?.address)
 
-		guard !stakeAndPoolAddresses.isEmpty else {
+		let uniqueStakeAndPoolAddresses = Array(stakeAndPoolAddresses.uniqued())
+
+		guard !uniqueStakeAndPoolAddresses.isEmpty else {
 			return .init(radixNetworkStakes: [], poolUnits: [])
 		}
 
@@ -407,7 +409,7 @@ extension AccountPortfoliosClient {
 		let xrdAddress = knownAddresses(networkId: networkId.rawValue).resourceAddresses.xrd.addressString()
 
 		let stakeAndPoolUnitDetails = try await gatewayAPIClient.fetchResourceDetails(
-			stakeAndPoolAddresses,
+			uniqueStakeAndPoolAddresses,
 			explicitMetadata: .poolUnitMetadataKeys,
 			ledgerState: ledgerState
 		)

--- a/Sources/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake+View.swift
+++ b/Sources/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake+View.swift
@@ -159,11 +159,12 @@ extension LSUStake.State {
 			id: stake.validator.address,
 			validatorNameViewState: .init(with: stake.validator),
 			liquidStakeUnit: stake.xrdRedemptionValue
-				.map {
-					.init(
+				.flatMap { amount in
+					guard !amount.isZero() else { return nil }
+					return .init(
 						thumbnail: .xrd,
 						symbol: Constants.xrdTokenName,
-						tokenAmount: $0.formatted(),
+						tokenAmount: amount.formatted(),
 						isSelected: isStakeSelected
 					)
 				},
@@ -172,12 +173,13 @@ extension LSUStake.State {
 					.map { claimNFT in
 						.init(
 							uncheckedUniqueElements: claimNFT.tokens
-								.map { token in
-									LSUStake.ViewState.StakeClaimNFTViewState(
+								.compactMap { token in
+									guard let stakeClaimAmount = token.stakeClaimAmount, !stakeClaimAmount.isZero() else { return nil }
+									return LSUStake.ViewState.StakeClaimNFTViewState(
 										id: token.id,
 										thumbnail: .xrd,
 										status: token.canBeClaimed ? .readyToClaim : .unstaking,
-										tokenAmount: (token.stakeClaimAmount ?? 0).formatted(),
+										tokenAmount: stakeClaimAmount.formatted(),
 										isSelected: self.selectedStakeClaimAssets?.contains(token.id)
 									)
 								}


### PR DESCRIPTION
Jira ticket: [ABW-1219](https://radixdlt.atlassian.net/browse/ABW-1219)

## Description

- Hides the Liquid Stake Unit when the amount is 0
- Hides a stake claim NFT token if it has a stakeClaimAmount that is 0 or nil
- Hides the entire stake entry if it doesn't have anything left visible
- Fixes [the crash](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1695983208070469) experienced by several users with LSUs.

## Screenshot
Before:
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/f387add8-1b16-4dfc-9853-3a1e91e602a7">

After:
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/d1c7a181-8164-4206-9432-c14ba65d2389">

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-1219]: https://radixdlt.atlassian.net/browse/ABW-1219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ