### PR TITLE
Quick fix - don't show missing mnemonic at startup

### DIFF
--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
@@ -82,7 +82,8 @@ extension DeviceFactorSourceClient: DependencyKey {
 						let mnemonicWithPassphrase = try await secureStorageClient
 						.loadMnemonicByFactorSourceID(
 							deviceFactorSource.id,
-							.checkingAccounts
+							.checkingAccounts,
+							false
 						)
 					else {
 						// Failed to find mnemonic for factor source

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
@@ -27,7 +27,7 @@ extension SecureStorageClient {
 	public typealias LoadProfileSnapshotData = @Sendable (ProfileSnapshot.Header.ID) async throws -> Data?
 
 	public typealias SaveMnemonicForFactorSource = @Sendable (PrivateHDFactorSource) async throws -> Void
-	public typealias LoadMnemonicByFactorSourceID = @Sendable (FactorSourceID.FromHash, LoadMnemonicPurpose) async throws -> MnemonicWithPassphrase?
+	public typealias LoadMnemonicByFactorSourceID = @Sendable (FactorSourceID.FromHash, LoadMnemonicPurpose, _ notifyIfMissing: Bool) async throws -> MnemonicWithPassphrase?
 	public typealias ContainsMnemonicIdentifiedByFactorSourceID = @Sendable (FactorSourceID.FromHash) async -> Bool
 
 	public typealias DeleteMnemonicByFactorSourceID = @Sendable (FactorSourceID.FromHash) async throws -> Void
@@ -76,6 +76,13 @@ extension SecureStorageClient {
 				"updateAccountMetadata"
 			}
 		}
+	}
+}
+
+extension SecureStorageClient {
+	@Sendable
+	public func loadMnemonicByFactorSourceID(_ factorSourceID: FactorSourceID.FromHash, _ purpose: LoadMnemonicPurpose) async throws -> MnemonicWithPassphrase? {
+		try await self.loadMnemonicByFactorSourceID(factorSourceID, purpose, true)
 	}
 }
 

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -203,7 +203,7 @@ extension SecureStorageClient: DependencyKey {
 					)
 				)
 			},
-			loadMnemonicByFactorSourceID: { factorSourceID, purpose in
+			loadMnemonicByFactorSourceID: { factorSourceID, purpose, notifyIfMissing in
 				let key = key(factorSourceID: factorSourceID)
 				let authPromptValue: String = {
 					switch purpose {
@@ -233,7 +233,9 @@ extension SecureStorageClient: DependencyKey {
 					forKey: key,
 					authenticationPrompt: authenticationPrompt
 				) else {
-					_ = await overlayWindowClient.scheduleAlert(.missingMnemonicAlert)
+					if notifyIfMissing {
+						_ = await overlayWindowClient.scheduleAlert(.missingMnemonicAlert)
+					}
 					return nil
 				}
 				return try jsonDecoder().decode(MnemonicWithPassphrase.self, from: data)

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Test.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Test.swift
@@ -12,7 +12,7 @@ extension SecureStorageClient: TestDependencyKey {
 		saveProfileSnapshot: { _ in },
 		loadProfileSnapshotData: { _ in nil },
 		saveMnemonicForFactorSource: { _ in },
-		loadMnemonicByFactorSourceID: { _, _ in nil },
+		loadMnemonicByFactorSourceID: { _, _, _ in nil },
 		containsMnemonicIdentifiedByFactorSourceID: { _ in false },
 		deleteMnemonicByFactorSourceID: { _ in },
 		deleteProfileAndMnemonicsByFactorSourceIDs: { _, _ in },


### PR DESCRIPTION
## Reasoning:

We do a background check of the accounts in the splash screen, if the mnemonic is missing we could show the alert with missing mnemonic, but the context is not clear to user. For now, disable showing the alert in splash screen, will enable again when we do have an explicit screen that informs the user what operation is happening.