### PR TITLE
[ABW-2207] Seed Phrase prompts - recover seed phrase if missing.

### DIFF
--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
@@ -9,6 +9,7 @@ extension DeviceFactorSourceClient: DependencyKey {
 		@Dependency(\.secureStorageClient) var secureStorageClient
 		@Dependency(\.accountsClient) var accountsClient
 		@Dependency(\.personasClient) var personasClient
+		@Dependency(\.userDefaultsClient) var userDefaultsClient
 		@Dependency(\.factorSourcesClient) var factorSourcesClient
 
 		let entitiesControlledByFactorSource: GetEntitiesControlledByFactorSource = { factorSource, maybeSnapshot in
@@ -40,10 +41,13 @@ extension DeviceFactorSourceClient: DependencyKey {
 				}
 			}
 
+			let isMnemonicMarkedAsBackedUp = userDefaultsClient.getFactorSourceIDOfBackedUpMnemonics().contains(factorSource.id)
+
 			return EntitiesControlledByFactorSource(
 				entities: entitiesForSource,
 				deviceFactorSource: factorSource,
-				isMnemonicPresentInKeychain: secureStorageClient.containsMnemonicIdentifiedByFactorSourceID(factorSource.id)
+				isMnemonicPresentInKeychain: secureStorageClient.containsMnemonicIdentifiedByFactorSourceID(factorSource.id),
+				isMnemonicMarkedAsBackedUp: isMnemonicMarkedAsBackedUp
 			)
 		}
 

--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
@@ -11,7 +11,9 @@ extension DeviceFactorSourceClient: DependencyKey {
 		@Dependency(\.personasClient) var personasClient
 		@Dependency(\.factorSourcesClient) var factorSourcesClient
 
-		let entitiesControlledByFactorSource: GetEntitiesControlledByFactorSource = { factorSource, maybeSnapshot in
+		let entitiesControlledByFactorSource: GetEntitiesControlledByFactorSource = {
+			factorSource,
+				maybeSnapshot in
 
 			let allEntities: [EntityPotentiallyVirtual] = try await {
 				let accounts: [Profile.Network.Account]
@@ -20,7 +22,7 @@ extension DeviceFactorSourceClient: DependencyKey {
 				// FIXME: Uh this aint pretty... but we are short on time.
 				if let overridingSnapshot = maybeSnapshot {
 					let networkID = Radix.Gateway.default.network.id
-					let profile = try Profile(snapshot: overridingSnapshot)
+					let profile = Profile(snapshot: overridingSnapshot)
 					let network = try profile.network(id: networkID)
 					accounts = network.accounts.elements
 					personas = network.personas.elements
@@ -39,9 +41,11 @@ extension DeviceFactorSourceClient: DependencyKey {
 					unsecuredEntityControl.transactionSigning.factorSourceID == factorSource.id
 				}
 			}
+
 			return EntitiesControlledByFactorSource(
 				entities: entitiesForSource,
-				deviceFactorSource: factorSource
+				deviceFactorSource: factorSource,
+				isMnemonicPresentInKeychain: secureStorageClient.containsMnemonicIdentifiedByFactorSourceID(factorSource.id)
 			)
 		}
 

--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
@@ -11,9 +11,7 @@ extension DeviceFactorSourceClient: DependencyKey {
 		@Dependency(\.personasClient) var personasClient
 		@Dependency(\.factorSourcesClient) var factorSourcesClient
 
-		let entitiesControlledByFactorSource: GetEntitiesControlledByFactorSource = {
-			factorSource,
-				maybeSnapshot in
+		let entitiesControlledByFactorSource: GetEntitiesControlledByFactorSource = { factorSource, maybeSnapshot in
 
 			let allEntities: [EntityPotentiallyVirtual] = try await {
 				let accounts: [Profile.Network.Account]

--- a/RadixWallet/Core/DesignSystem/Components/WarningView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/WarningView.swift
@@ -2,10 +2,12 @@
 public struct WarningErrorView: View {
 	public let text: String
 	public let type: ViewType
+	public let spacing: CGFloat
 
-	public init(text: String, type: ViewType) {
+	public init(text: String, type: ViewType, spacing: CGFloat = .medium3) {
 		self.text = text
 		self.type = type
+		self.spacing = spacing
 	}
 
 	public enum ViewType {
@@ -14,7 +16,7 @@ public struct WarningErrorView: View {
 	}
 
 	public var body: some View {
-		HStack(spacing: .medium3) {
+		HStack(spacing: spacing) {
 			Image(asset: AssetResource.warningError)
 				.resizable()
 				.renderingMode(.template)

--- a/RadixWallet/Core/DesignSystem/Components/WarningView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/WarningView.swift
@@ -4,10 +4,14 @@ public struct WarningErrorView: View {
 	public let type: ViewType
 	public let spacing: CGFloat
 
-	public init(text: String, type: ViewType, spacing: CGFloat = .medium3) {
+	public init(
+		text: String,
+		type: ViewType,
+		useNarrowSpacing: Bool = false
+	) {
 		self.text = text
 		self.type = type
-		self.spacing = spacing
+		self.spacing = useNarrowSpacing ? .small2 : .medium3
 	}
 
 	public enum ViewType {

--- a/RadixWallet/Core/FeaturePrelude/UserDefaultsClient+AccountRecovery.swift
+++ b/RadixWallet/Core/FeaturePrelude/UserDefaultsClient+AccountRecovery.swift
@@ -1,15 +1,15 @@
 extension UserDefaultsClient {
-	public func addFactorSourceIDOfBackedUpMnemonic(_ factorSourceID: FactorSourceID.FromHash) async throws {
+	public func addFactorSourceIDOfBackedUpMnemonic(_ factorSourceID: FactorSourceID.FromHash) throws {
 		var ids = getFactorSourceIDOfBackedUpMnemonics()
 		ids.append(factorSourceID)
-		try await save(codable: ids, forKey: .mnemonicsUserClaimsToHaveBackedUp)
+		try save(codable: ids, forKey: .mnemonicsUserClaimsToHaveBackedUp)
 	}
 
 	public func getFactorSourceIDOfBackedUpMnemonics() -> OrderedSet<FactorSourceID.FromHash> {
 		(try? loadCodable(key: .mnemonicsUserClaimsToHaveBackedUp)) ?? OrderedSet<FactorSourceID.FromHash>()
 	}
 
-	public func removeAllFactorSourceIDsOfBackedUpMnemonics() async {
-		await setData(nil, .mnemonicsUserClaimsToHaveBackedUp)
+	public func removeAllFactorSourceIDsOfBackedUpMnemonics() {
+		setData(nil, .mnemonicsUserClaimsToHaveBackedUp)
 	}
 }

--- a/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
+++ b/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
@@ -3,17 +3,23 @@ public struct EntitiesControlledByFactorSource: Sendable, Hashable, Identifiable
 	public typealias ID = FactorSourceID
 	public var id: ID { deviceFactorSource.id.embed() }
 	public let entities: [EntityPotentiallyVirtual]
-	public let isMnemonicPresentInKeychain: Bool
+	public var isMnemonicPresentInKeychain: Bool
+	public var isMnemonicMarkedAsBackedUp: Bool
 	public let deviceFactorSource: DeviceFactorSource
 
 	public init(
 		entities: [EntityPotentiallyVirtual],
 		deviceFactorSource: DeviceFactorSource,
-		isMnemonicPresentInKeychain: Bool
+		isMnemonicPresentInKeychain: Bool,
+		isMnemonicMarkedAsBackedUp: Bool
 	) {
+		if isMnemonicMarkedAsBackedUp, !isMnemonicPresentInKeychain {
+			assertionFailure("Discrepancy, bad state, a keychain should not be missing and ALSO be marked as backed up. We probably have a missing sync logic between the states.")
+		}
 		self.entities = entities
 		self.deviceFactorSource = deviceFactorSource
 		self.isMnemonicPresentInKeychain = isMnemonicPresentInKeychain
+		self.isMnemonicMarkedAsBackedUp = isMnemonicMarkedAsBackedUp
 	}
 }
 

--- a/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
+++ b/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
@@ -3,11 +3,17 @@ public struct EntitiesControlledByFactorSource: Sendable, Hashable, Identifiable
 	public typealias ID = FactorSourceID
 	public var id: ID { deviceFactorSource.id.embed() }
 	public let entities: [EntityPotentiallyVirtual]
+	public let isMnemonicPresentInKeychain: Bool
 	public let deviceFactorSource: DeviceFactorSource
 
-	public init(entities: [EntityPotentiallyVirtual], deviceFactorSource: DeviceFactorSource) {
+	public init(
+		entities: [EntityPotentiallyVirtual],
+		deviceFactorSource: DeviceFactorSource,
+		isMnemonicPresentInKeychain: Bool
+	) {
 		self.entities = entities
 		self.deviceFactorSource = deviceFactorSource
+		self.isMnemonicPresentInKeychain = isMnemonicPresentInKeychain
 	}
 }
 

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -10,30 +10,6 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 		public var deviceFactorSource: DeviceFactorSource { accountsForDeviceFactorSource.deviceFactorSource }
 
 		public var accountsForDeviceFactorSource: EntitiesControlledByFactorSource
-		public var displayRevealMnemonicLink: Bool {
-			switch mode {
-			case .mnemonicCanBeDisplayed: true
-			case .mnemonicNeedsImport: false
-			case .displayAccountListOnly: false
-			}
-		}
-
-		public var mnemonicNeedsImport: Bool {
-			switch mode {
-			case .mnemonicCanBeDisplayed: false
-			case .mnemonicNeedsImport: true
-			case .displayAccountListOnly: false
-			}
-		}
-
-		public var promptUserToBackUpMnemonic: Bool {
-			get {
-				!accountsForDeviceFactorSource.isMnemonicMarkedAsBackedUp
-			}
-			set {
-				accountsForDeviceFactorSource.isMnemonicMarkedAsBackedUp = !newValue
-			}
-		}
 
 		// Mutable since if we just imported a missing mnemonic we wanna change to `mnemonicCanBeDisplayed`
 		public var mode: Mode
@@ -46,12 +22,8 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 
 		public init(
 			accountsForDeviceFactorSource: EntitiesControlledByFactorSource,
-			mode: Mode? = nil
+			mode: Mode
 		) {
-			let mode = mode ?? (accountsForDeviceFactorSource.isMnemonicPresentInKeychain ? .mnemonicCanBeDisplayed : .mnemonicNeedsImport)
-			if mode == .mnemonicCanBeDisplayed, !accountsForDeviceFactorSource.isMnemonicPresentInKeychain {
-				preconditionFailure("Cannot reveal mnemonic since it is missing")
-			}
 			self.accountsForDeviceFactorSource = accountsForDeviceFactorSource
 			self.mode = mode
 		}
@@ -59,8 +31,8 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 
 	public enum ViewAction: Sendable, Equatable {
 		case appeared
-		case importMnemonic
-		case displayMnemonic
+		case importMnemonicTapped
+		case displayMnemonicTapped
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -74,9 +46,9 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 		switch viewAction {
 		case .appeared:
 			.none
-		case .displayMnemonic:
+		case .displayMnemonicTapped:
 			.send(.delegate(.displayMnemonic))
-		case .importMnemonic:
+		case .importMnemonicTapped:
 			.send(.delegate(.importMissingMnemonic))
 		}
 	}

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -9,7 +9,7 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 
 		public var deviceFactorSource: DeviceFactorSource { accountsForDeviceFactorSource.deviceFactorSource }
 
-		public let accountsForDeviceFactorSource: EntitiesControlledByFactorSource
+		public var accountsForDeviceFactorSource: EntitiesControlledByFactorSource
 		public var displayRevealMnemonicLink: Bool {
 			switch mode {
 			case .mnemonicCanBeDisplayed: true
@@ -23,6 +23,15 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 			case .mnemonicCanBeDisplayed: false
 			case .mnemonicNeedsImport: true
 			case .displayAccountListOnly: false
+			}
+		}
+
+		public var promptUserToBackUpMnemonic: Bool {
+			get {
+				!accountsForDeviceFactorSource.isMnemonicMarkedAsBackedUp
+			}
+			set {
+				accountsForDeviceFactorSource.isMnemonicMarkedAsBackedUp = !newValue
 			}
 		}
 

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -26,7 +26,9 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 			}
 		}
 
-		public let mode: Mode
+		// Mutable since if we just imported a missing mnemonic we wanna change to `mnemonicCanBeDisplayed`
+		public var mode: Mode
+
 		public enum Mode: Sendable, Hashable {
 			case mnemonicCanBeDisplayed
 			case mnemonicIsMissingNeedsImport

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -13,15 +13,15 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 		public var displayRevealMnemonicLink: Bool {
 			switch mode {
 			case .mnemonicCanBeDisplayed: true
-			case .mnemonicIsMissingNeedsImport: false
+			case .mnemonicNeedsImport: false
 			case .displayAccountListOnly: false
 			}
 		}
 
-		public var mnemonicIsMissingNeedsImport: Bool {
+		public var mnemonicNeedsImport: Bool {
 			switch mode {
 			case .mnemonicCanBeDisplayed: false
-			case .mnemonicIsMissingNeedsImport: true
+			case .mnemonicNeedsImport: true
 			case .displayAccountListOnly: false
 			}
 		}
@@ -31,7 +31,7 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 
 		public enum Mode: Sendable, Hashable {
 			case mnemonicCanBeDisplayed
-			case mnemonicIsMissingNeedsImport
+			case mnemonicNeedsImport
 			case displayAccountListOnly
 		}
 
@@ -39,7 +39,7 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 			accountsForDeviceFactorSource: EntitiesControlledByFactorSource,
 			mode: Mode? = nil
 		) {
-			let mode = mode ?? (accountsForDeviceFactorSource.isMnemonicPresentInKeychain ? .mnemonicCanBeDisplayed : .mnemonicIsMissingNeedsImport)
+			let mode = mode ?? (accountsForDeviceFactorSource.isMnemonicPresentInKeychain ? .mnemonicCanBeDisplayed : .mnemonicNeedsImport)
 			if mode == .mnemonicCanBeDisplayed, !accountsForDeviceFactorSource.isMnemonicPresentInKeychain {
 				preconditionFailure("Cannot reveal mnemonic since it is missing")
 			}
@@ -65,7 +65,7 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 		case .appeared:
 			.none
 		case .navigateButtonTapped:
-			if state.mnemonicIsMissingNeedsImport {
+			if state.mnemonicNeedsImport {
 				.send(.delegate(.importMissingMnemonic))
 			} else {
 				.send(.delegate(.displayMnemonic))

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -50,7 +50,8 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 
 	public enum ViewAction: Sendable, Equatable {
 		case appeared
-		case navigateButtonTapped
+		case importMnemonic
+		case displayMnemonic
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -64,12 +65,10 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 		switch viewAction {
 		case .appeared:
 			.none
-		case .navigateButtonTapped:
-			if state.mnemonicNeedsImport {
-				.send(.delegate(.importMissingMnemonic))
-			} else {
-				.send(.delegate(.displayMnemonic))
-			}
+		case .displayMnemonic:
+			.send(.delegate(.displayMnemonic))
+		case .importMnemonic:
+			.send(.delegate(.importMissingMnemonic))
 		}
 	}
 }

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -9,10 +9,6 @@ extension DisplayEntitiesControlledByMnemonic.State {
 			return L10n.SeedPhrases.SeedPhrase.multipleConnectedAccounts(accountsCount)
 		}
 	}
-
-	var canNavigate: Bool {
-		displayRevealMnemonicLink || mnemonicNeedsImport
-	}
 }
 
 // MARK: - DisplayEntitiesControlledByMnemonic.View
@@ -28,37 +24,49 @@ extension DisplayEntitiesControlledByMnemonic {
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: { $0 }, send: { .view($0) }) { viewStore in
 				VStack(alignment: .leading) {
-					if viewStore.canNavigate {
+					if viewStore.displayRevealMnemonicLink {
 						Button {
-							viewStore.send(.navigateButtonTapped)
+							viewStore.send(.displayMnemonic)
 						} label: {
 							HStack {
-								if viewStore.displayRevealMnemonicLink {
-									Image(asset: AssetResource.signingKey)
-										.resizable()
-										.frame(.smallest)
+								Image(asset: AssetResource.signingKey)
+									.resizable()
+									.frame(.smallest)
 
-									VStack(alignment: .leading) {
-										Text(L10n.SeedPhrases.SeedPhrase.reveal)
-											.textStyle(.body1Header)
-											.foregroundColor(.app.gray1)
-										Text(viewStore.connectedAccounts)
-											.textStyle(.body2Regular)
-											.foregroundColor(.app.gray2)
-									}
-								} else if viewStore.mnemonicNeedsImport {
-									WarningErrorView(
-										text: "Recover Seed Phrase", // FIXME: strings
-										type: .error,
-										spacing: .small2
-									)
+								VStack(alignment: .leading) {
+									Text(L10n.SeedPhrases.SeedPhrase.reveal)
+										.textStyle(.body1Header)
+										.foregroundColor(.app.gray1)
+									Text(viewStore.connectedAccounts)
+										.textStyle(.body2Regular)
+										.foregroundColor(.app.gray2)
 								}
 
 								Spacer()
 								Image(asset: AssetResource.chevronRight)
 							}
 						}
+					} else if viewStore.mnemonicNeedsImport {
+						Button {
+							viewStore.send(.importMnemonic)
+						} label: {
+							HStack {
+								VStack {
+									WarningErrorView(
+										text: "Recover Seed Phrase", // FIXME: strings
+										type: .error,
+										spacing: .small2
+									)
+									Text(viewStore.connectedAccounts)
+										.textStyle(.body2Regular)
+										.foregroundColor(.app.gray2)
+								}
+								Spacer()
+								Image(asset: AssetResource.chevronRight)
+							}
+						}
 					}
+
 					VStack(alignment: .leading, spacing: .small3) {
 						ForEach(viewStore.accountsForDeviceFactorSource.accounts) { account in
 							SmallAccountCard(account: account)

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -11,7 +11,7 @@ extension DisplayEntitiesControlledByMnemonic.State {
 	}
 
 	var canNavigate: Bool {
-		displayRevealMnemonicLink || mnemonicIsMissingNeedsImport
+		displayRevealMnemonicLink || mnemonicNeedsImport
 	}
 }
 
@@ -46,7 +46,7 @@ extension DisplayEntitiesControlledByMnemonic {
 											.textStyle(.body2Regular)
 											.foregroundColor(.app.gray2)
 									}
-								} else if viewStore.mnemonicIsMissingNeedsImport {
+								} else if viewStore.mnemonicNeedsImport {
 									WarningErrorView(
 										text: "Recover Seed Phrase", // FIXME: strings
 										type: .error,

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -46,6 +46,13 @@ extension DisplayEntitiesControlledByMnemonic {
 								Image(asset: AssetResource.chevronRight)
 							}
 						}
+						if viewStore.promptUserToBackUpMnemonic {
+							WarningErrorView(
+								text: "Please write down your seed phrase",
+								type: .error,
+								useNarrowSpacing: true
+							)
+						}
 					} else if viewStore.mnemonicNeedsImport {
 						Button {
 							viewStore.send(.importMnemonic)
@@ -53,9 +60,9 @@ extension DisplayEntitiesControlledByMnemonic {
 							HStack {
 								VStack {
 									WarningErrorView(
-										text: "Recover Seed Phrase", // FIXME: strings
+										text: "Please recover your seed phrase", // FIXME: strings
 										type: .error,
-										spacing: .small2
+										useNarrowSpacing: true
 									)
 									Text(viewStore.connectedAccounts)
 										.textStyle(.body2Regular)

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -33,11 +33,11 @@ extension DisplayEntitiesControlledByMnemonic {
 							viewStore.send(.navigateButtonTapped)
 						} label: {
 							HStack {
-								Image(asset: AssetResource.signingKey)
-									.resizable()
-									.frame(.smallest)
-
 								if viewStore.displayRevealMnemonicLink {
+									Image(asset: AssetResource.signingKey)
+										.resizable()
+										.frame(.smallest)
+
 									VStack(alignment: .leading) {
 										Text(L10n.SeedPhrases.SeedPhrase.reveal)
 											.textStyle(.body1Header)
@@ -47,8 +47,11 @@ extension DisplayEntitiesControlledByMnemonic {
 											.foregroundColor(.app.gray2)
 									}
 								} else if viewStore.mnemonicIsMissingNeedsImport {
-									WarningErrorView(text: "Recover", type: .error)
-										.padding(.horizontal, .medium3)
+									WarningErrorView(
+										text: "Recover Seed Phrase", // FIXME: strings
+										type: .error,
+										spacing: .small2
+									)
 								}
 
 								Spacer()

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -9,6 +9,10 @@ extension DisplayEntitiesControlledByMnemonic.State {
 			return L10n.SeedPhrases.SeedPhrase.multipleConnectedAccounts(accountsCount)
 		}
 	}
+
+	var canNavigate: Bool {
+		displayRevealMnemonicLink || mnemonicIsMissingNeedsImport
+	}
 }
 
 // MARK: - DisplayEntitiesControlledByMnemonic.View
@@ -24,22 +28,27 @@ extension DisplayEntitiesControlledByMnemonic {
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: { $0 }, send: { .view($0) }) { viewStore in
 				VStack(alignment: .leading) {
-					if viewStore.displayRevealMnemonicLink {
+					if viewStore.canNavigate {
 						Button {
-							viewStore.send(.tapped)
+							viewStore.send(.navigateButtonTapped)
 						} label: {
 							HStack {
 								Image(asset: AssetResource.signingKey)
 									.resizable()
 									.frame(.smallest)
 
-								VStack(alignment: .leading) {
-									Text(L10n.SeedPhrases.SeedPhrase.reveal)
-										.textStyle(.body1Header)
-										.foregroundColor(.app.gray1)
-									Text(viewStore.connectedAccounts)
-										.textStyle(.body2Regular)
-										.foregroundColor(.app.gray2)
+								if viewStore.displayRevealMnemonicLink {
+									VStack(alignment: .leading) {
+										Text(L10n.SeedPhrases.SeedPhrase.reveal)
+											.textStyle(.body1Header)
+											.foregroundColor(.app.gray1)
+										Text(viewStore.connectedAccounts)
+											.textStyle(.body2Regular)
+											.foregroundColor(.app.gray2)
+									}
+								} else if viewStore.mnemonicIsMissingNeedsImport {
+									WarningErrorView(text: "Recover", type: .error)
+										.padding(.horizontal, .medium3)
 								}
 
 								Spacer()
@@ -58,23 +67,3 @@ extension DisplayEntitiesControlledByMnemonic {
 		}
 	}
 }
-
-// #if DEBUG
-// import SwiftUI
-import ComposableArchitecture //
-//// MARK: - DisplayMnemonicRow_Preview
-// struct DisplayMnemonicRow_Preview: PreviewProvider {
-//	static var previews: some View {
-//		DisplayEntitiesControlledByMnemonic.View(
-//			store: .init(
-//				initialState: .previewValue,
-//				reducer: DisplayEntitiesControlledByMnemonic.init
-//			)
-//		)
-//	}
-// }
-//
-// extension DisplayEntitiesControlledByMnemonic.State {
-//    public static let previewValue = Self(deviceFactorSource: )
-// }
-// #endif

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -24,9 +24,9 @@ extension DisplayEntitiesControlledByMnemonic {
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: { $0 }, send: { .view($0) }) { viewStore in
 				VStack(alignment: .leading) {
-					if viewStore.displayRevealMnemonicLink {
+					if viewStore.mode == .mnemonicCanBeDisplayed {
 						Button {
-							viewStore.send(.displayMnemonic)
+							viewStore.send(.displayMnemonicTapped)
 						} label: {
 							HStack {
 								Image(asset: AssetResource.signingKey)
@@ -46,16 +46,16 @@ extension DisplayEntitiesControlledByMnemonic {
 								Image(asset: AssetResource.chevronRight)
 							}
 						}
-						if viewStore.promptUserToBackUpMnemonic {
+						if !viewStore.accountsForDeviceFactorSource.isMnemonicMarkedAsBackedUp {
 							WarningErrorView(
 								text: "Please write down your seed phrase",
 								type: .error,
 								useNarrowSpacing: true
 							)
 						}
-					} else if viewStore.mnemonicNeedsImport {
+					} else if viewStore.mode == .mnemonicNeedsImport {
 						Button {
-							viewStore.send(.importMnemonic)
+							viewStore.send(.importMnemonicTapped)
 						} label: {
 							HStack {
 								VStack {

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
@@ -348,7 +348,7 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 
 		case let .destination(.presented(.markMnemonicAsBackedUp(.userHaveBackedUp(factorSourceID)))):
 			return .run { send in
-				try await userDefaultsClient.addFactorSourceIDOfBackedUpMnemonic(factorSourceID)
+				try userDefaultsClient.addFactorSourceIDOfBackedUpMnemonic(factorSourceID)
 				await send(.delegate(.doneViewing(markedMnemonicAsBackedUp: true)))
 			} catch: { error, _ in
 				loggerGlobal.error("Failed to save mnemonic as backed up")

--- a/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+Reducer.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+Reducer.swift
@@ -287,7 +287,7 @@ public struct ProfileBackupSettings: Sendable, FeatureReducer {
 		.run { send in
 			cacheClient.removeAll()
 			await radixConnectClient.disconnectAndRemoveAll()
-			await userDefaultsClient.removeAll()
+			userDefaultsClient.removeAll()
 			await send(.delegate(.deleteProfileAndFactorSources(keepInICloudIfPresent: keepInICloudIfPresent)))
 		}
 	}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
@@ -13,7 +13,10 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 
 		public init(entitiesControlledByFactorSource: EntitiesControlledByFactorSource) {
 			self.entitiesControlledByFactorSource = entitiesControlledByFactorSource
-			self.entities = .init(accountsForDeviceFactorSource: entitiesControlledByFactorSource, displayRevealMnemonicLink: false)
+			self.entities = .init(
+				accountsForDeviceFactorSource: entitiesControlledByFactorSource,
+				mode: .displayAccountListOnly
+			)
 		}
 	}
 

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
@@ -136,9 +136,9 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 		case let .validated(privateHDFactorSource):
 			state.destination = nil
 			return .run { send in
-				try await userDefaultsClient.addFactorSourceIDOfBackedUpMnemonic(privateHDFactorSource.factorSource.id)
+				try userDefaultsClient.addFactorSourceIDOfBackedUpMnemonic(privateHDFactorSource.factorSource.id)
 
-				try await secureStorageClient.saveMnemonicForFactorSource(
+				try secureStorageClient.saveMnemonicForFactorSource(
 					privateHDFactorSource
 				)
 

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator.swift
@@ -27,7 +27,10 @@ public struct ImportMnemonicsFlowCoordinator: Sendable, FeatureReducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.importMnemonicControllingAccounts, action: /Action.importMnemonicControllingAccounts) {
+			Scope(
+				state: /State.importMnemonicControllingAccounts,
+				action: /Action.importMnemonicControllingAccounts
+			) {
 				ImportMnemonicControllingAccounts()
 			}
 		}

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Children/DisplayMnemonic.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Children/DisplayMnemonic.swift
@@ -47,7 +47,7 @@ public struct DisplayMnemonic: Sendable, FeatureReducer {
 			.run { [deviceFactorSource = state.deviceFactorSource] send in
 				let factorSourceID = deviceFactorSource.id
 				let result = await TaskResult {
-					try await secureStorageClient.loadMnemonic(
+					try secureStorageClient.loadMnemonic(
 						factorSourceID: factorSourceID,
 						purpose: .displaySeedPhrase
 					)

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Children/DisplayMnemonic.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Children/DisplayMnemonic.swift
@@ -27,7 +27,7 @@ public struct DisplayMnemonic: Sendable, FeatureReducer {
 
 	public enum DelegateAction: Sendable, Equatable {
 		case failedToLoad
-		case doneViewing
+		case doneViewing(isBackedUp: Bool, factorSourceID: FactorSource.ID.FromHash)
 	}
 
 	@Dependency(\.secureStorageClient) var secureStorageClient
@@ -83,9 +83,17 @@ public struct DisplayMnemonic: Sendable, FeatureReducer {
 
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
-		case .importMnemonic(.delegate(.doneViewing)):
+		case let .importMnemonic(.delegate(.doneViewing(markedMnemonicAsBackedUp))):
+			let isBackedUp = markedMnemonicAsBackedUp ?? true
 			state.importMnemonic = nil
-			return .send(.delegate(.doneViewing))
+			return .send(
+				.delegate(
+					.doneViewing(
+						isBackedUp: isBackedUp,
+						factorSourceID: state.deviceFactorSource.id
+					)
+				)
+			)
 		default: return .none
 		}
 	}

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics+View.swift
@@ -69,7 +69,9 @@ extension View {
 			action: { .child(.destination($0)) }
 		)
 
-		return displayMnemonicSheet(with: destinationStore)
+		return self
+			.displayMnemonicSheet(with: destinationStore)
+			.importMnemonicsSheet(with: destinationStore)
 	}
 
 	@MainActor
@@ -79,6 +81,22 @@ extension View {
 			state: /DisplayMnemonics.Destinations.State.displayMnemonic,
 			action: DisplayMnemonics.Destinations.Action.displayMnemonic,
 			destination: { DisplayMnemonic.View(store: $0) }
+		)
+	}
+
+	@MainActor
+	private func importMnemonicsSheet(with destinationStore: PresentationStoreOf<DisplayMnemonics.Destinations>) -> some View {
+		navigationDestination(
+			store: destinationStore,
+			state: /DisplayMnemonics.Destinations.State.importMnemonicControllingAccounts,
+			action: DisplayMnemonics.Destinations.Action.importMnemonicControllingAccounts,
+			destination: { importStore in
+				NavigationView {
+					ImportMnemonicControllingAccounts.View(
+						store: importStore
+					)
+				}
+			}
 		)
 	}
 }

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics+View.swift
@@ -1,15 +1,8 @@
 import ComposableArchitecture
 import SwiftUI
-extension DisplayMnemonics.State {
-	var viewState: DisplayMnemonics.ViewState {
-		.init()
-	}
-}
 
 // MARK: - DisplayMnemonics.View
 extension DisplayMnemonics {
-	public struct ViewState: Equatable {}
-
 	@MainActor
 	public struct View: SwiftUI.View {
 		private let store: StoreOf<DisplayMnemonics>
@@ -19,7 +12,7 @@ extension DisplayMnemonics {
 		}
 
 		public var body: some SwiftUI.View {
-			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
+			WithViewStore(store, observe: { $0 }, send: { .view($0) }) { viewStore in
 				ScrollView {
 					VStack(alignment: .leading, spacing: .medium1) {
 						Text(L10n.SeedPhrases.message)

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
@@ -17,7 +17,7 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 	}
 
 	public enum InternalAction: Sendable, Equatable {
-		case loadedFactorSources(TaskResult<IdentifiedArrayOf<EntitiesControlledByFactorSource>>)
+		case loadedDeviceFactorSources(TaskResult<IdentifiedArrayOf<DisplayEntitiesControlledByMnemonic.State>>)
 	}
 
 	public enum ChildAction: Sendable, Equatable {
@@ -28,10 +28,12 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 	public struct Destinations: Sendable, Equatable, Reducer {
 		public enum State: Sendable, Hashable {
 			case displayMnemonic(DisplayMnemonic.State)
+			case importMnemonicControllingAccounts(ImportMnemonicControllingAccounts.State)
 		}
 
 		public enum Action: Sendable, Equatable {
 			case displayMnemonic(DisplayMnemonic.Action)
+			case importMnemonicControllingAccounts(ImportMnemonicControllingAccounts.Action)
 		}
 
 		public init() {}
@@ -40,11 +42,16 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 			Scope(state: /State.displayMnemonic, action: /Action.displayMnemonic) {
 				DisplayMnemonic()
 			}
+
+			Scope(state: /State.importMnemonicControllingAccounts, action: /Action.importMnemonicControllingAccounts) {
+				ImportMnemonicControllingAccounts()
+			}
 		}
 	}
 
 	@Dependency(\.errorQueue) var errorQueue
 	@Dependency(\.deviceFactorSourceClient) var deviceFactorSourceClient
+	@Dependency(\.keychainClient) var keychainClient
 
 	public init() {}
 
@@ -62,28 +69,32 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 		switch viewAction {
 		case .onFirstTask:
 			.run { send in
-				await send(.internal(.loadedFactorSources(TaskResult {
-					try await deviceFactorSourceClient.controlledEntities(nil) // `nil` means read profile in ProfileStore, instead of using an overriding
-				})))
+				let result = await TaskResult {
+					let entitiesForDeviceFactorSources = try await deviceFactorSourceClient.controlledEntities(
+						// `nil` means read profile in ProfileStore, instead of using an overriding
+						nil
+					)
+					let deviceFactorSources = entitiesForDeviceFactorSources.map {
+						DisplayEntitiesControlledByMnemonic.State(accountsForDeviceFactorSource: $0)
+					}
+					return deviceFactorSources.asIdentifiable()
+				}
+
+				await send(
+					.internal(.loadedDeviceFactorSources(result))
+				)
 			}
 		}
 	}
 
 	public func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
 		switch internalAction {
-		case let .loadedFactorSources(.success(entitiesForDeviceFactorSources)):
-			state.deviceFactorSources = .init(
-				uniqueElements: entitiesForDeviceFactorSources.map { .init(
-					accountsForDeviceFactorSource: $0,
-					displayRevealMnemonicLink: true
-				) },
-				id: \.id
-			)
-
+		case let .loadedDeviceFactorSources(.success(deviceFactorSources)):
+			state.deviceFactorSources = deviceFactorSources
 			return .none
 
-		case let .loadedFactorSources(.failure(error)):
-			loggerGlobal.error("Failed to load factor source, error: \(error)")
+		case let .loadedDeviceFactorSources(.failure(error)):
+			loggerGlobal.error("Failed to load device factor sources, error: \(error)")
 			errorQueue.schedule(error)
 			return .none
 		}
@@ -91,14 +102,24 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
-		case let .row(id, action: .delegate(.openDetails)):
-			guard let deviceFactorSource = state.deviceFactorSources[id: id]?.deviceFactorSource else {
+		case let .row(id, action: .delegate(delegateAction)):
+			guard let child = state.deviceFactorSources[id: id] else {
 				loggerGlobal.warning("Unable to find factor source in state... strange!")
 				return .none
 			}
-			// FIXME: Auto close after 2 minutes?
-			state.destination = .displayMnemonic(.init(deviceFactorSource: deviceFactorSource))
-			return .none
+			let deviceFactorSource = child.deviceFactorSource
+			switch delegateAction {
+			case .displayMnemonic:
+				// FIXME: Auto close after 2 minutes?
+				state.destination = .displayMnemonic(.init(deviceFactorSource: deviceFactorSource))
+				return .none
+			case .importMissingMnemonic:
+				state.destination = .importMnemonicControllingAccounts(.init(
+					entitiesControlledByFactorSource: child.accountsForDeviceFactorSource
+				))
+				return .none
+			}
+
 		case .destination(.presented(.displayMnemonic(.delegate(.failedToLoad)))):
 			state.destination = nil
 			return .none
@@ -106,6 +127,19 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 		case .destination(.presented(.displayMnemonic(.delegate(.doneViewing)))):
 			state.destination = nil
 			return .none
+
+		case let .destination(.presented(.importMnemonicControllingAccounts(.delegate(delegatAction)))):
+			state.destination = nil
+			switch delegatAction {
+			case let .skippedMnemonic(factorSourceIDHash):
+				return .none
+
+			case let .persistedMnemonicInKeychain(factorSourceID):
+				return .none
+
+			case .failedToSaveInKeychain:
+				return .none
+			}
 
 		default: return .none
 		}

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
@@ -71,11 +71,14 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 			.run { send in
 				let result = await TaskResult {
 					let entitiesForDeviceFactorSources = try await deviceFactorSourceClient.controlledEntities(
-						// `nil` means read profile in ProfileStore, instead of using an overriding
+						// `nil` means read profile in ProfileStore, instead of using an overriding profile
 						nil
 					)
 					let deviceFactorSources = entitiesForDeviceFactorSources.map {
-						DisplayEntitiesControlledByMnemonic.State(accountsForDeviceFactorSource: $0)
+						DisplayEntitiesControlledByMnemonic.State(
+							accountsForDeviceFactorSource: $0,
+							mode: $0.isMnemonicPresentInKeychain ? .mnemonicCanBeDisplayed : .mnemonicNeedsImport
+						)
 					}
 					return deviceFactorSources.asIdentifiable()
 				}
@@ -152,10 +155,10 @@ extension DisplayEntitiesControlledByMnemonic.State {
 	mutating func imported() {
 		self.accountsForDeviceFactorSource.isMnemonicPresentInKeychain = true
 		self.mode = .mnemonicCanBeDisplayed
-		self.promptUserToBackUpMnemonic = false
+		backedUp()
 	}
 
 	mutating func backedUp() {
-		self.promptUserToBackUpMnemonic = false
+		self.accountsForDeviceFactorSource.isMnemonicMarkedAsBackedUp = true
 	}
 }

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
@@ -128,20 +128,23 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 			state.destination = nil
 			return .none
 
-		case let .destination(.presented(.importMnemonicControllingAccounts(.delegate(delegatAction)))):
+		case let .destination(.presented(.importMnemonicControllingAccounts(.delegate(delegateAction)))):
 			state.destination = nil
-			switch delegatAction {
-			case let .skippedMnemonic(factorSourceIDHash):
-				return .none
 
+			switch delegateAction {
+			case .skippedMnemonic, .failedToSaveInKeychain: break
 			case let .persistedMnemonicInKeychain(factorSourceID):
-				return .none
-
-			case .failedToSaveInKeychain:
-				return .none
+				state.deviceFactorSources[id: factorSourceID]?.imported()
 			}
+			return .none
 
 		default: return .none
 		}
+	}
+}
+
+extension DisplayEntitiesControlledByMnemonic.State {
+	mutating func imported() {
+		self.mode = .mnemonicCanBeDisplayed
 	}
 }

--- a/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator.swift
+++ b/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator.swift
@@ -417,7 +417,7 @@ public struct ImportOlympiaWalletCoordinator: Sendable, FeatureReducer {
 			)
 
 			do {
-				try await userDefaultsClient.addFactorSourceIDOfBackedUpMnemonic(factorSourceID)
+				try userDefaultsClient.addFactorSourceIDOfBackedUpMnemonic(factorSourceID)
 			} catch {
 				// Not important enought to throw
 				loggerGlobal.warning("Failed to save mnemonic as backed up, error: \(error)")


### PR DESCRIPTION
This PR contains a fix for [ABW-2207](https://radixdlt.atlassian.net/browse/ABW-2207)

# Decription

This PR improves UX in `Seed Phrases` screen in settings, by doing two new things:
* Prompting user to backup not yet backed mnemonics
* Prompting user to RECOVER a missing mnemonic, rather than incorrectly say they can display it - which leads to bug https://rdxworks.slack.com/archives/C03QFAWBRNX/p1698151009996849

# Demo

## Back up prompt
https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/a349351d-670e-4b4f-a2ff-ae3c4f9c7297

## Recover prompt and flow
https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/c868094c-cca1-49af-9d82-df11d18563ef




[ABW-2207]: https://radixdlt.atlassian.net/browse/ABW-2207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ