### PR TITLE
Account hiding crash fix

### DIFF
--- a/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+Reducer.swift
+++ b/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+Reducer.swift
@@ -232,7 +232,6 @@ public struct AccountDetails: Sendable, FeatureReducer {
 			}
 
 		case .destination(.presented(.preferences(.delegate(.accountHidden)))):
-			state.destination = nil
 			return .send(.delegate(.dismiss))
 
 		case .destination(.dismiss):

--- a/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+Reducer.swift
@@ -182,7 +182,6 @@ extension AccountPreferences {
 		case .devPreferences:
 			return .none
 		case let .confirmHideAccount(action):
-			state.destinations = nil
 			switch action {
 			case .confirmTapped:
 				return .run { [account = state.account] send in

--- a/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
@@ -22,58 +22,55 @@ extension Home {
 
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
-				NavigationStack {
-					ScrollView {
-						VStack(spacing: .medium1) {
-							Header.View(
-								store: store.scope(
-									state: \.header,
-									action: { .child(.header($0)) }
-								)
+				ScrollView {
+					VStack(spacing: .medium1) {
+						Header.View(
+							store: store.scope(
+								state: \.header,
+								action: { .child(.header($0)) }
 							)
+						)
 
-							AccountList.View(
-								store: store.scope(
-									state: \.accountList,
-									action: { .child(.accountList($0)) }
-								)
+						AccountList.View(
+							store: store.scope(
+								state: \.accountList,
+								action: { .child(.accountList($0)) }
 							)
-							.padding(.horizontal, .medium1)
+						)
+						.padding(.horizontal, .medium1)
 
-							Button(L10n.HomePage.createNewAccount) {
-								viewStore.send(.createAccountButtonTapped)
-							}
-							.buttonStyle(.secondaryRectangular())
+						Button(L10n.HomePage.createNewAccount) {
+							viewStore.send(.createAccountButtonTapped)
 						}
-						.padding(.bottom, .medium1)
+						.buttonStyle(.secondaryRectangular())
 					}
-					.toolbar {
-						ToolbarItem(placement: .navigationBarTrailing) {
-							SettingsButton(shouldShowNotification: viewStore.hasNotification) {
-								viewStore.send(.settingsButtonTapped)
-							}
-						}
-					}
-					.refreshable {
-						await viewStore.send(.pullToRefreshStarted).finish()
-					}
-					.task { @MainActor in
-						await viewStore.send(.task).finish()
-					}
-					.navigationDestination(
-						store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-						state: /Home.Destinations.State.accountDetails,
-						action: Home.Destinations.Action.accountDetails,
-						destination: { AccountDetails.View(store: $0) }
-					)
-					.sheet(
-						store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-						state: /Home.Destinations.State.createAccount,
-						action: Home.Destinations.Action.createAccount,
-						content: { CreateAccountCoordinator.View(store: $0) }
-					)
+					.padding(.bottom, .medium1)
 				}
-				.navigationTransition(.default, interactivity: .pan)
+				.toolbar {
+					ToolbarItem(placement: .navigationBarTrailing) {
+						SettingsButton(shouldShowNotification: viewStore.hasNotification) {
+							viewStore.send(.settingsButtonTapped)
+						}
+					}
+				}
+				.refreshable {
+					await viewStore.send(.pullToRefreshStarted).finish()
+				}
+				.task { @MainActor in
+					await viewStore.send(.task).finish()
+				}
+				.navigationDestination(
+					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+					state: /Home.Destinations.State.accountDetails,
+					action: Home.Destinations.Action.accountDetails,
+					destination: { AccountDetails.View(store: $0) }
+				)
+				.sheet(
+					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+					state: /Home.Destinations.State.createAccount,
+					action: Home.Destinations.Action.createAccount,
+					content: { CreateAccountCoordinator.View(store: $0) }
+				)
 			}
 		}
 

--- a/RadixWallet/Features/MainFeature/Main+View.swift
+++ b/RadixWallet/Features/MainFeature/Main+View.swift
@@ -25,9 +25,6 @@ extension Main {
 						action: { .child(.home($0)) }
 					)
 				)
-				.navigationBarBackButtonFont(.app.backButton)
-				.navigationBarInlineTitleFont(.app.secondaryHeader)
-				.navigationBarTitleColor(.app.gray1)
 				.navigationDestination(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
 					state: /Main.Destinations.State.settings,


### PR DESCRIPTION
Jira ticket:

## Description
Alternative fix for hide account crash.

Tradeoffs:
- Can't edge swipe to go back from Account Details view
- Account Details title sometimes starts out black, before turning white
- Account Details back button and ellipsis are hidden when going back TO Account Details, until view is completely visible.

Note that the first three commits are not strictly necessary, but they do remove superfluous code that is related to the navigation stack.

## How to test
Try to provoke a crash by hiding accounts
-> It should not crash

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/f92c7c15-ff80-4ff0-aedd-427c3e2100d2


## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
