### PR TITLE
[ABW-2410] Fix bug where app was in invalid state - discrepancy between Profile.header.lastUsedOnDevice.id and deviceID saved in keychain

### DIFF
--- a/Sources/Clients/ProfileStore/ProfileStore.swift
+++ b/Sources/Clients/ProfileStore/ProfileStore.swift
@@ -347,7 +347,7 @@ extension ProfileStore {
 					loggerGlobal.error("Failed to rectify deviceID discrepancy for users, error: \(error) (mismatch)")
 				}
 			} else {
-				loggerGlobal.debug("Verified that device owns profile snapshot ✅")
+				loggerGlobal.trace("Verified that device owns profile snapshot ✅")
 			}
 		} else {
 			loggerGlobal.notice("Found no DeviceIdentifier in keychain rectifiying by saving the one found in profile header: \(lastUsedOnDevice.id) into keychain.")

--- a/Sources/Clients/ProfileStore/ProfileStore.swift
+++ b/Sources/Clients/ProfileStore/ProfileStore.swift
@@ -340,6 +340,7 @@ extension ProfileStore {
 
 		if let deviceID = try? await secureStorageClient.loadDeviceIdentifier() {
 			if lastUsedOnDevice.id != deviceID {
+				loggerGlobal.notice("DeviceIdentifier discrepancy, in profile header \(lastUsedOnDevice.id) != \(deviceID) (loaded from keychain) => rectifiying by saving the one found in profile header into keychain.")
 				do {
 					try await secureStorageClient.saveDeviceIdentifier(lastUsedOnDevice.id)
 				} catch {
@@ -347,6 +348,7 @@ extension ProfileStore {
 				}
 			}
 		} else {
+			loggerGlobal.notice("Found no DeviceIdentifier in keychain rectifiying by saving the one found in profile header: \(lastUsedOnDevice.id) into keychain.")
 			do {
 				try await secureStorageClient.saveDeviceIdentifier(lastUsedOnDevice.id)
 			} catch {

--- a/Sources/Clients/ProfileStore/ProfileStore.swift
+++ b/Sources/Clients/ProfileStore/ProfileStore.swift
@@ -263,7 +263,7 @@ extension ProfileStore {
 	func claimProfileSnapshot(_ snapshot: inout ProfileSnapshot) async throws {
 		snapshot.header.lastUsedOnDevice = try await Self.createDeviceInfo()
 		do {
-			try await secureStorageClient.saveDeviceIdentifier(snapshot.header.lastUsedOnDevice.id)
+			try await secureStorageClient.saveDeviceIdentifierIfNeeded(snapshot.header.lastUsedOnDevice.id)
 		} catch {
 			loggerGlobal.critical("Failed to save newly generated device identifier, error: \(error)")
 		}

--- a/Sources/Clients/ProfileStore/ProfileStore.swift
+++ b/Sources/Clients/ProfileStore/ProfileStore.swift
@@ -509,7 +509,6 @@ extension ProfileStore {
 	private static func newEphemeralProfile() async -> Profile {
 		@Dependency(\.mnemonicClient) var mnemonicClient
 		@Dependency(\.secureStorageClient) var secureStorageClient
-		@Dependency(\.uuid) var uuid
 
 		do {
 			let name: String
@@ -542,6 +541,7 @@ extension ProfileStore {
 			))
 
 			@Dependency(\.date) var dateGenerator
+			@Dependency(\.uuid) var uuid
 
 			let deviceInfo = try await createDeviceInfo()
 

--- a/Sources/Clients/ProfileStore/ProfileStore.swift
+++ b/Sources/Clients/ProfileStore/ProfileStore.swift
@@ -346,6 +346,8 @@ extension ProfileStore {
 				} catch {
 					loggerGlobal.error("Failed to rectify deviceID discrepancy for users, error: \(error) (mismatch)")
 				}
+			} else {
+				loggerGlobal.debug("Verified that device owns profile snapshot ✅")
 			}
 		} else {
 			loggerGlobal.notice("Found no DeviceIdentifier in keychain rectifiying by saving the one found in profile header: \(lastUsedOnDevice.id) into keychain.")

--- a/Sources/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
+++ b/Sources/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
@@ -78,6 +78,18 @@ extension SecureStorageClient {
 	}
 }
 
+extension SecureStorageClient {
+	public func saveDeviceIdentifierIfNeeded(_ deviceID: UUID) async throws {
+		if let existing = try? await loadDeviceIdentifier() {
+			if existing != deviceID {
+				try await saveDeviceIdentifier(deviceID)
+			}
+		} else {
+			try await saveDeviceIdentifier(deviceID)
+		}
+	}
+}
+
 // MARK: - CloudProfileSyncActivation
 public enum CloudProfileSyncActivation: Sendable, Hashable {
 	/// iCloud sync was enabled, user request to disable it.

--- a/Sources/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
+++ b/Sources/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
@@ -19,6 +19,7 @@ public struct SecureStorageClient: Sendable {
 	public var deleteProfileHeaderList: DeleteProfileHeaderList
 
 	public var loadDeviceIdentifier: LoadDeviceIdentifier
+	public var saveDeviceIdentifier: SaveDeviceIdentifier
 }
 
 extension SecureStorageClient {
@@ -36,7 +37,8 @@ extension SecureStorageClient {
 	public typealias SaveProfileHeaderList = @Sendable (ProfileSnapshot.HeaderList) async throws -> Void
 	public typealias DeleteProfileHeaderList = @Sendable () async throws -> Void
 
-	public typealias LoadDeviceIdentifier = @Sendable () async throws -> UUID
+	public typealias LoadDeviceIdentifier = @Sendable () async throws -> UUID?
+	public typealias SaveDeviceIdentifier = @Sendable (UUID) async throws -> Void
 
 	public enum LoadMnemonicPurpose: Sendable, Hashable, CustomStringConvertible {
 		case signTransaction

--- a/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -156,7 +156,7 @@ extension SecureStorageClient: DependencyKey {
 				KeychainClient.SetItemWithoutAuthRequest(
 					data: data,
 					key: deviceIdentifierKey,
-					iCloudSyncEnabled: false, // Never, ever synced.
+					iCloudSyncEnabled: false, // Never ever synced, since related to this device only..
 					accessibility: .whenUnlocked,
 					label: "Radix Wallet device identifier",
 					comment: "The unique identifier of this device"

--- a/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -143,7 +143,7 @@ extension SecureStorageClient: DependencyKey {
 				}
 
 			if let loaded {
-				loggerGlobal.debug("Loaded deviceIdentifier: \(loaded)")
+				loggerGlobal.trace("Loaded deviceIdentifier: \(loaded)")
 			} else {
 				loggerGlobal.warning("No deviceIdentifier loaded, was nil.")
 			}

--- a/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -143,7 +143,7 @@ extension SecureStorageClient: DependencyKey {
 				}
 
 			if let loaded {
-				loggerGlobal.info("Loaded deviceIdentifier: \(loaded)")
+				loggerGlobal.debug("Loaded deviceIdentifier: \(loaded)")
 			} else {
 				loggerGlobal.warning("No deviceIdentifier loaded, was nil.")
 			}
@@ -162,7 +162,7 @@ extension SecureStorageClient: DependencyKey {
 					comment: "The unique identifier of this device"
 				)
 			)
-			loggerGlobal.info("Saved deviceIdentifier: \(deviceIdentifier)")
+			loggerGlobal.notice("Saved deviceIdentifier: \(deviceIdentifier)")
 		}
 
 		return Self(

--- a/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/Sources/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -136,11 +136,18 @@ extension SecureStorageClient: DependencyKey {
 		}
 
 		@Sendable func loadDeviceIdentifier() async throws -> UUID? {
-			try await keychainClient
+			let loaded = try await keychainClient
 				.getDataWithoutAuthForKey(deviceIdentifierKey)
 				.map {
 					try jsonDecoder().decode(UUID.self, from: $0)
 				}
+
+			if let loaded {
+				loggerGlobal.info("Loaded deviceIdentifier: \(loaded)")
+			} else {
+				loggerGlobal.warning("No deviceIdentifier loaded, was nil.")
+			}
+			return loaded
 		}
 
 		@Sendable func saveDeviceIdentifier(_ deviceIdentifier: UUID) async throws {
@@ -155,6 +162,7 @@ extension SecureStorageClient: DependencyKey {
 					comment: "The unique identifier of this device"
 				)
 			)
+			loggerGlobal.info("Saved deviceIdentifier: \(deviceIdentifier)")
 		}
 
 		return Self(

--- a/Sources/Clients/SecureStorageClient/SecureStorageClient+Test.swift
+++ b/Sources/Clients/SecureStorageClient/SecureStorageClient+Test.swift
@@ -20,7 +20,8 @@ extension SecureStorageClient: TestDependencyKey {
 		loadProfileHeaderList: { nil },
 		saveProfileHeaderList: { _ in },
 		deleteProfileHeaderList: {},
-		loadDeviceIdentifier: { .init() }
+		loadDeviceIdentifier: { .init() },
+		saveDeviceIdentifier: { _ },
 	)
 
 	public static let previewValue: Self = .noop
@@ -36,6 +37,7 @@ extension SecureStorageClient: TestDependencyKey {
 		loadProfileHeaderList: unimplemented("\(Self.self).loadProfileHeaderList"),
 		saveProfileHeaderList: unimplemented("\(Self.self).saveProfileHeaderList"),
 		deleteProfileHeaderList: unimplemented("\(Self.self).deleteProfileHeaderList"),
-		loadDeviceIdentifier: unimplemented("\(Self.self).loadDeviceIdentifier")
+		loadDeviceIdentifier: unimplemented("\(Self.self).loadDeviceIdentifier"),
+		saveDeviceIdentifier: unimplemented("\(Self.self).saveDeviceIdentifier")
 	)
 }

--- a/Sources/Clients/SecureStorageClient/SecureStorageClient+Test.swift
+++ b/Sources/Clients/SecureStorageClient/SecureStorageClient+Test.swift
@@ -21,7 +21,7 @@ extension SecureStorageClient: TestDependencyKey {
 		saveProfileHeaderList: { _ in },
 		deleteProfileHeaderList: {},
 		loadDeviceIdentifier: { .init() },
-		saveDeviceIdentifier: { _ },
+		saveDeviceIdentifier: { _ in }
 	)
 
 	public static let previewValue: Self = .noop

--- a/Sources/Features/AppFeature/App+Reducer.swift
+++ b/Sources/Features/AppFeature/App+Reducer.swift
@@ -23,7 +23,8 @@ public struct App: Sendable, FeatureReducer {
 			root: Root = .splash(.init())
 		) {
 			self.root = root
-			loggerGlobal.info("App started")
+			let retBuildInfo = buildInformation()
+			loggerGlobal.info("App started - engineToolkit commit hash: \(retBuildInfo.version)")
 		}
 	}
 
@@ -91,8 +92,6 @@ public struct App: Sendable, FeatureReducer {
 	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
 		case .task:
-			let retBuildInfo = buildInformation()
-			loggerGlobal.info("EngineToolkit commit hash: \(retBuildInfo.version)")
 			return .run { send in
 				for try await error in errorQueue.errors() {
 					guard !Task.isCancelled else { return }


### PR DESCRIPTION
[Jira Ticket - ABW-2410](https://radixdlt.atlassian.net/browse/ABW-2410)

# Description
This fixes a critical bug which me and Jacob have encountered in version 1.0.1 and which at least one community member encountered too.
![IMG_0532](https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/f2550638-6bd1-4012-9103-456c85f0243e)

# The Problem
The root cause is that ProfileStore's `managedAtomicLazyRef` ensures that only ever on Profile is used, HOWEVER, the deviceIdentifiers being saved into keychain could be out of sync, since each new ephemeral profile called `loadDeviceIdentifier` which generated and saved one if nil. If two different tasks called `loadDeviceIdentifier` simulatneously which is the case, then it might be so that the deviceIdentifier of Profile `Q` was saved in keychain as deviceIdentifier, but the Profile `P` was commited and used, where Q.header.lastUsedOnDevice.id != P.header.lastUsedOnDevice.id`, thus, a discrepancy and this bug happens.

## Assertion of root cause

If, on `main` you replace `secureStorage.loadIdentifier()` call in `ProfileStore` with `Self.loadIdentifier` which is this function here:

```swift
       static func loadDeviceIdentifier() async throws -> UUID {
           @Dependency(\.secureStorageClient) var secureStorageClient
           let t0 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t1 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t2 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t3 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t4 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t5 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t6 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t7 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t8 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t9 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t10 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t11 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t12 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t13 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t14 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           await Task.yield()
           let t15 = Task {
               try? await secureStorageClient.loadDeviceIdentifier()
           }
           let tasks = [t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15]
           var values = Set<UUID>()
           for task in tasks {
               guard let id = await task.value else {
                    continue
               }
               values.insert(id)
           }
           guard values.count == 1 else {
               fatalError("REPRODUCED BUG! MULTIPLE DIFFERENT DEVICE IDS: \(values)")
           }
           return values.first!
       }
```

You will see the issue, this crashes with fatal error:
```sh
ProfileStore/ProfileStore.swift:455: Fatal error: REPRODUCED BUG! MULTIPLE DIFFERENT DEVICE IDS: [ACAE7A30-FDB7-4B00-A36C-07E1C45E2703, BD51CB1E-B247-42ED-8DBA-F03550B54416, A9086310-A6EE-4C35-945F-0EA2227344AE, 483E80A6-D42A-4CFE-BB6D-ED6884A36C35, CF00A53A-A3E7-49C0-8198-589D3F2F72DC, 549EE4A0-909D-492A-8CB5-F3FD63827E2F, A893806C-9733-4B41-A523-A274E31D79F4, 496EC461-9426-451C-90E9-8AC2D7E48673, 14765105-499D-482E-8D79-A6D11CC00180, 71AD3BDB-1134-4A0B-ACAA-FEB837A779B0, 783950EB-223F-4686-BF38-D39F5EE9794D, 4F3A4A20-04E6-4C61-A9FB-3BB6F48E6977, 9E90AA06-7AFE-4329-BF34-5CE62095B406, E48C2100-C60C-480B-A78A-B391784908CA, 8E434020-73D2-47BC-AE73-F27FA3BFC237, A5ABF75D-C9E2-44A8-B1BA-F8D237BEE7F9]
```

# The Fix
This PR contains 3 fixes that:
1. prevents profile from being forgotten
2. rectifies the discrepancy, i.e. if `Q.header.lastUsedOnDevice.id != P.header.lastUsedOnDevice.id` then `P.header.lastUsedOnDevice.id` will now be saved into keychain as `deviceIdentifier`
3. No scary warning is shown to user

# Implications of fix (disabled a feature)
The implications of this fix is that the actual feature of displaying the warning "The wallet backup data is used on another device" is disabled. Instead user will 'auto-claim' the Profile on the last used device. **We should probably highlight to community that they ought to refrain from using the same wallet backup data (Profile) on two devices**. In a couple of months when we believe most users will have had the chance to upgrade to the next version (`1.0.4`) of the app, containing this fix, then we might reintroduce that feature, but in a safer form (not auto delete profile).

# Important Discovery
While working with this I noted that we accidentally removed `task` in App.View in https://github.com/radixdlt/babylon-wallet-ios/pull/801 meaning that [this code](https://github.com/radixdlt/babylon-wallet-ios/blob/main/Sources/Features/AppFeature/App%2BReducer.swift#L96-L108) never happens:

```swift
return .run { send in
	for try await error in errorQueue.errors() {
		guard !Task.isCancelled else { return }
		// Maybe instead we should listen here for the Profile.State change,
		// and when it switches to `.ephemeral` we navigate to onboarding.
		// For now, we react to the specific error, since the Profile.State is meant to be private.
		if error is Profile.ProfileIsUsedOnAnotherDeviceError {
			await send(.internal(.toOnboarding))
			// A slight delay to allow any modal that may be shown to be dismissed.
			try? await clock.sleep(for: .seconds(0.5))
		}
	}
}
```

**Which ironically is great! It prevents users who have NOT QUIT THE APP from hitting this bug.** However, if they quit the app, they might get this problem, since that `task` ensured we deleted the profile during the life cycle of the app, when users changes profile, but we "logged out" user if we this deviceIdentifier discrepancy was found [during app launch here](https://github.com/radixdlt/babylon-wallet-ios/blob/main/Sources/Features/AppFeature/App%2BReducer.swift#L164-L166).

# How to test
Well it is very hard to test the root cause... but you can manually test by changing the `profile.header.lastUsedOnDevice.id` to some other UUID string, e.g.:
`“E621E1F8-C36C-495A-93FC-0C247A3E6E5F”`
And you do this by opening Keychain on you mac and open `Radix Wallet Data` and show password and copy paste the Profile into a text editor, edit the `header.lastUsedOnDevice.id` and then paste it back into keychain and save. Restart Radix Wallet app...

 (you might need to change the header list - `Radix Wallet MetaData` - too? 🤔 maybe not needed if you are not testing restore flows...)
