### PR TITLE
[ABW-2557] Clean up strings

### DIFF
--- a/RadixWallet/Features/AssetsFeature/Components/HelperViews/AssetResourceDetails.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/HelperViews/AssetResourceDetails.swift
@@ -20,15 +20,17 @@ struct AssetResourceDetailsSection: View {
 		VStack(alignment: .leading, spacing: .medium1) {
 			AssetDetailsSeparator()
 
-			loadable(viewState.description,
-			         successContent: { description in
-			         	Text(description ?? "unknown")
-			         		.textStyle(.body1Regular)
-			         		.frame(maxWidth: .infinity, alignment: .leading)
-			         })
-			         .padding(.horizontal, .large2)
+			loadable(viewState.description) { description in
+				if let description {
+					Text(description)
+						.textStyle(.body1Regular)
+						.flushedLeft
 
-			AssetDetailsSeparator()
+					AssetDetailsSeparator()
+						.padding(.horizontal, -.large2)
+				}
+			}
+			.padding(.horizontal, .large2)
 
 			VStack(alignment: .leading, spacing: .medium3) {
 				KeyValueView(resourceAddress: viewState.resourceAddress)

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/AdvancedFeesCustomization+View.swift
@@ -46,7 +46,7 @@ extension AdvancedFeesCustomization {
 					Group {
 						Divider()
 						AppTextField(
-							primaryHeading: .init(text: L10n.TransactionReview.CustomizeNetworkFeeSheet.paddingFieldLabel),
+							primaryHeading: .init(text: L10n.CustomizeNetworkFees.paddingFieldLabel),
 							placeholder: "",
 							text: viewStore.binding(
 								get: \.paddingAmount,
@@ -66,8 +66,8 @@ extension AdvancedFeesCustomization {
 						.padding(.vertical, .medium1)
 
 						AppTextField(
-							primaryHeading: .init(text: L10n.TransactionReview.CustomizeNetworkFeeSheet.tipFieldLabel),
-							subHeading: L10n.TransactionReview.CustomizeNetworkFeeSheet.tipFieldInfo,
+							primaryHeading: .init(text: L10n.CustomizeNetworkFees.tipFieldLabel),
+							subHeading: L10n.CustomizeNetworkFees.tipFieldInfo,
 							placeholder: "",
 							text: viewStore.binding(
 								get: \.tipPercentage,

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
@@ -8,39 +8,39 @@ extension CustomizeFees.State {
 			title: {
 				switch transactionFee.mode {
 				case .normal:
-					L10n.TransactionReview.CustomizeNetworkFeeSheet.NormalMode.title
+					L10n.CustomizeNetworkFees.NormalMode.title
 				case .advanced:
-					L10n.TransactionReview.CustomizeNetworkFeeSheet.AdvancedMode.title
+					L10n.CustomizeNetworkFees.AdvancedMode.title
 				}
 			}(),
 			description: {
 				switch transactionFee.mode {
 				case .normal:
-					L10n.TransactionReview.CustomizeNetworkFeeSheet.NormalMode.subtitle
+					L10n.CustomizeNetworkFees.NormalMode.subtitle
 				case .advanced:
-					L10n.TransactionReview.CustomizeNetworkFeeSheet.AdvancedMode.subtitle
+					L10n.CustomizeNetworkFees.AdvancedMode.subtitle
 				}
 			}(),
 			modeSwitchTitle: {
 				switch transactionFee.mode {
 				case .normal:
-					L10n.TransactionReview.CustomizeNetworkFeeSheet.viewAdvancedModeButtonTitle
+					L10n.CustomizeNetworkFees.viewAdvancedModeButtonTitle
 				case .advanced:
-					L10n.TransactionReview.CustomizeNetworkFeeSheet.viewNormalModeButtonTitle
+					L10n.CustomizeNetworkFees.viewNormalModeButtonTitle
 				}
 			}(),
 			feePayer: feePayerSelection.selected,
 			noFeePayerText: {
 				if transactionFee.totalFee.lockFee == .zero {
-					L10n.TransactionReview.CustomizeNetworkFeeSheet.noneRequired
+					L10n.CustomizeNetworkFees.noneRequired
 				} else {
-					L10n.TransactionReview.CustomizeNetworkFeeSheet.noAccountSelected
+					L10n.CustomizeNetworkFees.noAccountSelected
 				}
 			}(),
 			insufficientBalanceMessage: {
 				if let feePayer = feePayerSelection.selected {
 					if feePayer.xrdBalance < transactionFee.totalFee.lockFee {
-						return L10n.TransactionReview.CustomizeNetworkFeeSheet.InsufficientBalance.warning
+						return L10n.CustomizeNetworkFees.Warning.insufficientBalance
 					}
 				}
 				return nil
@@ -144,13 +144,13 @@ extension CustomizeFees {
 		func feePayerView(_ viewStore: ViewStoreOf<CustomizeFees>) -> some SwiftUI.View {
 			VStack(alignment: .leading) {
 				HStack {
-					Text(L10n.TransactionReview.CustomizeNetworkFeeSheet.payFeeFrom)
+					Text(L10n.CustomizeNetworkFees.payFeeFrom)
 						.textStyle(.body1Link)
 						.foregroundColor(.app.gray2)
 						.textCase(.uppercase)
 
 					Spacer()
-					Button(L10n.TransactionReview.CustomizeNetworkFeeSheet.changeButtonTitle) {
+					Button(L10n.CustomizeNetworkFees.changeButtonTitle) {
 						viewStore.send(.changeFeePayerTapped)
 					}
 					.textStyle(.body1StandaloneLink)

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/FeesView.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/FeesView.swift
@@ -14,7 +14,7 @@ struct FeesView: View {
 	var body: some View {
 		VStack(spacing: .small1) {
 			HStack {
-				Text(L10n.TransactionReview.CustomizeNetworkFeeSheet.feeBreakdownTitle)
+				Text(L10n.CustomizeNetworkFees.feeBreakdownTitle)
 					.textStyle(.body1Link)
 					.foregroundColor(.app.gray2)
 					.textCase(.uppercase)
@@ -40,12 +40,12 @@ struct FeesView: View {
 	func transactionFeeView(fee: String, isAdvancedMode: Bool) -> some SwiftUI.View {
 		HStack {
 			VStack(spacing: .zero) {
-				Text(L10n.TransactionReview.CustomizeNetworkFeeSheet.totalFee)
+				Text(L10n.CustomizeNetworkFees.totalFee)
 					.textStyle(.body1Link)
 					.foregroundColor(.app.gray2)
 					.textCase(.uppercase)
 				if isAdvancedMode {
-					Text(L10n.TransactionReview.CustomizeNetworkFeeSheet.TotalFee.info)
+					Text(L10n.CustomizeNetworkFees.TotalFee.info)
 						.textStyle(.body1Link)
 						.foregroundColor(.app.gray2)
 				}
@@ -90,29 +90,29 @@ extension TransactionFee.AdvancedFeeCustomization {
 	var viewStates: IdentifiedArrayOf<FeeViewState> {
 		var displayedFees = IdentifiedArrayOf<FeeViewState>(uncheckedUniqueElements: [
 			.init(
-				name: L10n.TransactionReview.CustomizeNetworkFeeSheet.networkExecution,
+				name: L10n.CustomizeNetworkFees.networkExecution,
 				amount: feeSummary.totalExecutionCost
 			),
 			.init(
-				name: L10n.TransactionReview.CustomizeNetworkFeeSheet.networkFinalization,
+				name: L10n.CustomizeNetworkFees.networkFinalization,
 				amount: feeSummary.finalizationCost
 			),
 			.init(
-				name: L10n.TransactionReview.CustomizeNetworkFeeSheet.effectiveTip,
+				name: L10n.CustomizeNetworkFees.effectiveTip,
 				amount: tipAmount,
 				isUserConfigurable: true
 			),
 			.init(
-				name: L10n.TransactionReview.CustomizeNetworkFeeSheet.networkStorage,
+				name: L10n.CustomizeNetworkFees.networkStorage,
 				amount: feeSummary.storageExpansionCost
 			),
 			.init(
-				name: L10n.TransactionReview.CustomizeNetworkFeeSheet.padding,
+				name: L10n.CustomizeNetworkFees.padding,
 				amount: paddingFee,
 				isUserConfigurable: true
 			),
 			.init(
-				name: L10n.TransactionReview.CustomizeNetworkFeeSheet.royalties,
+				name: L10n.CustomizeNetworkFees.royalties,
 				amount: feeSummary.royaltyCost
 			),
 		])
@@ -120,7 +120,7 @@ extension TransactionFee.AdvancedFeeCustomization {
 		if paidByDapps > .zero {
 			displayedFees.append(
 				.init(
-					name: L10n.TransactionReview.CustomizeNetworkFeeSheet.paidByDApps,
+					name: L10n.CustomizeNetworkFees.paidByDApps,
 					amount: paidByDapps
 				)
 			)
@@ -133,11 +133,11 @@ extension TransactionFee.NormalFeeCustomization {
 	var viewStates: IdentifiedArrayOf<FeeViewState> {
 		.init(uncheckedUniqueElements: [
 			.init(
-				name: L10n.TransactionReview.CustomizeNetworkFeeSheet.networkFee,
+				name: L10n.CustomizeNetworkFees.networkFee,
 				amount: networkFee
 			),
 			.init(
-				name: L10n.TransactionReview.CustomizeNetworkFeeSheet.royaltyFee,
+				name: L10n.CustomizeNetworkFees.royaltyFee,
 				amount: royaltyFee
 			),
 		])
@@ -147,7 +147,7 @@ extension TransactionFee.NormalFeeCustomization {
 extension RETDecimal {
 	func formatted(showsZero: Bool) -> String {
 		if !showsZero, isZero() {
-			return L10n.TransactionReview.CustomizeNetworkFeeSheet.noneDue
+			return L10n.CustomizeNetworkFees.noneDue
 		}
 		return L10n.TransactionReview.xrdAmount(formatted())
 	}

--- a/RadixWallet/Features/TransactionReviewFeature/SelectFeePayer/SelectFeePayer+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SelectFeePayer/SelectFeePayer+View.swift
@@ -29,7 +29,7 @@ extension SelectFeePayer {
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
 				VStack {
-					Text(L10n.TransactionReview.CustomizeNetworkFeeSheet.SelectFeePayer.navigationTitle)
+					Text(L10n.CustomizeNetworkFees.SelectFeePayer.navigationTitle)
 						.multilineTextAlignment(.center)
 						.textStyle(.sheetTitle)
 						.foregroundColor(.app.gray1)
@@ -37,7 +37,7 @@ extension SelectFeePayer {
 						.padding(.horizontal, .medium1)
 						.padding(.bottom, .small2)
 
-					Text(L10n.TransactionReview.CustomizeNetworkFeeSheet.SelectFeePayer.subtitle(viewStore.fee))
+					Text(L10n.CustomizeNetworkFees.SelectFeePayer.subtitle(viewStore.fee))
 						.multilineTextAlignment(.center)
 						.textStyle(.body1HighImportance)
 						.foregroundColor(.app.gray2)
@@ -69,7 +69,7 @@ extension SelectFeePayer {
 						viewStore.selectedPayer,
 						forAction: { viewStore.send(.confirmedFeePayer($0)) }
 					) { action in
-						Button(L10n.TransactionReview.CustomizeNetworkFeeSheet.SelectFeePayer.selectAccountButtonTitle, action: action)
+						Button(L10n.CustomizeNetworkFees.SelectFeePayer.selectAccountButtonTitle, action: action)
 							.buttonStyle(.primaryRectangular)
 					}
 				}

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
@@ -14,13 +14,13 @@ extension SubmitTransaction.State.TXStatus {
 	var display: String {
 		switch self {
 		case .failed:
-			L10n.Transaction.Status.Failed.text
+			L10n.TransactionStatus.Failed.text
 		case .permanentlyRejected:
-			L10n.Transaction.Status.Rejected.text
+			L10n.TransactionStatus.Rejected.text
 		case let .temporarilyRejected(processingTime):
-			L10n.Transaction.Status.Error.text(processingTime)
+			L10n.TransactionStatus.Error.text(processingTime)
 		case .notYetSubmitted, .submitting, .submitted:
-			L10n.Transaction.Status.Completing.text
+			L10n.TransactionStatus.Completing.text
 		case .committedSuccessfully:
 			""
 		}
@@ -53,7 +53,7 @@ extension SubmitTransaction {
 					VStack(spacing: .medium2) {
 						if viewStore.status.failed {
 							Image(asset: AssetResource.warningError)
-							Text(L10n.Transaction.Status.Failure.title)
+							Text(L10n.TransactionStatus.Failure.title)
 								.foregroundColor(.app.gray1)
 								.textStyle(.sheetTitle)
 								.multilineTextAlignment(.center)

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
@@ -90,13 +90,13 @@ public struct SubmitTransaction: Sendable, FeatureReducer {
 			if state.status.isInProgress {
 				if state.inProgressDismissalDisabled {
 					state.dismissTransactionAlert = .init(
-						title: .init(L10n.Transaction.Status.DismissalDisabledDialog.title),
-						message: .init(L10n.Transaction.Status.DismissalDisabledDialog.text)
+						title: .init(L10n.TransactionStatus.DismissalDisabledDialog.title),
+						message: .init(L10n.TransactionStatus.DismissalDisabledDialog.text)
 					)
 				} else {
 					state.dismissTransactionAlert = .init(
 						title: .init(""),
-						message: TextState(L10n.Transaction.Status.Dismiss.Dialog.message),
+						message: TextState(L10n.TransactionStatus.DismissDialog.message),
 						primaryButton: .destructive(.init(L10n.Common.confirm), action: .send(.confirm)),
 						secondaryButton: .cancel(.init(L10n.Common.cancel), action: .send(.cancel))
 					)


### PR DESCRIPTION
Jira ticket: [ABW-2557](https://radixdlt.atlassian.net/browse/ABW-2557)

Requires _Clean up strings_ [#227](https://github.com/radixdlt/apps-localization-src/pull/227) and the wallet PR it spawns to be merged first.

## Description
- Removes unused strings
- Removes strings that have duplicates
- Only use **assetDetails_behaviors_x** for all behaviors
- Removes **depositGuarantees.json**
- Removes **importProfile.json**
- Adds **customizeNetworkFees.json** (replacing **transactionReview_customizeNetworkFeeSheet_x**)
- Moves **transaction_status** to **transactionStatus**

## How to test
This should not change anything, so please check that the moved strings still work. The removed strings were not used to begin with, so there is nothing to check there - the project wouldn't build if they were in use.

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works


[ABW-2557]: https://radixdlt.atlassian.net/browse/ABW-2557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ