### PR TITLE
[ABW-2158, ABW-2417] Add Missing Behaviors

### DIFF
--- a/Sources/Clients/GatewayAPI/GatewayAPIClient+Extension.swift
+++ b/Sources/Clients/GatewayAPI/GatewayAPIClient+Extension.swift
@@ -273,6 +273,7 @@ extension GatewayAPI.ComponentEntityRoleAssignments {
 		addBehavior(for: .recaller, ifSomeone: .removableByThirdParty, ifAnyone: .removableByAnyone)
 		addBehavior(for: .freezer, ifSomeone: .freezableByThirdParty, ifAnyone: .freezableByAnyone)
 		addBehavior(for: .nonFungibleDataUpdater, ifSomeone: .nftDataChangeable, ifAnyone: .nftDataChangeableByAnyone)
+		addBehavior(for: .metadataSetter, ifSomeone: .informationChangeable, ifAnyone: .informationChangeableByAnyone)
 
 		// If there are no special behaviors, that means it's a "simple asset"
 		if result.isEmpty {

--- a/Sources/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Interface.swift
+++ b/Sources/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Interface.swift
@@ -182,6 +182,8 @@ extension GatewayAPI.RoleKey {
 		case recaller
 		case freezer
 		case nonFungibleDataUpdater = "non_fungible_data_updater"
+		case metadataLocker = "metadata_locker"
+		case metadataSetter = "metadata_setter"
 
 		case minterUpdater = "minter_updater"
 		case burnerUpdater = "burner_updater"
@@ -190,6 +192,8 @@ extension GatewayAPI.RoleKey {
 		case recallerUpdater = "recaller_updater"
 		case freezerUpdater = "freezer_updater"
 		case nonFungibleDataUpdaterUpdater = "non_fungible_data_updater_updater"
+		case metadataLockerUpdater = "metadata_locker_updater"
+		case metadataSetterUpdater = "metadata_setter_updater"
 	}
 }
 

--- a/Sources/Core/SharedModels/Assets/AssetBehavior.swift
+++ b/Sources/Core/SharedModels/Assets/AssetBehavior.swift
@@ -25,7 +25,6 @@ public enum AssetBehavior: Sendable, Hashable, Codable, Comparable {
 	case nftDataChangeable
 	case nftDataChangeableByAnyone
 
-	// FIXME: Are these not used?
 	case informationChangeable
 	case informationChangeableByAnyone
 }

--- a/Sources/Features/AssetsFeature/Components/HelperViews/AssetBehaviorsView.swift
+++ b/Sources/Features/AssetsFeature/Components/HelperViews/AssetBehaviorsView.swift
@@ -81,7 +81,6 @@ extension AssetBehavior {
 			return L10n.AccountSettings.Behaviors.nftDataChangeable
 		case .nftDataChangeableByAnyone:
 			return L10n.AccountSettings.Behaviors.nftDataChangeableByAnyone
-
 		case .informationChangeable:
 			return L10n.AccountSettings.Behaviors.informationChangeable
 		case .informationChangeableByAnyone:
@@ -107,7 +106,6 @@ extension AssetBehavior {
 		case .freezableByAnyone: return AssetResource.removableByAnyone // FIXME: icons
 		case .nftDataChangeable: return AssetResource.nftDataChangeable
 		case .nftDataChangeableByAnyone: return AssetResource.nftDataChangeableByAnyone
-
 		case .informationChangeable: return AssetResource.informationChangeable
 		case .informationChangeableByAnyone: return AssetResource.informationChangeableByAnyone
 		}

--- a/Sources/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake.swift
+++ b/Sources/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake.swift
@@ -56,10 +56,7 @@ public struct LSUStake: FeatureReducer {
 			)
 	}
 
-	public func reduce(
-		into state: inout State,
-		viewAction: ViewAction
-	) -> Effect<Action> {
+	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
 		case .didTap:
 			if state.isStakeSelected != nil {
@@ -87,7 +84,7 @@ public struct LSUStake: FeatureReducer {
 				return .none
 			}
 		case let .didTapStakeClaimNFT(withID: id):
-			if state.isStakeSelected != nil {
+			if state.selectedStakeClaimAssets != nil {
 				state.selectedStakeClaimAssets?.toggle(id)
 			}
 

--- a/Sources/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Models.swift
+++ b/Sources/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Models.swift
@@ -41,7 +41,7 @@ extension CreateAccountConfig {
 		case let .firstAccountOnNewNetwork(specificNetworkID):
 			self.init(
 				isFirstAccount: true,
-				canBeDismissed: false,
+				canBeDismissed: true,
 				navigationButtonCTA: .goBackToGateways,
 				specificNetworkID: specificNetworkID
 			)


### PR DESCRIPTION
Jira tickets: [ABW-2158](https://radixdlt.atlassian.net/browse/ABW-2158), [ABW-2417](https://radixdlt.atlassian.net/browse/ABW-2417)

## Description
- ABW-2417: In certain specific cases, it was not possible to select for transfer Stake Claim NFTs
- ABW-2158: The _Information can be changed_ behavior has now been added
- We now show the navbar when Naming an account after GW change

## Screenshot
![Simulator Screenshot - iPhone 14 Pro - 2023-10-05 at 00 24 26](https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/46ffadc8-013b-4ebd-828f-26a87439d55c)

Name account view, before this fix - it lacks navigation bar:
![image](https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/d1176dc8-02cf-43cb-983a-55660020c034)

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2158]: https://radixdlt.atlassian.net/browse/ABW-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-2417]: https://radixdlt.atlassian.net/browse/ABW-2417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ