### PR TITLE
ci/cd - update cancellation rules

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,8 +16,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.inputs.flavour }}
+  cancel-in-progress: ${{ github.event.inputs.flavour == 'release' }}
 
 jobs:
 


### PR DESCRIPTION
## Description
separate concurrency groups from `CD-workflow_dispatch` and `CD_push` to:
- CD-workflow_dispatch-pre-alpha
- CD-workflow_dispatch-alpha
- CD-workflow_dispatch-beta
- CD-workflow_dispatch-release
- CD-push

Only group `CD-workflow_dispatch-release` will cancel any build in progress others will queue.

