### PR TITLE
[ABW-2415] Additions to Account Preferences

### DIFF
--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressFormat.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressFormat.swift
@@ -2,6 +2,7 @@
 public enum AddressFormat: String, Sendable {
 	case `default`
 	case olympia
+	case full
 	case nonFungibleLocalId
 }
 
@@ -18,6 +19,8 @@ extension String {
 			return truncatedMiddle(keepFirst: 4, last: 6)
 		case .olympia:
 			return truncatedMiddle(keepFirst: 3, last: 9)
+		case .full:
+			return self
 		case .nonFungibleLocalId:
 			guard let local = local(), local.count >= 3 else { return self }
 			return String(local.dropFirst().dropLast())

--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressView.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressView.swift
@@ -53,44 +53,42 @@ extension AddressView {
 
 	private var tappableAddressView: some View {
 		Button(action: tapAction) {
-			HStack(spacing: .small3) {
-				addressView
-				image
-			}
-			.contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: .medium1))
-			.contextMenu {
-				Button(copyText, asset: AssetResource.copyBig) {
-					copyToPasteboard()
-				}
-
-				Button(L10n.AddressAction.viewOnDashboard, asset: AssetResource.iconLinkOut) {
-					viewOnRadixDashboard()
-				}
-
-				if case let .address(.account(accountAddress, isLedgerHWAccount)) = identifiable {
-					Button(
-						L10n.AddressAction.showAccountQR,
-						asset: AssetResource.qrCodeScanner
-					) {
-						showQR(for: accountAddress)
+			addressView
+				.contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: .medium1))
+				.contextMenu {
+					Button(copyText, asset: AssetResource.copyBig) {
+						copyToPasteboard()
 					}
 
-					if isLedgerHWAccount {
+					Button(L10n.AddressAction.viewOnDashboard, asset: AssetResource.iconLinkOut) {
+						viewOnRadixDashboard()
+					}
+
+					if case let .address(.account(accountAddress, isLedgerHWAccount)) = identifiable {
 						Button(
-							"Verify Address with Ledger", // FIXME: Strings
-							asset: AssetResource.ledger
+							L10n.AddressAction.showAccountQR,
+							asset: AssetResource.qrCodeScanner
 						) {
-							verifyAddressOnLedger(accountAddress)
+							showQR(for: accountAddress)
+						}
+
+						if isLedgerHWAccount {
+							Button(
+								"Verify Address with Ledger", // FIXME: Strings
+								asset: AssetResource.ledger
+							) {
+								verifyAddressOnLedger(accountAddress)
+							}
 						}
 					}
 				}
-			}
 		}
 	}
 
 	private var addressView: some View {
-		Text((identifiable.address).formatted(format))
-			.lineLimit(1)
+		Text("\(identifiable.address.formatted(format)) \(image)")
+			.lineLimit(format == .full ? nil : 1)
+			.multilineTextAlignment(.leading)
 			.minimumScaleFactor(0.5)
 	}
 

--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressView.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressView.swift
@@ -15,6 +15,7 @@ public struct AddressView: View {
 
 	public init(
 		_ identifiable: LedgerIdentifiable,
+		showFull: Bool = false,
 		isTappable: Bool = true
 	) {
 		self.identifiable = identifiable
@@ -22,15 +23,15 @@ public struct AddressView: View {
 
 		switch identifiable {
 		case .address:
-			self.format = .default
+			self.format = showFull ? .full : .default
 			self.action = .copy
 		case let .identifier(identifier):
 			switch identifier {
 			case .transaction:
-				self.format = .default
+				self.format = showFull ? .full : .default
 				self.action = .viewOnDashboard
 			case .nonFungibleGlobalID:
-				self.format = .nonFungibleLocalId
+				self.format = showFull ? .full : .nonFungibleLocalId
 				self.action = .copy
 			}
 		}

--- a/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
@@ -2,29 +2,33 @@ import ComposableArchitecture
 import SwiftUI
 extension AccountPreferences.State {
 	var viewState: AccountPreferences.ViewState {
-		.init(sections: [
-			.init(
-				id: .personalize,
-				title: L10n.AccountSettings.personalizeHeading,
-				rows: [.accountLabel(account)]
-			),
-			.init(
-				id: .onLedgerBehaviour,
-				title: L10n.AccountSettings.setBehaviorHeading,
-				rows: [.thirdPartyDeposits(account.onLedgerSettings.thirdPartyDeposits.depositRule)]
-			),
-			.init(
-				id: .development,
-				title: "Set development preferences", // FIXME: strings
-				rows: [.devAccountPreferneces()]
-			),
-		])
+		.init(
+			account: account,
+			sections: [
+				.init(
+					id: .personalize,
+					title: L10n.AccountSettings.personalizeHeading,
+					rows: [.accountLabel(account)]
+				),
+				.init(
+					id: .onLedgerBehaviour,
+					title: L10n.AccountSettings.setBehaviorHeading,
+					rows: [.thirdPartyDeposits(account.onLedgerSettings.thirdPartyDeposits.depositRule)]
+				),
+				.init(
+					id: .development,
+					title: "Set development preferences", // FIXME: strings
+					rows: [.devAccountPreferneces()]
+				),
+			]
+		)
 	}
 }
 
 // MARK: - AccountPreferences.View
 extension AccountPreferences {
 	public struct ViewState: Equatable {
+		let account: Profile.Network.Account
 		var sections: [PreferenceSection<AccountPreferences.Section, AccountPreferences.Section.SectionRow>.ViewState]
 	}
 
@@ -38,6 +42,13 @@ extension AccountPreferences {
 
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
+				AddressView(.address(of: viewStore.account), showFull: true)
+					.textStyle(.body2Regular)
+					.foregroundColor(.app.gray2)
+					.padding(.top, .small1)
+					.padding(.horizontal, .medium3)
+					.padding(.bottom, .medium3)
+
 				PreferencesList(
 					viewState: .init(sections: viewStore.sections),
 					onRowSelected: { _, rowId in viewStore.send(.rowTapped(rowId)) }

--- a/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
@@ -49,7 +49,7 @@ extension AccountPreferences {
 					.padding(.horizontal, .medium3)
 					.padding(.bottom, .medium3)
 
-				Button("Show Address QR Code") { // FIXME: Strings L10n.AccountSettings.showQR
+				Button("Show Address QR Code") { // FIXME: Strings - L10n.AccountSettings.showQR
 					viewStore.send(.qrCodeButtonTapped)
 				}
 				.buttonStyle(.secondaryRectangular(shouldExpand: true))

--- a/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
@@ -49,6 +49,13 @@ extension AccountPreferences {
 					.padding(.horizontal, .medium3)
 					.padding(.bottom, .medium3)
 
+				Button("Show Address QR Code") { // FIXME: Strings L10n.AccountSettings.showQR
+					viewStore.send(.qrCodeButtonTapped)
+				}
+				.buttonStyle(.secondaryRectangular(shouldExpand: true))
+				.padding(.horizontal, .medium3)
+				.padding(.bottom, .medium3)
+
 				PreferencesList(
 					viewState: .init(sections: viewStore.sections),
 					onRowSelected: { _, rowId in viewStore.send(.rowTapped(rowId)) }
@@ -73,9 +80,21 @@ extension View {
 	@MainActor
 	func destination(store: StoreOf<AccountPreferences>) -> some View {
 		let destinationStore = store.scope(state: \.$destinations, action: { .child(.destinations($0)) })
-		return updateAccountLabel(with: destinationStore)
+		return showQRCode(with: destinationStore)
+			.updateAccountLabel(with: destinationStore)
 			.thirdPartyDeposits(with: destinationStore)
 			.devAccountPreferences(with: destinationStore)
+	}
+
+	@MainActor
+	func showQRCode(with destinationStore: PresentationStoreOf<AccountPreferences.Destinations>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /AccountPreferences.Destinations.State.showQR,
+			action: AccountPreferences.Destinations.Action.showQR
+		) {
+			ShowQR.View(store: $0)
+		}
 	}
 
 	@MainActor

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
@@ -56,8 +56,6 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 		case createMultipleFungibleTokenButtonTapped
 		case createMultipleNonFungibleTokenButtonTapped
 		#endif // DEBUG
-
-		case qrCodeButtonTapped
 	}
 
 	public enum InternalAction: Sendable, Equatable {
@@ -85,23 +83,18 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 
 	public struct Destination: Reducer {
 		public enum State: Equatable, Hashable {
-			case showQR(ShowQR.State)
 			#if DEBUG
 			case reviewTransaction(TransactionReview.State)
 			#endif // DEBUG
 		}
 
 		public enum Action: Equatable {
-			case showQR(ShowQR.Action)
 			#if DEBUG
 			case reviewTransaction(TransactionReview.Action)
 			#endif // DEBUG
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.showQR, action: /Action.showQR) {
-				ShowQR()
-			}
 			#if DEBUG
 			Scope(state: /State.reviewTransaction, action: /Action.reviewTransaction) {
 				TransactionReview()
@@ -192,10 +185,6 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 				loggerGlobal.warning("Failed to create manifest which turns account into dapp definition account type, error: \(error)")
 			}
 		#endif
-
-		case .qrCodeButtonTapped:
-			state.destination = .showQR(.init(accountAddress: state.address))
-			return .none
 		}
 	}
 
@@ -210,12 +199,6 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 				}
 				return .none
 			#endif
-
-			case .showQR(.delegate(.dismiss)):
-				if case .showQR = state.destination {
-					state.destination = nil
-				}
-				return .none
 
 			default:
 				return .none

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+View.swift
@@ -91,7 +91,6 @@ extension DevAccountPreferences {
 						createMultipleFungibleTokenButton(with: viewStore)
 						createMultipleNonFungibleTokenButton(with: viewStore)
 						#endif // DEBUG
-						qrCodeButton(with: viewStore)
 					}
 					.frame(maxHeight: .infinity, alignment: .top)
 					.padding(.medium1)
@@ -99,15 +98,8 @@ extension DevAccountPreferences {
 						viewStore.send(.appeared)
 					}
 					.navigationTitle("Dev Preferences")
-					.sheet(
-						store: store.destination,
-						state: /DevAccountPreferences.Destination.State.showQR,
-						action: DevAccountPreferences.Destination.Action.showQR
-					) { store in
-						ShowQR.View(store: store)
-					}
 					#if DEBUG
-					.sheet(
+						.sheet(
 							store: store.destination,
 							state: /DevAccountPreferences.Destination.State.reviewTransaction,
 							action: DevAccountPreferences.Destination.Action.reviewTransaction
@@ -149,14 +141,6 @@ extension DevAccountPreferences.View {
 				.font(.app.body2Regular)
 				.foregroundColor(.app.gray1)
 		}
-	}
-
-	@ViewBuilder
-	private func qrCodeButton(with viewStore: ViewStoreOf<DevAccountPreferences>) -> some View {
-		Button(L10n.AccountSettings.showQR) {
-			viewStore.send(.qrCodeButtonTapped)
-		}
-		.buttonStyle(.secondaryRectangular(shouldExpand: true))
 	}
 }
 


### PR DESCRIPTION
Jira ticket: [ABW-2415](https://radixdlt.atlassian.net/browse/ABW-2415)

## Description
We want to show the full account address, and the button to show the QR code, right in Account Preferences, as seen in [Figma](https://www.figma.com/file/6MaKVYek0m9GKkd1xujB8P/Babylon-Wallet?type=design&node-id=11004-38632&mode=design&t=m2KXOLS2rFZteKS7-0).

### Notes
The QR code button is also removed from Dev preferences.

## How to test
- Verify that the full address and the QR code button show up where they should, and that they work as expected
- Also verify that other address views look and behave as before

## Screenshot
![image](https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/efb35990-e95d-4cd7-8128-4f8662883944)

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2415]: https://radixdlt.atlassian.net/browse/ABW-2415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ