### PR TITLE
ci: improve performance

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     name: "Test Flight Deploy"
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !(contains(github.event.head_commit.message, '[skip cd]') || contains(github.event.head_commit.message, '[cd skip]')) }}
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
 
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,6 @@ jobs:
 
     needs:
       - linting
-      - snyk_scan
-      - snyk_sbom
 
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
@@ -180,6 +178,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - test-and-build
+      - snyk_scan
+      - snyk_sbom
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,6 @@ jobs:
       contents: read
     name: "Snyk SBOM"
     runs-on: ubuntu-latest
-    needs:
-      - snyk_scan
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       - uses: actions/setup-node@v2
@@ -117,7 +115,6 @@ jobs:
 
     needs:
       - linting
-      - snyk_scan
 
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
 
     needs:
       - linting
+      - snyk_scan
+      - snyk_sbom
 
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
   linting:
     name: "Linting"
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
 
     steps:
       - uses: actions/checkout@v3.1.0
@@ -112,7 +112,7 @@ jobs:
       id-token: write
       contents: read
     name: "Test and build"
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     timeout-minutes: 70
 
     needs:


### PR DESCRIPTION
- use M1 macos runners
- don't wait for snyk jobs on build