### PR TITLE
Fastlane and README improvments

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,32 +1,15 @@
 # Setup development
 For getting started with development [read the setup development guide][devSetup].
 
-# Overview
-
-## Packages
-We use the super modular design that Point-Free uses in [Isowords][isowordsPackage] - with almost 100 different packages.
-
-## What do I import where?
-  
-We automatically link to all the below mentioned targets for each target type, i.e. no need to add `FeaturePrelude` as a dependency on a new target if you declare it using `feature(name:dependencies:tests:)`.
-
-- If you're working on a **Feature** `import FeaturePrelude` 
-- If you're working on a **Client**: `import ClientPrelude` 
-- If you're writing tests for:
-  - a **Client**: `import ClientTestingPrelude` 
-  - a **Feature**: `import FeatureTestingPrelude`
-  - **Core** or standalone module: `import TestingPrelude`
-
-## Preview Apps
-Thanks to TCA we can create Feature Previews, which are super small apps using a specific Feature's package as entry point, this is extremely useful, because suddenly we can start a small Preview App which takes us directly to Settings, or Directly directly to onboarding. See [Previews folder](/App/Previews) for our preview apps.
-
-
 # Architecture
 The Radix Wallet was originally developed under 2022/2023 using Xcode 13/14 using Swift 5.6, SwiftUI and [The Composable Architecture (TCA)][tca].
 
+## Mono-target
+We _used_ to  use SPM and have ~100 targets, but [after 15 months of pain with it we switched to mono target](https://github.com/radixdlt/babylon-wallet-ios/pull/842), and saw an immediate 2x speedup in build time.
+
 The Radix Wallet rests on several pillars:
-* [Profile](./Sources/Profile): In the Radix Wallet the `Profile` is referred to as "wallet backup data", contains the list of all Accounts, Personas, Authorized Dapps, linked browsers, app settings and more. Securely stored in Keychain and by default backed-up to users iCloud Keychain.  
-* [Radix Connect](./Sources/RadixConnect): Technology for safe, decentralized peer-to-peer communication between the [Radix Connector Extension][ce] and Radix Wallet, the underlying technology powering it is [WebRTC][webrtc]. 
+* [Profile](./RadixWallet/Profile): In the Radix Wallet the `Profile` is referred to as "wallet backup data", contains the list of all Accounts, Personas, Authorized Dapps, linked browsers, app settings and more. Securely stored in Keychain and by default backed-up to users iCloud Keychain.  
+* [Radix Connect](./RadixWallet/RadixConnect): Technology for safe, decentralized peer-to-peer communication between the [Radix Connector Extension][ce] and Radix Wallet, the underlying technology powering it is [WebRTC][webrtc]. 
 * [Swift Engine Toolkit][set]: Swift wrapper around the Rust library [Radix Engine Toolkit - RET][ret] used to compile transaction intents into SBOR that the wallet signs, analyze transaction manifests, calculate transaction hashes and much much more.  
 
 
@@ -39,8 +22,6 @@ Application version is specified in [Common.xcconfig](App/Config/Common.xcconfig
 
 [devSetup]: ./SETUP_DEV.md
 [tca]: https://github.com/pointfreeco/swift-composable-architecture
-[isowords]: https://github.com/pointfreeco/isowords
-[isowordsPackage]: https://github.com/pointfreeco/isowords/blob/main/Package.swift
 [ret]: https://github.com/radixdlt/radix-engine-toolkit
 [set]: https://github.com/radixdlt/swift-engine-toolkit
 [ce]: https://github.com/radixdlt/connector-extension

--- a/SETUP_DEV.md
+++ b/SETUP_DEV.md
@@ -12,7 +12,7 @@ Will will setup SwiftFormat to format code, rules are defined in `.swiftformat`.
 ## Open project
 
 ```sh
-open App/BabylonWallet.xcodeproj
+open RadixWallet.xcodeproj
 ```
 
 Select the `Radix Wallet Dev (iOS)` scheme and hit run (`⌘R`).
@@ -45,13 +45,13 @@ bundle install
 - Run the below command to bring the necessary certificates for development:
 
 ```sh
-bundle exec fastlane ios install_development_certificates
+bundle exec fastlane install_development_certificates
 ```
 
 - If your device is unregistered, register it with the below command, it will prompt you to enter the device name and device UDID.
 
 ```sh
-bundle exec fastlane ios register_new_iphone_device
+bundle exec fastlane register_new_device
 ```
 
 After the above setup, you are good to go with building and running the app on iPhone. 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,5 @@
 fastlane_require 'dotenv'
+default_platform(:ios)
 
 before_all do
     ensure_xcode_version
@@ -165,18 +166,16 @@ end
 
 private_lane :create_gh_release do |options|
     flavour = options.fetch(:flavour).delete_prefix('"').delete_suffix('"') # if accidentally included
-    
-    puts "👀 SharedValues::IPA_OUTPUT_PATH]: '#{lane_context[SharedValues::IPA_OUTPUT_PATH]}'\n"
 
     dsymPathUsed = locate_dsym()
 
     sh('git fetch --tags')
     most_recent_tags = sh("git tag | grep #{flavour} | sort -r | head -2").split("\n")
 
-    changelog = rev_changelog(flavour, most_recent_tags)
+    pr_log = rev_changelog(flavour, most_recent_tags)
     versions_string = dependencies_with_hyperlinks()
 
-    release_description = "**Dependencies**: \n" + versions_string + "\n\n**Changelog**: \n" + changelog
+    release_description = "**Changelog**:\nREPLACE_ME_SYNC_WITH_APP_CONNECT_AND_STAKE_HOLDERS" + "\n\n**Rull Requests**: \n" + pr_log + "\n\n**Dependencies**: \n" + versions_string
     last_tag = most_recent_tags[0]
 
     set_github_release(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -293,6 +293,7 @@ private_lane :code_signing do |options|
     sync_code_signing(
         type: type,
         force_for_new_devices: true,
+        additional_cert_types: "mac_installer_distribution", # allows Catalyst, run destination "My Mac (Designed for iPhone)"
         readonly: readonly,
         app_identifier: read_env_config(key: "PRODUCT_BUNDLE_IDENTIFIER"),
         team_id: read_common_config(key: "DEV_TEAM")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -87,9 +87,9 @@ platform :ios do
         code_signing(type: "appstore", readonly: false)
     end
 
-    desc "Registers a new iPhone device and updates the certificates"
-    lane :register_new_iphone_device do
-        register_new_device
+    desc "Registers a new iPhone/Mac device and updates the certificates"
+    lane :register_new_device do
+        register_new_device_iphone_or_mac
         generate_new_dev_certificates
     end
 
@@ -252,7 +252,7 @@ private_lane :dependencies_with_hyperlinks do |options|
     versions.map { |k, v| "- #{k}: #{v}" }.join("\n")
 end
 
-private_lane :register_new_device do |options|
+private_lane :register_new_device_iphone_or_mac do |options|
     name = prompt(text: "Device name: ")
     udid = prompt(text: "Device UDID: ")
     devices = {}

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -77,13 +77,13 @@ Generate new appstore certificates
 
 Usage bundle exec fastlane ios generate_new_appstore_certificates --env ios.<specific env>
 
-### ios register_new_iphone_device
+### ios register_new_device
 
 ```sh
-[bundle exec] fastlane ios register_new_iphone_device
+[bundle exec] fastlane ios register_new_device
 ```
 
-Registers a new iPhone device and updates the certificates
+Registers a new iPhone/Mac device and updates the certificates
 
 ----
 


### PR DESCRIPTION
* We don't have to run `bundle exec fastlane ios` we can use only `bundle exec fastlane` now since this PR adds `default_plattform` - and update `SETUP_DEV` guide.
* Remove section in `DEVELOPMENT` which incorrectly stated that we are using many targets, no true since since mono target switch https://github.com/radixdlt/babylon-wallet-ios/pull/842
* Rename fastlane lane `register_new_iphone_device` to just `register_new_device` since it we can run the app on Mac! Using Catalyst, "just works"! N.B. **no build settings have changed at all, Catalyst is working on `main` branch already...,**
* Update GH release lane to create GH release with description with 3 sections, with placeholder Changelog first, renaming what used to be called Changelog->Pull Requests (and thirdly Dependencies)

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/1866b139-c45a-4fca-8daa-29ab7c1d3831

