### PR TITLE
[ABW-2438] Parsing Decimals

### DIFF
--- a/Sources/EngineKit/RETDecimal+Extensions.swift
+++ b/Sources/EngineKit/RETDecimal+Extensions.swift
@@ -87,13 +87,18 @@ extension RETDecimal {
 // MARK: Truncation and rounding
 
 extension RETDecimal {
-	/// Truncates to `decimalPlaces` decimals
-	public func truncated(decimalPlaces: UInt) -> RETDecimal {
+	/// Rounds to `decimalPlaces` decimals, in the direction of 0
+	public func floor(decimalPlaces: UInt) -> RETDecimal {
 		try! round(decimalPlaces: Int32(decimalPlaces), roundingMode: .toZero)
 	}
 
+	/// Rounds to `decimalPlaces` decimals, in the direction away from zero
+	public func ceil(decimalPlaces: UInt) -> RETDecimal {
+		try! round(decimalPlaces: Int32(decimalPlaces), roundingMode: .awayFromZero)
+	}
+
 	/// Rounds to `decimalPlaces` decimals
-	public func rounded(decimalPlaces: UInt) -> RETDecimal {
+	public func rounded(decimalPlaces: UInt = 0) -> RETDecimal {
 		try! round(decimalPlaces: Int32(decimalPlaces), roundingMode: .toNearestMidpointAwayFromZero)
 	}
 }

--- a/Sources/EngineKit/RETDecimal+Extensions.swift
+++ b/Sources/EngineKit/RETDecimal+Extensions.swift
@@ -135,7 +135,8 @@ extension RETDecimal {
 		formattedString: String,
 		locale: Locale = .autoupdatingCurrent
 	) throws {
-		var string = formattedString
+		// Pad with a leading zero, to make numbers with leading decimal separator parsable
+		var string = "0" + formattedString
 		// If the locale recognizes a grouping separator, we strip that from the string
 		if let groupingSeparator = locale.groupingSeparator {
 			string.replace(groupingSeparator, with: "")

--- a/Sources/Features/TransactionReviewFeature/TransactionReviewGuarantees/MinimumPercentageStepper/MinimumPercentageStepper.swift
+++ b/Sources/Features/TransactionReviewFeature/TransactionReviewGuarantees/MinimumPercentageStepper/MinimumPercentageStepper.swift
@@ -13,7 +13,7 @@ public struct MinimumPercentageStepper: FeatureReducer {
 		var string: String
 
 		public init(value: RETDecimal) {
-			let clamped = value.rounded(decimalPlaces: 2).clamped
+			let clamped = value.clamped
 			self.value = clamped
 			self.string = clamped.formattedPlain()
 		}
@@ -34,13 +34,13 @@ public struct MinimumPercentageStepper: FeatureReducer {
 	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
 		case .increaseTapped:
-			let value = state.value.map { $0 + percentageDelta } ?? 100
+			let value = state.value.map { $0.floor(decimalPlaces: 0) + percentageDelta } ?? 100
 			let clamped = value.clamped
 			state.value = clamped
 			state.string = clamped.formattedPlain()
 
 		case .decreaseTapped:
-			let value = state.value.map { $0 - percentageDelta } ?? 0
+			let value = state.value.map { $0.ceil(decimalPlaces: 0) - percentageDelta } ?? 0
 			let clamped = value.clamped
 			state.value = clamped
 			state.string = clamped.formattedPlain()
@@ -59,7 +59,7 @@ public struct MinimumPercentageStepper: FeatureReducer {
 		return .send(.delegate(.valueChanged))
 	}
 
-	private let percentageDelta: RETDecimal = 0.1
+	private let percentageDelta: RETDecimal = 1
 }
 
 extension MinimumPercentageStepper.State {

--- a/Sources/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees.swift
+++ b/Sources/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees.swift
@@ -123,7 +123,8 @@ public struct TransactionReviewGuarantee: Sendable, FeatureReducer {
 			}
 
 			let newMinimumDecimal = value * 0.01
-			let newAmount = newMinimumDecimal * state.details.amount
+			let divisibility = state.resource.divisibility.map(UInt.init) ?? RETDecimal.maxDivisibility
+			let newAmount = (newMinimumDecimal * state.details.amount).rounded(decimalPlaces: divisibility)
 			state.guarantee.amount = newAmount
 
 			return .none

--- a/Tests/EngineKitTests/DecimalTests.swift
+++ b/Tests/EngineKitTests/DecimalTests.swift
@@ -265,6 +265,8 @@ final class DecimalTests: TestCase {
 		}
 		let spanish = Locale(identifier: "es")
 		let us = Locale(identifier: "en_US_POSIX")
+		try doTest(",005", locale: spanish, expected: .init(value: "0.005"))
+		try doTest(".005", locale: us, expected: .init(value: "0.005"))
 		try doTest("1,001", locale: spanish, expected: .init(value: "1.001"))
 		try doTest("1,001", locale: us, expected: .init(value: "1001"))
 		try doTest("1.001,45", locale: spanish, expected: .init(value: "1001.45"))

--- a/Tests/EngineKitTests/DecimalTests.swift
+++ b/Tests/EngineKitTests/DecimalTests.swift
@@ -213,7 +213,7 @@ final class DecimalTests: TestCase {
 		func doTest(_ decimalString: String, divisibility: UInt, expected expectedString: String, line: UInt = #line) throws {
 			let expected = try RETDecimal(value: expectedString)
 			let decimal = try RETDecimal(value: decimalString)
-			let actual = decimal.truncated(decimalPlaces: divisibility)
+			let actual = decimal.floor(decimalPlaces: divisibility)
 			XCTAssertEqual(actual, expected, line: line)
 		}
 


### PR DESCRIPTION
Jira ticket: [ABW-2438](https://radixdlt.atlassian.net/browse/ABW-2438)

## Description
- We want to accept numbers starting with a decimal separator (`.1`)
- For the guarantee, we want to save all the decimals the user enters
- Also, the guarantee stepper should work in 1% point increments
- When pressing plus/minus on a number with decimals, it will first go to the nearest higher/lower integer

Example for the last point:
If the number is `12.34` and you press +, the number will change to 13. If you press -, it would change to 12. 

## Video

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2438]: https://radixdlt.atlassian.net/browse/ABW-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ