### PR TITLE
Properly check for the missing mnemonic

### DIFF
--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -33,6 +33,7 @@ extension SecureStorageClient: DependencyKey {
 		@Dependency(\.localAuthenticationClient) var localAuthenticationClient
 		@Dependency(\.uuid) var uuid
 		@Dependency(\.assertionFailure) var assertionFailure
+		@Dependency(\.overlayWindowClient) var overlayWindowClient
 
 		struct AccesibilityAndAuthenticationPolicy: Sendable, Equatable {
 			/// The most secure currently available accessibility
@@ -232,6 +233,7 @@ extension SecureStorageClient: DependencyKey {
 					forKey: key,
 					authenticationPrompt: authenticationPrompt
 				) else {
+					_ = await overlayWindowClient.scheduleAlert(.missingMnemonicAlert)
 					return nil
 				}
 				return try jsonDecoder().decode(MnemonicWithPassphrase.self, from: data)

--- a/RadixWallet/Features/DerivePublicKeys/DerivePublicKeys.swift
+++ b/RadixWallet/Features/DerivePublicKeys/DerivePublicKeys.swift
@@ -86,7 +86,6 @@ public struct DerivePublicKeys: Sendable, FeatureReducer {
 	@Dependency(\.factorSourcesClient) var factorSourcesClient
 	@Dependency(\.deviceFactorSourceClient) var deviceFactorSourceClient
 	@Dependency(\.ledgerHardwareWalletClient) var ledgerHardwareWalletClient
-	@Dependency(\.overlayWindowClient) var overlayWindowClient
 
 	public init() {}
 

--- a/RadixWallet/Features/DerivePublicKeys/DerivePublicKeys.swift
+++ b/RadixWallet/Features/DerivePublicKeys/DerivePublicKeys.swift
@@ -205,23 +205,16 @@ extension DerivePublicKeys {
 		loadMnemonicPurpose: SecureStorageClient.LoadMnemonicPurpose,
 		state: State
 	) async throws -> Action {
-		do {
-			let hdKeys = try await deviceFactorSourceClient.publicKeysFromOnDeviceHD(.init(
-				deviceFactorSource: deviceFactorSource,
-				derivationPaths: derivationPaths,
-				loadMnemonicPurpose: loadMnemonicPurpose
-			))
-			return .delegate(.derivedPublicKeys(
-				hdKeys,
-				factorSourceID: deviceFactorSource.id.embed(),
-				networkID: networkID
-			))
-		} catch {
-			if error is FailedToFindFactorSource {
-				_ = await overlayWindowClient.scheduleAlert(.missingMnemonicAlert)
-			}
-			throw error
-		}
+		let hdKeys = try await deviceFactorSourceClient.publicKeysFromOnDeviceHD(.init(
+			deviceFactorSource: deviceFactorSource,
+			derivationPaths: derivationPaths,
+			loadMnemonicPurpose: loadMnemonicPurpose
+		))
+		return .delegate(.derivedPublicKeys(
+			hdKeys,
+			factorSourceID: deviceFactorSource.id.embed(),
+			networkID: networkID
+		))
 	}
 
 	private func deriveWith(

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Children/DisplayMnemonic.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Children/DisplayMnemonic.swift
@@ -61,7 +61,7 @@ public struct DisplayMnemonic: Sendable, FeatureReducer {
 			guard let mnemonicWithPassphrase = maybeMnemonicWithPassphrase else {
 				loggerGlobal.error("Mnemonic was nil")
 				return .run { send in
-					_ = await overlayWindowClient.scheduleAlert(.missingMnemonicAlert)
+
 					await send(.delegate(.failedToLoad))
 				}
 			}
@@ -78,14 +78,7 @@ public struct DisplayMnemonic: Sendable, FeatureReducer {
 
 		case let .loadMnemonicResult(.failure(error)):
 			loggerGlobal.error("Error loading mnemonic: \(error)")
-
-			return .run { send in
-				_ = await overlayWindowClient.scheduleAlert(.init(
-					title: { TextState("Could Not Complete") },
-					message: { TextState("The required seed phrase is missing. Please return to the account and begin the recovery process.") }
-				))
-				await send(.delegate(.failedToLoad))
-			}
+			return .send(.delegate(.failedToLoad))
 		}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Children/DisplayMnemonic.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Children/DisplayMnemonic.swift
@@ -31,7 +31,6 @@ public struct DisplayMnemonic: Sendable, FeatureReducer {
 	}
 
 	@Dependency(\.secureStorageClient) var secureStorageClient
-	@Dependency(\.overlayWindowClient) var overlayWindowClient
 
 	public init() {}
 
@@ -60,10 +59,7 @@ public struct DisplayMnemonic: Sendable, FeatureReducer {
 		case let .loadMnemonicResult(.success(maybeMnemonicWithPassphrase)):
 			guard let mnemonicWithPassphrase = maybeMnemonicWithPassphrase else {
 				loggerGlobal.error("Mnemonic was nil")
-				return .run { send in
-
-					await send(.delegate(.failedToLoad))
-				}
+				return .send(.delegate(.failedToLoad))
 			}
 
 			state.importMnemonic = .init(

--- a/RadixWallet/Features/Signing/Children/Factors/SignWithFactorSourcesOfKindReducerProtocol.swift
+++ b/RadixWallet/Features/Signing/Children/Factors/SignWithFactorSourcesOfKindReducerProtocol.swift
@@ -76,10 +76,6 @@ extension SignWithFactorSourcesOfKindReducer {
 					)
 					allSignatures.append(contentsOf: signatures)
 				} catch {
-					if error is FailedToFindDeviceFactorSourceForSigning {
-						@Dependency(\.overlayWindowClient) var overlayWindowClient
-						await overlayWindowClient.scheduleAlert(.missingMnemonicAlert)
-					}
 					await send(.delegate(.failedToSign(signingFactor)))
 					break
 				}


### PR DESCRIPTION
Jira ticket: https://radixdlt.atlassian.net/browse/ABW-2511

Moved the check in a single place, where we do know for sure that the mnemonic is missing. Was initially reticent to put the alert in secureStorageClient, to not be too upfront with displaying the alert, but it works well in current setup. We should move this potentially closer to UI, when we will have a dedicated sheet for reading the mnemonic from the Keychain.