### PR TITLE
[ABW-2456] Seed Phrase Warning When Importing Olympia Accounts

### DIFF
--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
@@ -219,6 +219,7 @@ extension SwiftUI.View {
 	func destination(store: StoreOf<ImportMnemonic>) -> some View {
 		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return offDeviceMnemonicInfoSheet(with: destinationStore)
+			.onContinueWarningAlert(with: destinationStore)
 			.markMnemonicAsBackedUpAlert(with: destinationStore)
 	}
 
@@ -228,6 +229,15 @@ extension SwiftUI.View {
 			store: destinationStore,
 			state: /ImportMnemonic.Destinations.State.markMnemonicAsBackedUp,
 			action: ImportMnemonic.Destinations.Action.markMnemonicAsBackedUp
+		)
+	}
+
+	@MainActor
+	fileprivate func onContinueWarningAlert(with destinationStore: PresentationStoreOf<ImportMnemonic.Destinations>) -> some SwiftUI.View {
+		alert(
+			store: destinationStore,
+			state: /ImportMnemonic.Destinations.State.onContinueWarning,
+			action: ImportMnemonic.Destinations.Action.onContinueWarning
 		)
 	}
 

--- a/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator+View.swift
+++ b/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator+View.swift
@@ -50,7 +50,11 @@ extension ImportOlympiaWalletCoordinator.Path {
 					CaseLet(
 						/State.importMnemonic,
 						action: Action.importMnemonic,
-						then: { ImportMnemonic.View(store: $0) }
+						then: { childStore in
+							NavigationView {
+								ImportMnemonic.View(store: childStore)
+							}
+						}
 					)
 				case .importOlympiaLedgerAccountsAndFactorSources:
 					CaseLet(

--- a/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator.swift
+++ b/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator.swift
@@ -360,6 +360,11 @@ public struct ImportOlympiaWalletCoordinator: Sendable, FeatureReducer {
 					subtitle: L10n.ImportOlympiaAccounts.VerifySeedPhrase.subtitle
 				),
 				warning: L10n.ImportOlympiaAccounts.VerifySeedPhrase.warning,
+				warningOnContinue: .init(
+					title: "Warning", // FIXME: Strings
+					text: "Do not throw away this seed phrase! You will still need it if you need to recover access to your Olympia accounts in the future.", // FIXME: Strings
+					button: "I understand" // FIXME: Strings
+				),
 				isWordCountFixed: true,
 				persistStrategy: nil,
 				wordCount: progress.previous.expectedMnemonicWordCount


### PR DESCRIPTION
Jira ticket: [ABW-2456](https://radixdlt.atlassian.net/browse/ABW-2456)

## Description
Show a warning after entering the seed phrase when importing Olympia accounts.

## How to test
- Import Olympia software accounts
- Enter seed phrase
-> Should show warning

- Try all other ways to see the seed phrase screen 
-> Should NOT show warning

## Screenshot
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/dc5ef620-2485-4434-a563-03092d86b98d">

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2456]: https://radixdlt.atlassian.net/browse/ABW-2456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ