### PR TITLE
Dont tell user mnemonic M is missing when they are about to import it...

### DIFF
--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
@@ -86,10 +86,10 @@ extension DeviceFactorSourceClient: DependencyKey {
 					guard
 						let deviceFactorSource,
 						let mnemonicWithPassphrase = try secureStorageClient
-						.loadMnemonicByFactorSourceID(
-							deviceFactorSource.id,
-							.checkingAccounts,
-							false
+						.loadMnemonic(
+							factorSourceID: deviceFactorSource.id,
+							purpose: .checkingAccounts,
+							notifyIfMissing: false
 						)
 					else {
 						// Failed to find mnemonic for factor source

--- a/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
+++ b/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
@@ -92,7 +92,8 @@ extension FactorSourcesClient: DependencyKey {
 						guard
 							let mnemonic = try secureStorageClient.loadMnemonic(
 								factorSourceID: factorSourceID,
-								purpose: .importOlympiaAccounts
+								purpose: .importOlympiaAccounts,
+								notifyIfMissing: false
 							)
 						else {
 							continue

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
@@ -95,9 +95,10 @@ extension SecureStorageClient {
 	@Sendable
 	public func loadMnemonic(
 		factorSourceID: FactorSourceID.FromHash,
-		purpose: LoadMnemonicPurpose
+		purpose: LoadMnemonicPurpose,
+		notifyIfMissing: Bool = true
 	) throws -> MnemonicWithPassphrase? {
-		try self.loadMnemonicByFactorSourceID(factorSourceID, purpose, true)
+		try self.loadMnemonicByFactorSourceID(factorSourceID, purpose, notifyIfMissing)
 	}
 
 	@Sendable

--- a/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
+++ b/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
@@ -13,9 +13,6 @@ public struct EntitiesControlledByFactorSource: Sendable, Hashable, Identifiable
 		isMnemonicPresentInKeychain: Bool,
 		isMnemonicMarkedAsBackedUp: Bool
 	) {
-		if isMnemonicMarkedAsBackedUp, !isMnemonicPresentInKeychain {
-			assertionFailure("Discrepancy, bad state, a keychain should not be missing and ALSO be marked as backed up. We probably have a missing sync logic between the states.")
-		}
 		self.entities = entities
 		self.deviceFactorSource = deviceFactorSource
 		self.isMnemonicPresentInKeychain = isMnemonicPresentInKeychain

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
@@ -6,6 +6,7 @@ extension ImportMnemonic.State {
 	var viewState: ImportMnemonic.ViewState {
 		var viewState = ImportMnemonic.ViewState(
 			readonlyMode: readonlyMode?.context,
+			isProgressing: isProgressing,
 			isWordCountFixed: isWordCountFixed,
 			isAdvancedMode: isAdvancedMode,
 			header: header,
@@ -35,6 +36,7 @@ extension ImportMnemonic {
 		}
 
 		let readonlyMode: ImportMnemonic.State.ReadonlyMode.Context?
+		let isProgressing: Bool // irrelevant for read only mode
 		let isWordCountFixed: Bool
 		let isAdvancedMode: Bool
 		let header: State.Header?
@@ -328,6 +330,7 @@ extension ImportMnemonic.View {
 				}
 				Button(L10n.ImportMnemonic.importSeedPhrase, action: action)
 					.buttonStyle(.primaryRectangular)
+					.controlState(viewStore.isProgressing ? .loading(.local) : .enabled)
 			} else {
 				Button(L10n.Common.done) {
 					viewStore.send(.doneViewing)

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
@@ -380,7 +380,6 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 			return .send(.delegate(.doneViewing(markedMnemonicAsBackedUp: false)))
 
 		case .destination(.presented(.onContinueWarning(.buttonTapped))):
-			state.destination = nil
 			guard let mnemonic = state.mnemonic else {
 				loggerGlobal.error("Can't read mnemonic")
 				struct FailedToReadMnemonic: Error {}

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
@@ -380,6 +380,7 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 			return .send(.delegate(.doneViewing(markedMnemonicAsBackedUp: false)))
 
 		case .destination(.presented(.onContinueWarning(.buttonTapped))):
+			state.destination = nil
 			guard let mnemonic = state.mnemonic else {
 				loggerGlobal.error("Can't read mnemonic")
 				struct FailedToReadMnemonic: Error {}
@@ -643,7 +644,9 @@ extension ImportMnemonic.Destinations.State {
 		))
 	}
 
-	fileprivate static func onContinueWarning(_ warning: ImportMnemonic.State.OnContinueWarning) -> Self {
+	fileprivate static func onContinueWarning(
+		_ warning: ImportMnemonic.State.OnContinueWarning
+	) -> Self {
 		.onContinueWarning(.init(
 			title: { TextState(warning.title) },
 			actions: {

--- a/RadixWallet/Features/SplashFeature/Splash.swift
+++ b/RadixWallet/Features/SplashFeature/Splash.swift
@@ -29,7 +29,7 @@ public struct Splash: Sendable, FeatureReducer {
 
 	public enum InternalAction: Sendable, Equatable {
 		case passcodeConfigResult(TaskResult<LocalAuthenticationConfig>)
-		case loadProfile(Profile)
+		case loadedProfile(Profile)
 		case accountRecoveryNeeded(TaskResult<Bool>)
 	}
 
@@ -103,11 +103,15 @@ public struct Splash: Sendable, FeatureReducer {
 			}
 
 			return .run { send in
-				await send(.internal(.loadProfile(onboardingClient.loadProfile())))
+				await send(.internal(.loadedProfile(onboardingClient.loadProfile())))
 			}
 
-		case .loadProfile:
-			return checkAccountRecoveryNeeded()
+		case let .loadedProfile(profile):
+			if profile.networks.isEmpty {
+				return delegateCompleted(accountRecoveryNeeded: false)
+			} else {
+				return checkAccountRecoveryNeeded()
+			}
 
 		case let .accountRecoveryNeeded(.failure(error)):
 			state.biometricsCheckFailed = true


### PR DESCRIPTION
# Description
We have a bug where the "Could Not Complete" _missing mnemonic_  alert is shown when user is importing an Olympia Wallet with mnemonic.

# Changes
* This PR changes to `notifyIfMissing: false` when we are checking if Olympia Mnemonic already exists.
* Adds a loading indicator in the `Import` button in ImportMnemonic feature which disabled the button and shows loader while the mnemonic is being imported
* Small infra improvement, prevent showing confusing error due to account recovery check being done on empty profile

## BEFORE (bug)
https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/84336205-b374-4da7-85c9-ace84626ec62

## AFTER (also added loader)

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/74f7d17d-c20e-4f64-bbc0-999b58e6d36f

