### PR TITLE
[ABW-2289] Remove Quotation Marks Around Persona Nickname

### DIFF
--- a/RadixWallet/Profile/Entity/PersonaData/EntryKinds/Name/PersonaData+Name.swift
+++ b/RadixWallet/Profile/Entity/PersonaData/EntryKinds/Name/PersonaData+Name.swift
@@ -55,7 +55,7 @@ extension PersonaData {
 
 			return [
 				NonEmptyString(names.joined(separator: " ")),
-				NonEmptyString(maybeString: nickname.nilIfEmpty.map { "\"\($0)\"" }),
+				NonEmptyString(maybeString: nickname),
 			]
 			.compactMap { $0 }
 			.map(\.rawValue)


### PR DESCRIPTION
Jira ticket: [ABW-2289](https://radixdlt.atlassian.net/browse/ABW-2289)

## Description
There should never be quotation marks around a Persona nickname 

## Screenshot
![image](https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/adfb7bc5-c691-46d6-831c-38a836903b04)

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2289]: https://radixdlt.atlassian.net/browse/ABW-2289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ