### PR TITLE
[ABW-2271] Remove spurious portfolio reloading

### DIFF
--- a/Sources/Features/AccountListFeature/Components/Row/Row+Reducer.swift
+++ b/Sources/Features/AccountListFeature/Components/Row/Row+Reducer.swift
@@ -79,9 +79,10 @@ extension AccountList {
 		public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 			switch viewAction {
 			case .task:
-
 				let accountAddress = state.account.address
-				state.portfolio = .loading
+				if state.portfolio.wrappedValue == nil {
+					state.portfolio = .loading
+				}
 
 				checkIfCallActionIsNeeded(state: &state)
 

--- a/Sources/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
+++ b/Sources/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
@@ -259,6 +259,7 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 
 		case let .callDone(controlStateKeyPath, changeTo):
 			if controlStateKeyPath == \State.faucetButtonState {
+				// NB: This call to update might be superfluous, since after any transaction we fetch all accounts
 				return updateAccountPortfolio(state).concatenate(with: loadIsAllowedToUseFaucet(&state))
 			} else {
 				state[keyPath: controlStateKeyPath] = changeTo

--- a/Sources/Features/HomeFeature/Coordinator/Home.swift
+++ b/Sources/Features/HomeFeature/Coordinator/Home.swift
@@ -124,6 +124,10 @@ public struct Home: Sendable, FeatureReducer {
 	public func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
 		switch internalAction {
 		case let .accountsLoadedResult(.success(accounts)):
+			guard accounts.elements != state.accounts.elements else {
+				return .none
+			}
+
 			state.accountList = .init(accounts: accounts)
 			let accountAddresses = state.accounts.map(\.address)
 			return .run { _ in


### PR DESCRIPTION
## Description
The wallet reloads the account portfolios too often. This PR removes most of the unnecessary reloads, and even more cases where an already fetched portfolio is recreated without fetching.

### Notes
The next step is probably to move to an architecture where e.g. AccountPortfolioClient emits "events" like `portfolioChange(AccountAddress)` which we subscribe to, instead of a currentValueSubject of the portfolios. This will make it possible to distinguish between the first reading of an already fetched portfolio, and subsequent updates to the data. This is important because `.task` is called not just when a view is first created, but every time it comes back into view, causing us to set up subscriptions too often.

## How to test
Try everything related to portfolio reloading, making sure that views are automatically reloaded e.g. when
- Using the faucet
- Performing a transfer
- Accepting a remotely initiated transaction
- etc

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
