### PR TITLE
Improve type checking everywhere

### DIFF
--- a/RadixWallet/Clients/AccountsClient/AccountsClient+Test.swift
+++ b/RadixWallet/Clients/AccountsClient/AccountsClient+Test.swift
@@ -8,20 +8,8 @@ extension DependencyValues {
 
 // MARK: - AccountsClient + TestDependencyKey
 extension AccountsClient: TestDependencyKey {
-	public static let noop = Self(
-		getCurrentNetworkID: { .kisharnet },
-		nextAccountIndex: { _ in 0 },
-		getAccountsOnCurrentNetwork: { throw NoopError() },
-		accountsOnCurrentNetwork: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
-		accountUpdates: { _ in AsyncLazySequence([]).eraseToAnyAsyncSequence() },
-		getAccountsOnNetwork: { _ in throw NoopError() },
-		newVirtualAccount: { _ in throw NoopError() },
-		saveVirtualAccounts: { _ in },
-		getAccountByAddress: { _ in throw NoopError() },
-		hasAccountOnNetwork: { _ in false },
-		updateAccount: { _ in }
-	)
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
+
 	public static let testValue = Self(
 		getCurrentNetworkID: unimplemented("\(Self.self).getCurrentNetworkID"),
 		nextAccountIndex: unimplemented("\(Self.self).nextAccountIndex"),
@@ -34,5 +22,19 @@ extension AccountsClient: TestDependencyKey {
 		getAccountByAddress: unimplemented("\(Self.self).getAccountByAddress"),
 		hasAccountOnNetwork: unimplemented("\(Self.self).hasAccountOnNetwork"),
 		updateAccount: unimplemented("\(Self.self).updateAccount")
+	)
+
+	public static let noop = Self(
+		getCurrentNetworkID: { .kisharnet },
+		nextAccountIndex: { _ in 0 },
+		getAccountsOnCurrentNetwork: { throw NoopError() },
+		accountsOnCurrentNetwork: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
+		accountUpdates: { _ in AsyncLazySequence([]).eraseToAnyAsyncSequence() },
+		getAccountsOnNetwork: { _ in throw NoopError() },
+		newVirtualAccount: { _ in throw NoopError() },
+		saveVirtualAccounts: { _ in },
+		getAccountByAddress: { _ in throw NoopError() },
+		hasAccountOnNetwork: { _ in false },
+		updateAccount: { _ in }
 	)
 }

--- a/RadixWallet/Clients/AuthorizedDappsClient/AuthorizedDappsClient+Test.swift
+++ b/RadixWallet/Clients/AuthorizedDappsClient/AuthorizedDappsClient+Test.swift
@@ -8,17 +8,7 @@ extension DependencyValues {
 
 // MARK: - AuthorizedDappsClient + TestDependencyKey
 extension AuthorizedDappsClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
-
-	public static let noop = Self(
-		getAuthorizedDapps: { [] },
-		addAuthorizedDapp: { _ in },
-		forgetAuthorizedDapp: { _, _ in },
-		updateAuthorizedDapp: { _ in },
-		updateOrAddAuthorizedDapp: { _ in },
-		deauthorizePersonaFromDapp: { _, _, _ in },
-		detailsForAuthorizedDapp: { _ in throw NoopError() }
-	)
+	public static let previewValue = Self.noop
 
 	public static let testValue = Self(
 		getAuthorizedDapps: unimplemented("\(Self.self).getAuthorizedDapps"),
@@ -28,5 +18,15 @@ extension AuthorizedDappsClient: TestDependencyKey {
 		updateOrAddAuthorizedDapp: unimplemented("\(Self.self).updateOrAddAuthorizedDapp"),
 		deauthorizePersonaFromDapp: unimplemented("\(Self.self).deauthorizePersonaFromDapp"),
 		detailsForAuthorizedDapp: unimplemented("\(Self.self).detailsForAuthorizedDapp")
+	)
+
+	public static let noop = Self(
+		getAuthorizedDapps: { [] },
+		addAuthorizedDapp: { _ in },
+		forgetAuthorizedDapp: { _, _ in },
+		updateAuthorizedDapp: { _ in },
+		updateOrAddAuthorizedDapp: { _ in },
+		deauthorizePersonaFromDapp: { _, _, _ in },
+		detailsForAuthorizedDapp: { _ in throw NoopError() }
 	)
 }

--- a/RadixWallet/Clients/BackupsClient/BackupsClient+Test.swift
+++ b/RadixWallet/Clients/BackupsClient/BackupsClient+Test.swift
@@ -8,7 +8,8 @@ extension DependencyValues {
 
 // MARK: - BackupsClient + TestDependencyKey
 extension BackupsClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
+
 	public static let testValue = Self(
 		snapshotOfProfileForExport: unimplemented("\(Self.self).snapshotOfProfileForExport"),
 		loadProfileBackups: unimplemented("\(Self.self).loadProfile"),

--- a/RadixWallet/Clients/DappInteractionClient/DappInteractionClient+Test.swift
+++ b/RadixWallet/Clients/DappInteractionClient/DappInteractionClient+Test.swift
@@ -8,15 +8,17 @@ extension DependencyValues {
 
 // MARK: - DappInteractionClient + TestDependencyKey
 extension DappInteractionClient: TestDependencyKey {
-	public static let noop = Self(
-		interactions: AsyncLazySequence([]).eraseToAnyAsyncSequence(),
-		addWalletInteraction: { _, _ in .none },
-		completeInteraction: { _ in }
-	)
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
+
 	public static let testValue = Self(
 		interactions: unimplemented("\(Self.self).requests"),
 		addWalletInteraction: unimplemented("\(Self.self).addWalletRequest"),
 		completeInteraction: unimplemented("\(Self.self).sendResponse")
+	)
+
+	public static let noop = Self(
+		interactions: AsyncLazySequence([]).eraseToAnyAsyncSequence(),
+		addWalletInteraction: { _, _ in .none },
+		completeInteraction: { _ in }
 	)
 }

--- a/RadixWallet/Clients/EntitiesVisibilityClient/EntitiesVisibilityClient+Test.swift
+++ b/RadixWallet/Clients/EntitiesVisibilityClient/EntitiesVisibilityClient+Test.swift
@@ -7,13 +7,15 @@ extension DependencyValues {
 
 // MARK: - EntitiesVisibilityClient + TestDependencyKey
 extension EntitiesVisibilityClient: TestDependencyKey {
+	public static let previewValue = Self.noop
+
 	public static let noop = Self(
 		hideAccount: { _ in throw NoopError() },
 		hidePersona: { _ in throw NoopError() },
 		unhideAllEntities: { throw NoopError() },
 		getHiddenEntityCounts: { throw NoopError() }
 	)
-	public static let previewValue: Self = .noop
+
 	public static let testValue = Self(
 		hideAccount: unimplemented("\(Self.self).hideAccount"),
 		hidePersona: unimplemented("\(Self.self).hidePersona"),

--- a/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Test.swift
+++ b/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Test.swift
@@ -8,7 +8,8 @@ extension DependencyValues {
 
 // MARK: - FactorSourcesClient + TestDependencyKey
 extension FactorSourcesClient: TestDependencyKey {
-	public static let previewValue: Self = noop
+	public static let previewValue = Self.noop
+
 	public static let testValue = Self(
 		getCurrentNetworkID: unimplemented("\(Self.self).getCurrentNetworkID"),
 		getFactorSources: unimplemented("\(Self.self).getFactorSources"),

--- a/RadixWallet/Clients/GatewaysClient/GatewaysClient+Test.swift
+++ b/RadixWallet/Clients/GatewaysClient/GatewaysClient+Test.swift
@@ -8,17 +8,7 @@ extension DependencyValues {
 
 // MARK: - GatewaysClient + TestDependencyKey
 extension GatewaysClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
-
-	public static let noop = Self(
-		currentGatewayValues: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
-		gatewaysValues: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
-		getAllGateways: { .init(rawValue: .init(uniqueElements: [.nebunet]))! },
-		getCurrentGateway: { .nebunet },
-		addGateway: { _ in },
-		removeGateway: { _ in },
-		changeGateway: { _ in }
-	)
+	public static let previewValue = Self.noop
 
 	public static let testValue = Self(
 		currentGatewayValues: unimplemented("\(Self.self).currentGatewayValues"),
@@ -28,5 +18,15 @@ extension GatewaysClient: TestDependencyKey {
 		addGateway: unimplemented("\(Self.self).addGateway"),
 		removeGateway: unimplemented("\(Self.self).removeGateway"),
 		changeGateway: unimplemented("\(Self.self).changeGateway")
+	)
+
+	public static let noop = Self(
+		currentGatewayValues: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
+		gatewaysValues: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
+		getAllGateways: { .init(rawValue: .init(uniqueElements: [.nebunet]))! },
+		getCurrentGateway: { .nebunet },
+		addGateway: { _ in },
+		removeGateway: { _ in },
+		changeGateway: { _ in }
 	)
 }

--- a/RadixWallet/Clients/KeychainClient/KeychainClient+Mocked.swift
+++ b/RadixWallet/Clients/KeychainClient/KeychainClient+Mocked.swift
@@ -8,6 +8,8 @@ extension DependencyValues {
 
 // MARK: - KeychainClient + TestDependencyKey
 extension KeychainClient: TestDependencyKey {
+	public static let previewValue = Self.noop
+
 	public static var testValue = Self(
 		getServiceAndAccessGroup: unimplemented("\(Self.self).getServiceAndAccessGroup"),
 		containsDataForKey: unimplemented("\(Self.self).containsDataForKey"),
@@ -33,6 +35,4 @@ extension KeychainClient: TestDependencyKey {
 		removeDataForKey: { _ in throw NoopError() },
 		removeAllItems: {}
 	)
-
-	public static let previewValue: Self = .noop
 }

--- a/RadixWallet/Clients/LedgerHardwareWalletClient/LedgerHardwareWalletClient+Test.swift
+++ b/RadixWallet/Clients/LedgerHardwareWalletClient/LedgerHardwareWalletClient+Test.swift
@@ -8,7 +8,16 @@ extension DependencyValues {
 
 // MARK: - LedgerHardwareWalletClient + TestDependencyKey
 extension LedgerHardwareWalletClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
+
+	public static let testValue = Self(
+		isConnectedToAnyConnectorExtension: unimplemented("\(Self.self).isConnectedToAnyConnectorExtension"),
+		getDeviceInfo: unimplemented("\(Self.self).getDeviceInfo"),
+		derivePublicKeys: unimplemented("\(Self.self).derivePublicKeys"),
+		signTransaction: unimplemented("\(Self.self).signTransaction"),
+		signAuthChallenge: unimplemented("\(Self.self).signAuthChallenge"),
+		deriveAndDisplayAddress: unimplemented("\(Self.self).deriveAndDisplayAddress")
+	)
 
 	public static let noop = Self(
 		isConnectedToAnyConnectorExtension: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
@@ -24,14 +33,5 @@ extension LedgerHardwareWalletClient: TestDependencyKey {
 		signTransaction: { _ in [] },
 		signAuthChallenge: { _ in [] },
 		deriveAndDisplayAddress: { _, _ in throw NoopError() }
-	)
-
-	public static let testValue = Self(
-		isConnectedToAnyConnectorExtension: unimplemented("\(Self.self).isConnectedToAnyConnectorExtension"),
-		getDeviceInfo: unimplemented("\(Self.self).getDeviceInfo"),
-		derivePublicKeys: unimplemented("\(Self.self).derivePublicKeys"),
-		signTransaction: unimplemented("\(Self.self).signTransaction"),
-		signAuthChallenge: unimplemented("\(Self.self).signAuthChallenge"),
-		deriveAndDisplayAddress: unimplemented("\(Self.self).deriveAndDisplayAddress")
 	)
 }

--- a/RadixWallet/Clients/MnemonicClient/MnemonicClient+Test.swift
+++ b/RadixWallet/Clients/MnemonicClient/MnemonicClient+Test.swift
@@ -8,17 +8,17 @@ extension DependencyValues {
 
 // MARK: - MnemonicClient + TestDependencyKey
 extension MnemonicClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
-
-	public static let noop = Self(
-		generate: { _, _ in throw NoopError() },
-		import: { _, _ in throw NoopError() },
-		lookup: { _ in .unknown(.tooShort) }
-	)
+	public static let previewValue = Self.noop
 
 	public static let testValue = Self(
 		generate: unimplemented("\(Self.self).generate"),
 		import: unimplemented("\(Self.self).import"),
 		lookup: unimplemented("\(Self.self).lookup")
+	)
+
+	public static let noop = Self(
+		generate: { _, _ in throw NoopError() },
+		import: { _, _ in throw NoopError() },
+		lookup: { _ in .unknown(.tooShort) }
 	)
 }

--- a/RadixWallet/Clients/NetworkSwitchingClient/NetworkSwitchingClient+Test.swift
+++ b/RadixWallet/Clients/NetworkSwitchingClient/NetworkSwitchingClient+Test.swift
@@ -1,7 +1,7 @@
 
 #if DEBUG
 extension NetworkSwitchingClient: TestDependencyKey {
-	public static let testValue: Self = .init(
+	public static let testValue = Self(
 		validateGatewayURL: unimplemented("\(Self.self).validateGatewayURL"),
 		hasAccountOnNetwork: unimplemented("\(Self.self).hasAccountOnNetwork"),
 		switchTo: unimplemented("\(Self.self).switchTo")

--- a/RadixWallet/Clients/OnboardingClient/OnboardingClient+Test.swift
+++ b/RadixWallet/Clients/OnboardingClient/OnboardingClient+Test.swift
@@ -8,7 +8,8 @@ extension DependencyValues {
 
 // MARK: - OnboardingClient + TestDependencyKey
 extension OnboardingClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
+
 	public static let testValue = Self(
 		unlockApp: unimplemented("\(Self.self).unlockApp"),
 		loadProfile: unimplemented("\(Self.self).loadProfile"),

--- a/RadixWallet/Clients/OverlayWindowClient/OverlayWindowClient+Test.swift
+++ b/RadixWallet/Clients/OverlayWindowClient/OverlayWindowClient+Test.swift
@@ -1,7 +1,7 @@
 
 // MARK: - BannerClient + TestDependencyKey
 extension OverlayWindowClient: TestDependencyKey {
-	public static let testValue: Self = .init(
+	public static let testValue = Self(
 		scheduledItems: unimplemented("\(Self.self).scheduledItems"),
 		scheduleAlertIgnoreAction: unimplemented("\(Self.self).scheduleAlertIgnoreAction"),
 		scheduleAlertAwaitAction: unimplemented("\(Self.self).scheduleAlertAwaitAction"),

--- a/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Test.swift
+++ b/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Test.swift
@@ -8,7 +8,7 @@ extension DependencyValues {
 
 // MARK: - P2PLinksClient + TestDependencyKey
 extension P2PLinksClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
 	public static let noop = Self(
 		getP2PLinks: { [] },
 		addP2PLink: { _ in },

--- a/RadixWallet/Clients/PersonasClient/PersonasClient+Test.swift
+++ b/RadixWallet/Clients/PersonasClient/PersonasClient+Test.swift
@@ -8,7 +8,7 @@ extension DependencyValues {
 
 // MARK: - PersonasClient + TestDependencyKey
 extension PersonasClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
 	public static let testValue = Self(
 		personas: unimplemented("\(Self.self).personas"),
 		nextPersonaIndex: unimplemented("\(Self.self).nextPersonaIndex"),

--- a/RadixWallet/Clients/QRGeneratorClient/QRGeneratorClient+Test.swift
+++ b/RadixWallet/Clients/QRGeneratorClient/QRGeneratorClient+Test.swift
@@ -8,7 +8,8 @@ extension DependencyValues {
 
 // MARK: - QRGeneratorClient + TestDependencyKey
 extension QRGeneratorClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
+
 	public static let testValue = Self(
 		generate: unimplemented("\(Self.self).generate")
 	)

--- a/RadixWallet/Clients/ROLAClient/ROLAClient+Live.swift
+++ b/RadixWallet/Clients/ROLAClient/ROLAClient+Live.swift
@@ -128,25 +128,28 @@ extension ROLAClient {
 	}
 }
 
-/// `0x52 || challenge(32) || L_dda(1) || dda_utf8(L_dda) || origin_utf8`
-func payloadToHash(
-	challenge: P2P.Dapp.Request.AuthChallengeNonce,
-	dAppDefinitionAddress accountAddress: AccountAddress,
-	origin metadataOrigin: P2P.Dapp.Request.Metadata.Origin
-) -> Data {
-	let rPrefix: UInt8 = 0x52
-	let dAppDefinitionAddress = accountAddress.address
-	let origin = metadataOrigin.urlString.rawValue
-	precondition(dAppDefinitionAddress.count <= UInt8.max)
-	let challengeBytes = [UInt8](challenge.data.data)
-	let lengthDappDefinitionAddress = UInt8(dAppDefinitionAddress.count)
-	return Data(
-		[rPrefix]
-			+ challengeBytes
-			+ [lengthDappDefinitionAddress]
-			+ [UInt8](dAppDefinitionAddress.utf8)
-			+ [UInt8](origin.utf8)
-	)
+extension ROLAClient {
+	/// `0x52 || challenge(32) || L_dda(1) || dda_utf8(L_dda) || origin_utf8`
+	static func payloadToHash(
+		challenge: P2P.Dapp.Request.AuthChallengeNonce,
+		dAppDefinitionAddress accountAddress: AccountAddress,
+		origin metadataOrigin: P2P.Dapp.Request.Metadata.Origin
+	) -> Data {
+		let rPrefix: UInt8 = 0x52
+		let dAppDefinitionAddress = accountAddress.address
+		let origin = metadataOrigin.urlString.rawValue
+		precondition(dAppDefinitionAddress.count <= UInt8.max)
+		let challengeBytes = [UInt8](challenge.data.data)
+		let lengthDappDefinitionAddress = UInt8(dAppDefinitionAddress.count)
+
+		var data = [rPrefix]
+		data.append(contentsOf: challengeBytes)
+		data.append(contentsOf: [lengthDappDefinitionAddress])
+		data.append(contentsOf: [UInt8](dAppDefinitionAddress.utf8))
+		data.append(contentsOf: [UInt8](origin.utf8))
+
+		return Data(data)
+	}
 }
 
 extension EngineToolkit.PublicKeyHash {

--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Test.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Test.swift
@@ -3,6 +3,7 @@
 
 extension RadixConnectClient: TestDependencyKey {
 	public static let previewValue = Self.noop
+
 	public static let testValue = Self(
 		loadFromProfileAndConnectAll: unimplemented("\(Self.self).loadFromProfileAndConnectAll"),
 		disconnectAndRemoveAll: unimplemented("\(Self.self).disconnectAndRemoveAll"),

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Test.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Test.swift
@@ -8,27 +8,7 @@ extension DependencyValues {
 
 // MARK: - SecureStorageClient + TestDependencyKey
 extension SecureStorageClient: TestDependencyKey {
-	public static let noop: Self = .init(
-		saveProfileSnapshot: { _ in },
-		loadProfileSnapshotData: { _ in nil },
-		loadProfileSnapshot: { _ in nil },
-		loadProfile: { _ in nil },
-		saveMnemonicForFactorSource: { _ in },
-		loadMnemonicByFactorSourceID: { _, _, _ in nil },
-		containsMnemonicIdentifiedByFactorSourceID: { _ in false },
-		deleteMnemonicByFactorSourceID: { _ in },
-		deleteProfileAndMnemonicsByFactorSourceIDs: { _, _ in },
-		updateIsCloudProfileSyncEnabled: { _, _ in },
-		loadProfileHeaderList: { nil },
-		saveProfileHeaderList: { _ in },
-		deleteProfileHeaderList: {},
-		loadDeviceInfo: { nil },
-		saveDeviceInfo: { _ in },
-		deprecatedLoadDeviceID: { nil },
-		deleteDeprecatedDeviceID: {}
-	)
-
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
 
 	public static let testValue = Self(
 		saveProfileSnapshot: unimplemented("\(Self.self).saveProfileSnapshot"),
@@ -48,5 +28,25 @@ extension SecureStorageClient: TestDependencyKey {
 		saveDeviceInfo: unimplemented("\(Self.self).saveDeviceInfo"),
 		deprecatedLoadDeviceID: unimplemented("\(Self.self).deprecatedLoadDeviceID"),
 		deleteDeprecatedDeviceID: unimplemented("\(Self.self).deleteDeprecatedDeviceID")
+	)
+
+	public static let noop = Self(
+		saveProfileSnapshot: { _ in },
+		loadProfileSnapshotData: { _ in nil },
+		loadProfileSnapshot: { _ in nil },
+		loadProfile: { _ in nil },
+		saveMnemonicForFactorSource: { _ in },
+		loadMnemonicByFactorSourceID: { _, _, _ in nil },
+		containsMnemonicIdentifiedByFactorSourceID: { _ in false },
+		deleteMnemonicByFactorSourceID: { _ in },
+		deleteProfileAndMnemonicsByFactorSourceIDs: { _, _ in },
+		updateIsCloudProfileSyncEnabled: { _, _ in },
+		loadProfileHeaderList: { nil },
+		saveProfileHeaderList: { _ in },
+		deleteProfileHeaderList: {},
+		loadDeviceInfo: { nil },
+		saveDeviceInfo: { _ in },
+		deprecatedLoadDeviceID: { nil },
+		deleteDeprecatedDeviceID: {}
 	)
 }

--- a/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Test.swift
+++ b/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Test.swift
@@ -10,15 +10,15 @@ extension DependencyValues {
 extension SubmitTransactionClient: TestDependencyKey {
 	public static let previewValue = Self.noop
 
+	public static let testValue = Self(
+		submitTransaction: unimplemented("\(Self.self).submitTransaction"),
+		hasTXBeenCommittedSuccessfully: unimplemented("\(Self.self).hasTXBeenCommittedSuccessfully")
+	)
+
 	public static let noop = Self(
 		submitTransaction: { _ in
 			throw NoopError()
 		},
 		hasTXBeenCommittedSuccessfully: { _ in }
-	)
-
-	public static let testValue = Self(
-		submitTransaction: unimplemented("\(Self.self).submitTransaction"),
-		hasTXBeenCommittedSuccessfully: unimplemented("\(Self.self).hasTXBeenCommittedSuccessfully")
 	)
 }

--- a/RadixWallet/Clients/TransactionClient/TransactionClient+TestValue.swift
+++ b/RadixWallet/Clients/TransactionClient/TransactionClient+TestValue.swift
@@ -1,7 +1,7 @@
 #if DEBUG
 
 extension TransactionClient: TestDependencyKey {
-	public static let testValue: TransactionClient = .init(
+	public static let testValue = Self(
 		getTransactionReview: unimplemented("\(Self.self).getTransactionReview"),
 		buildTransactionIntent: unimplemented("\(Self.self).buildTransactionIntent"),
 		notarizeTransaction: unimplemented("\(Self.self).notarizeTransaction"),

--- a/RadixWallet/Clients/URLFormatterClient/URLFormatterClient+Test.swift
+++ b/RadixWallet/Clients/URLFormatterClient/URLFormatterClient+Test.swift
@@ -8,7 +8,7 @@ extension DependencyValues {
 
 // MARK: - URLFormatterClient + TestDependencyKey
 extension URLFormatterClient: TestDependencyKey {
-	public static let previewValue: Self = .noop
+	public static let previewValue = Self.noop
 
 	public static let testValue = Self(
 		fixedSizeImage: unimplemented("\(Self.self).fixedSize"),

--- a/RadixWallet/Core/DesignSystem/Components/ApprovalSlider.swift
+++ b/RadixWallet/Core/DesignSystem/Components/ApprovalSlider.swift
@@ -77,9 +77,11 @@ public struct ApprovalSlider: View {
 		private let padding: CGFloat = 2
 
 		private func gradientMask(for width: CGFloat) -> some View {
-			Rectangle()
-				.offset(.init(x: (position - 1) * width - (approved ? 0 : 0.5 * .approveSliderHeight), y: 0))
-				.opacity(min(1.0, 2.0 * position))
+			let xAdjustment: CGFloat = (approved ? 0 : 0.5 * .approveSliderHeight)
+			let opacity: CGFloat = min(1.0, 2.0 * position)
+			return Rectangle()
+				.offset(x: (position - 1) * width - xAdjustment)
+				.opacity(opacity)
 		}
 
 		private func handle(for width: CGFloat) -> some View {

--- a/RadixWallet/Core/FeaturePrelude/FeatureReducer.swift
+++ b/RadixWallet/Core/FeaturePrelude/FeatureReducer.swift
@@ -70,7 +70,6 @@ extension Reducer where Self: FeatureReducer {
 	}
 }
 
-public typealias AlertPresentationStore<AlertAction> = Store<PresentationState<AlertState<AlertAction>>, PresentationAction<AlertAction>>
 public typealias PresentationStoreOf<R: Reducer> = Store<PresentationState<R.State>, PresentationAction<R.Action>>
 
 public typealias ViewStoreOf<Feature: FeatureReducer> = ViewStore<Feature.ViewState, Feature.ViewAction>

--- a/RadixWallet/Core/FeaturePrelude/SlideUpPanel/SlideUpPanel+View.swift
+++ b/RadixWallet/Core/FeaturePrelude/SlideUpPanel/SlideUpPanel+View.swift
@@ -18,6 +18,11 @@ public struct WithNavigationBar<Content: View>: View {
 		self.closeAction = closeAction
 	}
 
+	init(closeAction: @escaping () -> Void, content: Content) {
+		self.content = content
+		self.closeAction = closeAction
+	}
+
 	public var body: some View {
 		NavigationStack {
 			content
@@ -28,6 +33,18 @@ public struct WithNavigationBar<Content: View>: View {
 					}
 				}
 		}
+	}
+}
+
+extension View {
+	public var inNavigationView: some View {
+		NavigationView {
+			self
+		}
+	}
+
+	public func withNavigationBar(closeAction: @escaping () -> Void) -> some View {
+		WithNavigationBar(closeAction: closeAction, content: self)
 	}
 }
 

--- a/RadixWallet/Core/SharedModels/Assets/OnLedgerEntity.swift
+++ b/RadixWallet/Core/SharedModels/Assets/OnLedgerEntity.swift
@@ -420,10 +420,12 @@ extension OnLedgerEntity.NonFungibleToken.NFTData {
 	}
 
 	public func getU64Value(forField field: Field) -> UInt64? {
-		self.fields
-			.compactMap(/GatewayAPI.ProgrammaticScryptoSborValue.u64)
-			.first { $0.fieldName == field.rawValue }
-			.flatMap { UInt64($0.value) }
+		for f in fields {
+			if case let .u64(u64) = f, u64.fieldName == field.rawValue {
+				return UInt64(u64.value)
+			}
+		}
+		return nil
 	}
 
 	public func getDecimalValue(forField field: Field) -> RETDecimal? {

--- a/RadixWallet/Core/SharedModels/P2P/Dapp/Models/Interaction/WalletInteraction+PreviewValue.swift
+++ b/RadixWallet/Core/SharedModels/P2P/Dapp/Models/Interaction/WalletInteraction+PreviewValue.swift
@@ -14,7 +14,7 @@ private let complexManifestString = """
 """
 
 extension P2P.Dapp.Request.AccountsRequestItem {
-	public static let previewValue: Self = .init(
+	public static let previewValue = Self(
 		numberOfAccounts: .exactly(1),
 		challenge: nil
 	)
@@ -25,7 +25,7 @@ extension P2P.Dapp.Request.PersonaDataRequestItem {
 }
 
 extension P2P.Dapp.Request.SendTransactionItem {
-	public static let previewValue: Self = .init(version: .default, transactionManifest: .previewValue, message: nil)
+	public static let previewValue = Self(version: .default, transactionManifest: .previewValue, message: nil)
 }
 
 extension P2P.Dapp.Request.ID {
@@ -64,7 +64,8 @@ extension P2P.Dapp.Request {
 		)
 	}
 
-	public static let previewValueOneTimeAccount: Self = .previewValueOneTimeAccount()
+	public static let previewValueOneTimeAccount = Self.previewValueOneTimeAccount()
+
 	public static func previewValueOneTimeAccount(
 		id: ID = .previewValue0
 	) -> Self {
@@ -80,7 +81,7 @@ extension P2P.Dapp.Request {
 		)
 	}
 
-	public static let previewValueSignTX: Self = .previewValueSignTX()
+	public static let previewValueSignTX = Self.previewValueSignTX()
 
 	public static func previewValueSignTX(
 		id: ID = .previewValue0

--- a/RadixWallet/Core/SharedModels/PreviewValues/Profile/Account+PreviewValues.swift
+++ b/RadixWallet/Core/SharedModels/PreviewValues/Profile/Account+PreviewValues.swift
@@ -43,7 +43,7 @@ extension Profile.Network.Account {
 }
 
 extension Profile.Network.Accounts {
-	public static let previewValue: Self = .init(rawValue: .init(uniqueElements: [Profile.Network.Account.previewValue0, Profile.Network.Account.previewValue1]))!
+	public static let previewValue = Self(rawValue: .init(uniqueElements: [Profile.Network.Account.previewValue0, Profile.Network.Account.previewValue1]))!
 }
 
 #endif // DEBUG

--- a/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+Reducer.swift
+++ b/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+Reducer.swift
@@ -38,7 +38,7 @@ public struct AccountDetails: Sendable, FeatureReducer {
 		public var exportMnemonicPrompt: ExportMnemonicPrompt
 
 		@PresentationState
-		var destination: Destinations.State?
+		var destination: Destination.State?
 
 		fileprivate var deviceControlledFactorInstance: HierarchicalDeterministicFactorInstance {
 			switch account.securityState {
@@ -71,7 +71,7 @@ public struct AccountDetails: Sendable, FeatureReducer {
 
 	public enum ChildAction: Sendable, Equatable {
 		case assets(AssetsView.Action)
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -95,7 +95,7 @@ public struct AccountDetails: Sendable, FeatureReducer {
 		public let factorSourceKind: FactorSourceKind
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case preferences(AccountPreferences.State)
 			case transfer(AssetTransfer.State)
@@ -149,7 +149,7 @@ public struct AccountDetails: Sendable, FeatureReducer {
 		}
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
+++ b/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
@@ -80,7 +80,7 @@ extension AccountDetails {
 					}
 				}
 			}
-			.destinations(store.scope(state: \.$destination, action: { .child(.destination($0)) }))
+			.destination(store.scope(state: \.$destination, action: { .child(.destination($0)) }))
 		}
 
 		@ViewBuilder
@@ -114,36 +114,36 @@ extension AccountDetails {
 
 @MainActor
 private extension View {
-	func destinations(_ destinationStore: PresentationStoreOf<AccountDetails.Destinations>) -> some SwiftUI.View {
+	func destination(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
 		preferences(destinationStore)
 			.transfer(destinationStore)
 			.exportMnemonic(destinationStore)
 			.importMnemonics(destinationStore)
 	}
 
-	func preferences(_ destinationStore: PresentationStoreOf<AccountDetails.Destinations>) -> some SwiftUI.View {
+	func preferences(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AccountDetails.Destinations.State.preferences,
-			action: AccountDetails.Destinations.Action.preferences,
+			state: /AccountDetails.Destination.State.preferences,
+			action: AccountDetails.Destination.Action.preferences,
 			destination: { AccountPreferences.View(store: $0) }
 		)
 	}
 
-	func transfer(_ destinationStore: PresentationStoreOf<AccountDetails.Destinations>) -> some SwiftUI.View {
+	func transfer(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
 		fullScreenCover(
 			store: destinationStore,
-			state: /AccountDetails.Destinations.State.transfer,
-			action: AccountDetails.Destinations.Action.transfer,
+			state: /AccountDetails.Destination.State.transfer,
+			action: AccountDetails.Destination.Action.transfer,
 			content: { AssetTransfer.SheetView(store: $0) }
 		)
 	}
 
-	func exportMnemonic(_ destinationStore: PresentationStoreOf<AccountDetails.Destinations>) -> some SwiftUI.View {
+	func exportMnemonic(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
 		fullScreenCover( /* Full Screen cover to not be able to use iOS dismiss gestures */
 			store: destinationStore,
-			state: /AccountDetails.Destinations.State.exportMnemonic,
-			action: AccountDetails.Destinations.Action.exportMnemonic,
+			state: /AccountDetails.Destination.State.exportMnemonic,
+			action: AccountDetails.Destination.Action.exportMnemonic,
 			content: { childStore in
 				NavigationView {
 					ImportMnemonic.View(store: childStore)
@@ -153,11 +153,11 @@ private extension View {
 		)
 	}
 
-	func importMnemonics(_ destinationStore: PresentationStoreOf<AccountDetails.Destinations>) -> some SwiftUI.View {
+	func importMnemonics(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
 		sheet(
 			store: destinationStore,
-			state: /AccountDetails.Destinations.State.importMnemonics,
-			action: AccountDetails.Destinations.Action.importMnemonics,
+			state: /AccountDetails.Destination.State.importMnemonics,
+			action: AccountDetails.Destination.Action.importMnemonics,
 			content: { ImportMnemonicsFlowCoordinator.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
+++ b/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
@@ -80,7 +80,7 @@ extension AccountDetails {
 					}
 				}
 			}
-			.destination(store.scope(state: \.$destination, action: { .child(.destination($0)) }))
+			.destinations(with: store)
 		}
 
 		@ViewBuilder
@@ -112,16 +112,23 @@ extension AccountDetails {
 	}
 }
 
+private extension StoreOf<AccountDetails> {
+	var destination: PresentationStoreOf<AccountDetails.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
 @MainActor
 private extension View {
-	func destination(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
-		preferences(destinationStore)
-			.transfer(destinationStore)
-			.exportMnemonic(destinationStore)
-			.importMnemonics(destinationStore)
+	func destinations(with store: StoreOf<AccountDetails>) -> some SwiftUI.View {
+		let destinationStore = store.destination
+		return preferences(with: destinationStore)
+			.transfer(with: destinationStore)
+			.exportMnemonic(with: destinationStore)
+			.importMnemonics(with: destinationStore)
 	}
 
-	func preferences(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
+	private func preferences(with destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AccountDetails.Destination.State.preferences,
@@ -130,7 +137,7 @@ private extension View {
 		)
 	}
 
-	func transfer(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
+	private func transfer(with destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
 		fullScreenCover(
 			store: destinationStore,
 			state: /AccountDetails.Destination.State.transfer,
@@ -139,21 +146,20 @@ private extension View {
 		)
 	}
 
-	func exportMnemonic(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
+	private func exportMnemonic(with destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
 		fullScreenCover( /* Full Screen cover to not be able to use iOS dismiss gestures */
 			store: destinationStore,
 			state: /AccountDetails.Destination.State.exportMnemonic,
 			action: AccountDetails.Destination.Action.exportMnemonic,
-			content: { childStore in
-				NavigationView {
-					ImportMnemonic.View(store: childStore)
-						.navigationTitle(L10n.ImportMnemonic.navigationTitleBackup)
-				}
+			content: {
+				ImportMnemonic.View(store: $0)
+					.navigationTitle(L10n.ImportMnemonic.navigationTitleBackup)
+					.inNavigationView
 			}
 		)
 	}
 
-	func importMnemonics(_ destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
+	private func importMnemonics(with destinationStore: PresentationStoreOf<AccountDetails.Destination>) -> some SwiftUI.View {
 		sheet(
 			store: destinationStore,
 			state: /AccountDetails.Destination.State.importMnemonics,

--- a/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+Reducer.swift
@@ -7,7 +7,7 @@ public struct AccountPreferences: Sendable, FeatureReducer {
 		public var account: Profile.Network.Account
 
 		@PresentationState
-		var destinations: Destinations.State? = nil
+		var destination: Destination.State? = nil
 
 		public init(account: Profile.Network.Account) {
 			self.account = account
@@ -28,7 +28,7 @@ public struct AccountPreferences: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destinations(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -36,7 +36,7 @@ public struct AccountPreferences: Sendable, FeatureReducer {
 	}
 
 	// MARK: - Destination
-	public struct Destinations: Reducer, Sendable {
+	public struct Destination: Reducer, Sendable {
 		public enum State: Equatable, Hashable {
 			case showQR(ShowQR.State)
 			case updateAccountLabel(UpdateAccountLabel.State)
@@ -83,8 +83,8 @@ public struct AccountPreferences: Sendable, FeatureReducer {
 
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
-			.ifLet(\.$destinations, action: /Action.child .. ChildAction.destinations) {
-				Destinations()
+			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
+				Destination()
 			}
 	}
 
@@ -99,14 +99,14 @@ public struct AccountPreferences: Sendable, FeatureReducer {
 			}
 
 		case .qrCodeButtonTapped:
-			state.destinations = .showQR(.init(accountAddress: state.account.address))
+			state.destination = .showQR(.init(accountAddress: state.account.address))
 			return .none
 
 		case let .rowTapped(row):
 			return destination(for: row, &state)
 
 		case .hideAccountTapped:
-			state.destinations = .confirmHideAccount(.init(
+			state.destination = .confirmHideAccount(.init(
 				title: .init(L10n.AccountSettings.hideThisAccount),
 				message: .init(L10n.AccountSettings.hideAccountConfirmation),
 				buttons: [
@@ -120,7 +120,7 @@ public struct AccountPreferences: Sendable, FeatureReducer {
 
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
-		case let .destinations(.presented(action)):
+		case let .destination(.presented(action)):
 			onDestinationAction(action, &state)
 		default:
 			.none
@@ -140,7 +140,7 @@ extension AccountPreferences {
 	func destination(for row: AccountPreferences.Section.SectionRow, _ state: inout State) -> Effect<Action> {
 		switch row {
 		case .personalize(.accountLabel):
-			state.destinations = .updateAccountLabel(.init(account: state.account))
+			state.destination = .updateAccountLabel(.init(account: state.account))
 			return .none
 
 		case .personalize(.accountColor):
@@ -150,30 +150,30 @@ extension AccountPreferences {
 			return .none
 
 		case .onLedger(.thirdPartyDeposits):
-			state.destinations = .thirdPartyDeposits(.init(account: state.account))
+			state.destination = .thirdPartyDeposits(.init(account: state.account))
 			return .none
 
 		case .onLedger(.accountSecurity):
 			return .none
 
 		case .dev(.devPreferences):
-			state.destinations = .devPreferences(.init(address: state.account.address))
+			state.destination = .devPreferences(.init(address: state.account.address))
 			return .none
 		}
 	}
 
-	func onDestinationAction(_ action: AccountPreferences.Destinations.Action, _ state: inout State) -> Effect<Action> {
+	func onDestinationAction(_ action: AccountPreferences.Destination.Action, _ state: inout State) -> Effect<Action> {
 		switch action {
 		case .showQR(.delegate(.dismiss)):
-			if case .showQR = state.destinations {
-				state.destinations = nil
+			if case .showQR = state.destination {
+				state.destination = nil
 			}
 			return .none
 		case .showQR:
 			return .none
 		case .updateAccountLabel(.delegate(.accountLabelUpdated)),
 		     .thirdPartyDeposits(.delegate(.accountUpdated)):
-			state.destinations = nil
+			state.destination = nil
 			return .none
 		case .updateAccountLabel:
 			return .none

--- a/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
@@ -88,10 +88,16 @@ extension AccountPreferences.View {
 	}
 }
 
-extension View {
-	@MainActor
+private extension StoreOf<AccountPreferences> {
+	var destination: PresentationStoreOf<AccountPreferences.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
 	func destination(store: StoreOf<AccountPreferences>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+		let destinationStore = store.destination
 		return showQRCode(with: destinationStore)
 			.updateAccountLabel(with: destinationStore)
 			.thirdPartyDeposits(with: destinationStore)
@@ -99,8 +105,7 @@ extension View {
 			.confirmHideAccountAlert(with: destinationStore)
 	}
 
-	@MainActor
-	func showQRCode(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
+	private func showQRCode(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
 			state: /AccountPreferences.Destination.State.showQR,
@@ -110,8 +115,7 @@ extension View {
 		}
 	}
 
-	@MainActor
-	func updateAccountLabel(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
+	private func updateAccountLabel(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AccountPreferences.Destination.State.updateAccountLabel,
@@ -120,8 +124,7 @@ extension View {
 		)
 	}
 
-	@MainActor
-	func thirdPartyDeposits(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
+	private func thirdPartyDeposits(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AccountPreferences.Destination.State.thirdPartyDeposits,
@@ -130,8 +133,7 @@ extension View {
 		)
 	}
 
-	@MainActor
-	func devAccountPreferences(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
+	private func devAccountPreferences(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AccountPreferences.Destination.State.devPreferences,
@@ -140,8 +142,7 @@ extension View {
 		)
 	}
 
-	@MainActor
-	func confirmHideAccountAlert(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
+	private func confirmHideAccountAlert(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		alert(
 			store: destinationStore,
 			state: /AccountPreferences.Destination.State.confirmHideAccount,

--- a/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/AccountPreferences+View.swift
@@ -91,7 +91,7 @@ extension AccountPreferences.View {
 extension View {
 	@MainActor
 	func destination(store: StoreOf<AccountPreferences>) -> some View {
-		let destinationStore = store.scope(state: \.$destinations, action: { .child(.destinations($0)) })
+		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return showQRCode(with: destinationStore)
 			.updateAccountLabel(with: destinationStore)
 			.thirdPartyDeposits(with: destinationStore)
@@ -100,52 +100,52 @@ extension View {
 	}
 
 	@MainActor
-	func showQRCode(with destinationStore: PresentationStoreOf<AccountPreferences.Destinations>) -> some View {
+	func showQRCode(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /AccountPreferences.Destinations.State.showQR,
-			action: AccountPreferences.Destinations.Action.showQR
+			state: /AccountPreferences.Destination.State.showQR,
+			action: AccountPreferences.Destination.Action.showQR
 		) {
 			ShowQR.View(store: $0)
 		}
 	}
 
 	@MainActor
-	func updateAccountLabel(with destinationStore: PresentationStoreOf<AccountPreferences.Destinations>) -> some View {
+	func updateAccountLabel(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AccountPreferences.Destinations.State.updateAccountLabel,
-			action: AccountPreferences.Destinations.Action.updateAccountLabel,
+			state: /AccountPreferences.Destination.State.updateAccountLabel,
+			action: AccountPreferences.Destination.Action.updateAccountLabel,
 			destination: { UpdateAccountLabel.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func thirdPartyDeposits(with destinationStore: PresentationStoreOf<AccountPreferences.Destinations>) -> some View {
+	func thirdPartyDeposits(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AccountPreferences.Destinations.State.thirdPartyDeposits,
-			action: AccountPreferences.Destinations.Action.thirdPartyDeposits,
+			state: /AccountPreferences.Destination.State.thirdPartyDeposits,
+			action: AccountPreferences.Destination.Action.thirdPartyDeposits,
 			destination: { ManageThirdPartyDeposits.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func devAccountPreferences(with destinationStore: PresentationStoreOf<AccountPreferences.Destinations>) -> some View {
+	func devAccountPreferences(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AccountPreferences.Destinations.State.devPreferences,
-			action: AccountPreferences.Destinations.Action.devPreferences,
+			state: /AccountPreferences.Destination.State.devPreferences,
+			action: AccountPreferences.Destination.Action.devPreferences,
 			destination: { DevAccountPreferences.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func confirmHideAccountAlert(with destinationStore: PresentationStoreOf<AccountPreferences.Destinations>) -> some View {
+	func confirmHideAccountAlert(with destinationStore: PresentationStoreOf<AccountPreferences.Destination>) -> some View {
 		alert(
 			store: destinationStore,
-			state: /AccountPreferences.Destinations.State.confirmHideAccount,
-			action: AccountPreferences.Destinations.Action.confirmHideAccount
+			state: /AccountPreferences.Destination.State.confirmHideAccount,
+			action: AccountPreferences.Destination.Action.confirmHideAccount
 		)
 	}
 }

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+View.swift
@@ -99,17 +99,8 @@ extension DevAccountPreferences {
 					}
 					.navigationTitle("Dev Preferences")
 					#if DEBUG
-						.sheet(
-							store: store.destination,
-							state: /DevAccountPreferences.Destination.State.reviewTransaction,
-							action: DevAccountPreferences.Destination.Action.reviewTransaction
-						) { store in
-							// FIXME: Should use DappInteractionClient intstead to schedule a transaction
-							NavigationView {
-								TransactionReview.View(store: store)
-							}
-						}
-					#endif // DEBUG
+						.destinations(with: store)
+					#endif
 						.navigationBarTitleColor(.app.gray1)
 						.navigationBarTitleDisplayMode(.inline)
 						.navigationBarInlineTitleFont(.app.secondaryHeader)
@@ -118,12 +109,6 @@ extension DevAccountPreferences {
 				}
 			}
 		}
-	}
-}
-
-private extension StoreOf<DevAccountPreferences> {
-	var destination: PresentationStoreOf<DevAccountPreferences.Destination> {
-		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 
@@ -144,7 +129,34 @@ extension DevAccountPreferences.View {
 	}
 }
 
+private extension StoreOf<DevAccountPreferences> {
+	var destination: PresentationStoreOf<DevAccountPreferences.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
 #if DEBUG
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<DevAccountPreferences>) -> some View {
+		let destinationStore = store.destination
+		return reviewTransaction(with: destinationStore)
+	}
+
+	private func reviewTransaction(with destinationStore: PresentationStoreOf<DevAccountPreferences.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /DevAccountPreferences.Destination.State.reviewTransaction,
+			action: DevAccountPreferences.Destination.Action.reviewTransaction
+		) { store in
+			// FIXME: Should use DappInteractionClient intstead to schedule a transaction
+			NavigationView {
+				TransactionReview.View(store: store)
+			}
+		}
+	}
+}
+
 extension DevAccountPreferences.View {
 	@ViewBuilder
 	private func turnIntoDappDefinitionAccountTypeButton(with viewStore: ViewStoreOf<DevAccountPreferences>) -> some View {

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+View.swift
@@ -123,7 +123,7 @@ extension DevAccountPreferences {
 
 private extension StoreOf<DevAccountPreferences> {
 	var destination: PresentationStoreOf<DevAccountPreferences.Destination> {
-		scope(state: \.$destination, action: { .child(.destination($0)) })
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+Reducer.swift
@@ -24,6 +24,8 @@ public struct ResourceViewState: Hashable, Sendable, Identifiable {
 
 // MARK: - ResourcesList
 public struct ResourcesList: FeatureReducer, Sendable {
+	// MARK: State
+
 	public struct State: Hashable, Sendable {
 		var allDepositorAddresses: OrderedSet<ResourceViewState.Address> {
 			switch mode {
@@ -56,6 +58,8 @@ public struct ResourcesList: FeatureReducer, Sendable {
 		var destination: Destination.State? = nil
 	}
 
+	// MARK: Action
+
 	public enum ViewAction: Equatable, Sendable {
 		case task
 		case addAssetTapped
@@ -76,13 +80,15 @@ public struct ResourcesList: FeatureReducer, Sendable {
 		case resourcesLoaded([OnLedgerEntity.Resource]?)
 	}
 
+	// MARK: Destination
+
 	public struct Destination: Reducer, Sendable {
-		public enum State: Equatable, Hashable, Sendable {
+		public enum State: Hashable, Sendable {
 			case addAsset(AddAsset.State)
 			case confirmAssetDeletion(AlertState<Action.ConfirmDeletionAlert>)
 		}
 
-		public enum Action: Hashable, Sendable {
+		public enum Action: Equatable, Sendable {
 			case addAsset(AddAsset.Action)
 			case confirmAssetDeletion(ConfirmDeletionAlert)
 
@@ -98,6 +104,8 @@ public struct ResourcesList: FeatureReducer, Sendable {
 			}
 		}
 	}
+
+	// MARK: Reducer
 
 	@Dependency(\.onLedgerEntitiesClient) var onLedgerEntitiesClient
 

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+View.swift
@@ -144,27 +144,27 @@ extension ResourcesList.View {
 private extension View {
 	@MainActor
 	func destination(store: StoreOf<ResourcesList>) -> some View {
-		let destinationStore = store.scope(state: \.$destinations, action: { .child(.destinations($0)) })
+		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return addAsset(with: destinationStore)
 			.confirmDeletionAlert(with: destinationStore)
 	}
 
 	@MainActor
-	func addAsset(with destinationStore: PresentationStoreOf<ResourcesList.Destinations>) -> some View {
+	func addAsset(with destinationStore: PresentationStoreOf<ResourcesList.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /ResourcesList.Destinations.State.addAsset,
-			action: ResourcesList.Destinations.Action.addAsset,
+			state: /ResourcesList.Destination.State.addAsset,
+			action: ResourcesList.Destination.Action.addAsset,
 			content: { AddAsset.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func confirmDeletionAlert(with destinationStore: PresentationStoreOf<ResourcesList.Destinations>) -> some View {
+	func confirmDeletionAlert(with destinationStore: PresentationStoreOf<ResourcesList.Destination>) -> some View {
 		alert(
 			store: destinationStore,
-			state: /ResourcesList.Destinations.State.confirmAssetDeletion,
-			action: ResourcesList.Destinations.Action.confirmAssetDeletion
+			state: /ResourcesList.Destination.State.confirmAssetDeletion,
+			action: ResourcesList.Destination.Action.confirmAssetDeletion
 		)
 	}
 }

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+View.swift
@@ -57,7 +57,7 @@ extension ResourcesList {
 				}
 				.padding(.top, .medium1)
 				.background(.app.gray5)
-				.destination(store: store)
+				.destinations(with: store)
 				.navigationTitle(viewStore.mode.navigationTitle)
 				.defaultNavBarConfig()
 				.footer {
@@ -141,16 +141,21 @@ extension ResourcesList.View {
 	}
 }
 
+private extension StoreOf<ResourcesList> {
+	var destination: PresentationStoreOf<ResourcesList.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
 private extension View {
-	@MainActor
-	func destination(store: StoreOf<ResourcesList>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+	func destinations(with store: StoreOf<ResourcesList>) -> some View {
+		let destinationStore = store.destination
 		return addAsset(with: destinationStore)
 			.confirmDeletionAlert(with: destinationStore)
 	}
 
-	@MainActor
-	func addAsset(with destinationStore: PresentationStoreOf<ResourcesList.Destination>) -> some View {
+	private func addAsset(with destinationStore: PresentationStoreOf<ResourcesList.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
 			state: /ResourcesList.Destination.State.addAsset,
@@ -159,8 +164,7 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	func confirmDeletionAlert(with destinationStore: PresentationStoreOf<ResourcesList.Destination>) -> some View {
+	private func confirmDeletionAlert(with destinationStore: PresentationStoreOf<ResourcesList.Destination>) -> some View {
 		alert(
 			store: destinationStore,
 			state: /ResourcesList.Destination.State.confirmAssetDeletion,

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ThirdPartyDeposits+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ThirdPartyDeposits+Reducer.swift
@@ -14,7 +14,7 @@ public struct ManageThirdPartyDeposits: FeatureReducer, Sendable {
 		var thirdPartyDeposits: ThirdPartyDeposits
 
 		@PresentationState
-		var destinations: Destinations.State? = nil
+		var destination: Destination.State? = nil
 
 		init(account: Profile.Network.Account) {
 			self.account = account
@@ -32,14 +32,14 @@ public struct ManageThirdPartyDeposits: FeatureReducer, Sendable {
 	}
 
 	public enum ChildAction: Equatable, Sendable {
-		case destinations(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum InternalAction: Equatable, Sendable {
 		case updated(Profile.Network.Account)
 	}
 
-	public struct Destinations: Reducer, Sendable {
+	public struct Destination: Reducer, Sendable {
 		public enum State: Equatable, Hashable, Sendable {
 			case allowDenyAssets(ResourcesList.State)
 			case allowDepositors(ResourcesList.State)
@@ -68,8 +68,8 @@ public struct ManageThirdPartyDeposits: FeatureReducer, Sendable {
 
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
-			.ifLet(\.$destinations, action: /Action.child .. ChildAction.destinations) {
-				Destinations()
+			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
+				Destination()
 			}
 	}
 
@@ -81,14 +81,14 @@ public struct ManageThirdPartyDeposits: FeatureReducer, Sendable {
 				state.thirdPartyDeposits.depositRule = rule
 
 			case .allowDenyAssets:
-				state.destinations = .allowDenyAssets(.init(
+				state.destination = .allowDenyAssets(.init(
 					mode: .allowDenyAssets(.allow),
 					thirdPartyDeposits: state.thirdPartyDeposits,
 					networkID: state.account.networkID
 				))
 
 			case .allowDepositors:
-				state.destinations = .allowDepositors(.init(
+				state.destination = .allowDepositors(.init(
 					mode: .allowDepositors,
 					thirdPartyDeposits: state.thirdPartyDeposits,
 					networkID: state.account.networkID
@@ -108,11 +108,11 @@ public struct ManageThirdPartyDeposits: FeatureReducer, Sendable {
 
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
-		case let .destinations(.presented(.allowDenyAssets(.delegate(.updated(thirdPartyDeposits))))),
-		     let .destinations(.presented(.allowDepositors(.delegate(.updated(thirdPartyDeposits))))):
+		case let .destination(.presented(.allowDenyAssets(.delegate(.updated(thirdPartyDeposits))))),
+		     let .destination(.presented(.allowDepositors(.delegate(.updated(thirdPartyDeposits))))):
 			state.thirdPartyDeposits = thirdPartyDeposits
 			return .none
-		case .destinations:
+		case .destination:
 			return .none
 		}
 	}

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ThirdPartyDeposits+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ThirdPartyDeposits+View.swift
@@ -47,7 +47,7 @@ extension ManageThirdPartyDeposits {
 				.background(.app.gray5)
 				.navigationTitle(L10n.AccountSettings.thirdPartyDeposits)
 				.defaultNavBarConfig()
-				.destination(store: store)
+				.destinations(with: store)
 				.footer {
 					Button(L10n.AccountSettings.SpecificAssetsDeposits.update) {
 						viewStore.send(.updateTapped)
@@ -129,16 +129,21 @@ extension PreferenceSection.Row where SectionId == ManageThirdPartyDeposits.Sect
 	}
 }
 
-extension View {
-	@MainActor
-	func destination(store: StoreOf<ManageThirdPartyDeposits>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+private extension StoreOf<ManageThirdPartyDeposits> {
+	var destination: PresentationStoreOf<ManageThirdPartyDeposits.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<ManageThirdPartyDeposits>) -> some View {
+		let destinationStore = store.destination
 		return allowDenyAssets(with: destinationStore)
 			.allowDepositors(with: destinationStore)
 	}
 
-	@MainActor
-	func allowDenyAssets(with destinationStore: PresentationStoreOf<ManageThirdPartyDeposits.Destination>) -> some View {
+	private func allowDenyAssets(with destinationStore: PresentationStoreOf<ManageThirdPartyDeposits.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /ManageThirdPartyDeposits.Destination.State.allowDenyAssets,
@@ -147,8 +152,7 @@ extension View {
 		)
 	}
 
-	@MainActor
-	func allowDepositors(with destinationStore: PresentationStoreOf<ManageThirdPartyDeposits.Destination>) -> some View {
+	private func allowDepositors(with destinationStore: PresentationStoreOf<ManageThirdPartyDeposits.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /ManageThirdPartyDeposits.Destination.State.allowDepositors,

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ThirdPartyDeposits+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ThirdPartyDeposits+View.swift
@@ -132,27 +132,27 @@ extension PreferenceSection.Row where SectionId == ManageThirdPartyDeposits.Sect
 extension View {
 	@MainActor
 	func destination(store: StoreOf<ManageThirdPartyDeposits>) -> some View {
-		let destinationStore = store.scope(state: \.$destinations, action: { .child(.destinations($0)) })
+		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return allowDenyAssets(with: destinationStore)
 			.allowDepositors(with: destinationStore)
 	}
 
 	@MainActor
-	func allowDenyAssets(with destinationStore: PresentationStoreOf<ManageThirdPartyDeposits.Destinations>) -> some View {
+	func allowDenyAssets(with destinationStore: PresentationStoreOf<ManageThirdPartyDeposits.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /ManageThirdPartyDeposits.Destinations.State.allowDenyAssets,
-			action: ManageThirdPartyDeposits.Destinations.Action.allowDenyAssets,
+			state: /ManageThirdPartyDeposits.Destination.State.allowDenyAssets,
+			action: ManageThirdPartyDeposits.Destination.Action.allowDenyAssets,
 			destination: { ResourcesList.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func allowDepositors(with destinationStore: PresentationStoreOf<ManageThirdPartyDeposits.Destinations>) -> some View {
+	func allowDepositors(with destinationStore: PresentationStoreOf<ManageThirdPartyDeposits.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /ManageThirdPartyDeposits.Destinations.State.allowDepositors,
-			action: ManageThirdPartyDeposits.Destinations.Action.allowDepositors,
+			state: /ManageThirdPartyDeposits.Destination.State.allowDepositors,
+			action: ManageThirdPartyDeposits.Destination.Action.allowDepositors,
 			destination: { ResourcesList.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/AddLedgerFactorSource/AddLedgerFactorSource+View.swift
+++ b/RadixWallet/Features/AddLedgerFactorSource/AddLedgerFactorSource+View.swift
@@ -82,15 +82,20 @@ extension AddLedgerFactorSource {
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func destination(store: StoreOf<AddLedgerFactorSource>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+private extension StoreOf<AddLedgerFactorSource> {
+	var destination: PresentationStoreOf<AddLedgerFactorSource.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destination(store: StoreOf<AddLedgerFactorSource>) -> some View {
+		let destinationStore = store.destination
 		return ledgerAlreadyExistsAlert(with: destinationStore)
 			.nameLedger(with: destinationStore)
 	}
 
-	@MainActor
 	private func ledgerAlreadyExistsAlert(with destinationStore: PresentationStoreOf<AddLedgerFactorSource.Destination>) -> some View {
 		alert(
 			store: destinationStore,
@@ -99,7 +104,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func nameLedger(with destinationStore: PresentationStoreOf<AddLedgerFactorSource.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,

--- a/RadixWallet/Features/AddLedgerFactorSource/AddLedgerFactorSource+View.swift
+++ b/RadixWallet/Features/AddLedgerFactorSource/AddLedgerFactorSource+View.swift
@@ -91,20 +91,20 @@ extension View {
 	}
 
 	@MainActor
-	private func ledgerAlreadyExistsAlert(with destinationStore: PresentationStoreOf<AddLedgerFactorSource.Destinations>) -> some View {
+	private func ledgerAlreadyExistsAlert(with destinationStore: PresentationStoreOf<AddLedgerFactorSource.Destination>) -> some View {
 		alert(
 			store: destinationStore,
-			state: /AddLedgerFactorSource.Destinations.State.ledgerAlreadyExistsAlert,
-			action: AddLedgerFactorSource.Destinations.Action.ledgerAlreadyExistsAlert
+			state: /AddLedgerFactorSource.Destination.State.ledgerAlreadyExistsAlert,
+			action: AddLedgerFactorSource.Destination.Action.ledgerAlreadyExistsAlert
 		)
 	}
 
 	@MainActor
-	private func nameLedger(with destinationStore: PresentationStoreOf<AddLedgerFactorSource.Destinations>) -> some View {
+	private func nameLedger(with destinationStore: PresentationStoreOf<AddLedgerFactorSource.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AddLedgerFactorSource.Destinations.State.nameLedger,
-			action: AddLedgerFactorSource.Destinations.Action.nameLedger,
+			state: /AddLedgerFactorSource.Destination.State.nameLedger,
+			action: AddLedgerFactorSource.Destination.Action.nameLedger,
 			destination: { NameLedgerFactorSource.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/AddLedgerFactorSource/AddLedgerFactorSource.swift
+++ b/RadixWallet/Features/AddLedgerFactorSource/AddLedgerFactorSource.swift
@@ -11,7 +11,7 @@ public struct AddLedgerFactorSource: Sendable, FeatureReducer {
 		public var unnamedDeviceToAdd: LedgerDeviceInfo?
 
 		@PresentationState
-		public var destination: Destinations.State? = nil
+		public var destination: Destination.State? = nil
 
 		public init() {}
 	}
@@ -24,7 +24,7 @@ public struct AddLedgerFactorSource: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum InternalAction: Sendable, Equatable {
@@ -39,9 +39,9 @@ public struct AddLedgerFactorSource: Sendable, FeatureReducer {
 		case dismiss
 	}
 
-	// MARK: Destinations
+	// MARK: Destination
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case ledgerAlreadyExistsAlert(AlertState<Never>)
 			case nameLedger(NameLedgerFactorSource.State)
@@ -71,7 +71,7 @@ public struct AddLedgerFactorSource: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/AppFeature/Overlay/Overlay+Reducer.swift
+++ b/RadixWallet/Features/AppFeature/Overlay/Overlay+Reducer.swift
@@ -9,7 +9,7 @@ struct OverlayReducer: Sendable, FeatureReducer {
 		}
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 	}
 
 	enum ViewAction: Sendable, Equatable {
@@ -22,10 +22,10 @@ struct OverlayReducer: Sendable, FeatureReducer {
 	}
 
 	enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case hud(HUD.State)
 			case alert(OverlayWindowClient.Item.AlertState)
@@ -52,7 +52,7 @@ struct OverlayReducer: Sendable, FeatureReducer {
 	var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/AppFeature/Overlay/Overlay+Reducer.swift
+++ b/RadixWallet/Features/AppFeature/Overlay/Overlay+Reducer.swift
@@ -40,9 +40,6 @@ struct OverlayReducer: Sendable, FeatureReducer {
 			Scope(state: /State.hud, action: /Action.hud) {
 				HUD()
 			}
-			Scope(state: /State.alert, action: /Action.alert) {
-				EmptyReducer()
-			}
 		}
 	}
 

--- a/RadixWallet/Features/AppFeature/Overlay/Overlay+View.swift
+++ b/RadixWallet/Features/AppFeature/Overlay/Overlay+View.swift
@@ -17,11 +17,7 @@ extension OverlayReducer {
 				action: OverlayReducer.Destination.Action.hud,
 				then: { HUD.View(store: $0) }
 			)
-			.alert(
-				store: store.destination,
-				state: /OverlayReducer.Destination.State.alert,
-				action: OverlayReducer.Destination.Action.alert
-			)
+			.destinations(with: store)
 			.task { store.send(.view(.task)) }
 		}
 	}
@@ -30,5 +26,17 @@ extension OverlayReducer {
 private extension StoreOf<OverlayReducer> {
 	var destination: PresentationStoreOf<OverlayReducer.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<OverlayReducer>) -> some View {
+		let destinationStore = store.destination
+		return alert(
+			store: destinationStore,
+			state: /OverlayReducer.Destination.State.alert,
+			action: OverlayReducer.Destination.Action.alert
+		)
 	}
 }

--- a/RadixWallet/Features/AppFeature/Overlay/Overlay+View.swift
+++ b/RadixWallet/Features/AppFeature/Overlay/Overlay+View.swift
@@ -13,14 +13,14 @@ extension OverlayReducer {
 		var body: some SwiftUI.View {
 			IfLetStore(
 				store.destination,
-				state: /OverlayReducer.Destinations.State.hud,
-				action: OverlayReducer.Destinations.Action.hud,
+				state: /OverlayReducer.Destination.State.hud,
+				action: OverlayReducer.Destination.Action.hud,
 				then: { HUD.View(store: $0) }
 			)
 			.alert(
 				store: store.destination,
-				state: /OverlayReducer.Destinations.State.alert,
-				action: OverlayReducer.Destinations.Action.alert
+				state: /OverlayReducer.Destination.State.alert,
+				action: OverlayReducer.Destination.Action.alert
 			)
 			.task { store.send(.view(.task)) }
 		}
@@ -28,7 +28,7 @@ extension OverlayReducer {
 }
 
 private extension StoreOf<OverlayReducer> {
-	var destination: PresentationStoreOf<OverlayReducer.Destinations> {
+	var destination: PresentationStoreOf<OverlayReducer.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/AppFeature/Overlay/Overlay+View.swift
+++ b/RadixWallet/Features/AppFeature/Overlay/Overlay+View.swift
@@ -11,20 +11,24 @@ extension OverlayReducer {
 		}
 
 		var body: some SwiftUI.View {
-			WithViewStore(store, observe: { $0 }, send: { .view($0) }) { viewStore in
-				IfLetStore(
-					store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /OverlayReducer.Destinations.State.hud,
-					action: OverlayReducer.Destinations.Action.hud,
-					then: { HUD.View(store: $0) }
-				)
-				.alert(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /OverlayReducer.Destinations.State.alert,
-					action: OverlayReducer.Destinations.Action.alert
-				)
-				.task { viewStore.send(.task) }
-			}
+			IfLetStore(
+				store.destination,
+				state: /OverlayReducer.Destinations.State.hud,
+				action: OverlayReducer.Destinations.Action.hud,
+				then: { HUD.View(store: $0) }
+			)
+			.alert(
+				store: store.destination,
+				state: /OverlayReducer.Destinations.State.alert,
+				action: OverlayReducer.Destinations.Action.alert
+			)
+			.task { store.send(.view(.task)) }
 		}
+	}
+}
+
+private extension StoreOf<OverlayReducer> {
+	var destination: PresentationStoreOf<OverlayReducer.Destinations> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+Reducer.swift
@@ -12,7 +12,7 @@ public struct AssetTransferMessage: Sendable, FeatureReducer {
 		public var focused: Bool = true
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		init(message: String) {
 			self.message = message
@@ -35,10 +35,10 @@ public struct AssetTransferMessage: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case messageMode(MessageMode.State)
 		}
@@ -57,7 +57,7 @@ public struct AssetTransferMessage: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+View.swift
@@ -72,17 +72,31 @@ extension AssetTransferMessage.View {
 					.bind(viewStore.focusedBinding, to: $focused)
 				}
 			}
-			.sheet(
-				store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-				state: /AssetTransferMessage.Destination.State.messageMode,
-				action: AssetTransferMessage.Destination.Action.messageMode,
-				content: {
-					MessageMode.View(store: $0)
-						.presentationDetents([.medium])
-						.presentationDragIndicator(.visible)
-						.presentationBackground(.blur)
-				}
-			)
 		}
+		.destinations(with: store)
+	}
+}
+
+private extension StoreOf<AssetTransferMessage> {
+	var destination: PresentationStoreOf<AssetTransferMessage.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<AssetTransferMessage>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /AssetTransferMessage.Destination.State.messageMode,
+			action: AssetTransferMessage.Destination.Action.messageMode,
+			content: {
+				MessageMode.View(store: $0)
+					.presentationDetents([.medium])
+					.presentationDragIndicator(.visible)
+					.presentationBackground(.blur)
+			}
+		)
 	}
 }

--- a/RadixWallet/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/AssetTransferMessage/AssetTransferMessage+View.swift
@@ -74,8 +74,8 @@ extension AssetTransferMessage.View {
 			}
 			.sheet(
 				store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-				state: /AssetTransferMessage.Destinations.State.messageMode,
-				action: AssetTransferMessage.Destinations.Action.messageMode,
+				state: /AssetTransferMessage.Destination.State.messageMode,
+				action: AssetTransferMessage.Destination.Action.messageMode,
 				content: {
 					MessageMode.View(store: $0)
 						.presentationDetents([.medium])

--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+Reducer.swift
@@ -51,7 +51,7 @@ public struct ChooseReceivingAccount: Sendable, FeatureReducer {
 		let networkID: NetworkID
 
 		@PresentationState
-		var destination: Destinations.State? = nil
+		var destination: Destination.State? = nil
 
 		public init(networkID: NetworkID, chooseAccounts: ChooseAccounts.State) {
 			self.networkID = networkID
@@ -68,7 +68,7 @@ public struct ChooseReceivingAccount: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 		case chooseAccounts(ChooseAccounts.Action)
 	}
 
@@ -77,7 +77,7 @@ public struct ChooseReceivingAccount: Sendable, FeatureReducer {
 		case handleResult(ReceivingAccount.State.Account)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case scanAccountAddress(ScanQRCoordinator.State)
 		}
@@ -102,7 +102,7 @@ public struct ChooseReceivingAccount: Sendable, FeatureReducer {
 
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
@@ -77,15 +77,7 @@ extension ChooseReceivingAccount.View {
 					}
 					.padding(.medium3)
 				}
-				.navigationDestination(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /ChooseReceivingAccount.Destination.State.scanAccountAddress,
-					action: ChooseReceivingAccount.Destination.Action.scanAccountAddress,
-					destination: {
-						ScanQRCoordinator.View(store: $0)
-							.navigationTitle(L10n.AssetTransfer.ChooseReceivingAccount.scanQRNavigationTitle)
-					}
-				)
+				.destinations(with: store)
 				.footer { chooseButton(viewStore) }
 				.navigationTitle(L10n.AssetTransfer.ChooseReceivingAccount.navigationTitle)
 				.navigationBarTitleColor(.app.gray1)
@@ -141,6 +133,28 @@ extension ChooseReceivingAccount.View {
 			control: { action in
 				Button(L10n.Common.choose, action: action)
 					.buttonStyle(.primaryRectangular)
+			}
+		)
+	}
+}
+
+private extension StoreOf<ChooseReceivingAccount> {
+	var destination: PresentationStoreOf<ChooseReceivingAccount.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<ChooseReceivingAccount>) -> some View {
+		let destinationStore = store.destination
+		return navigationDestination(
+			store: destinationStore,
+			state: /ChooseReceivingAccount.Destination.State.scanAccountAddress,
+			action: ChooseReceivingAccount.Destination.Action.scanAccountAddress,
+			destination: {
+				ScanQRCoordinator.View(store: $0)
+					.navigationTitle(L10n.AssetTransfer.ChooseReceivingAccount.scanQRNavigationTitle)
 			}
 		)
 	}

--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
@@ -79,8 +79,8 @@ extension ChooseReceivingAccount.View {
 				}
 				.navigationDestination(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /ChooseReceivingAccount.Destinations.State.scanAccountAddress,
-					action: ChooseReceivingAccount.Destinations.Action.scanAccountAddress,
+					state: /ChooseReceivingAccount.Destination.State.scanAccountAddress,
+					action: ChooseReceivingAccount.Destination.Action.scanAccountAddress,
 					destination: {
 						ScanQRCoordinator.View(store: $0)
 							.navigationTitle(L10n.AssetTransfer.ChooseReceivingAccount.scanQRNavigationTitle)

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+Reducer.swift
@@ -18,7 +18,7 @@ public struct TransferAccountList: Sendable, FeatureReducer {
 		}
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init(fromAccount: Profile.Network.Account, receivingAccounts: IdentifiedArrayOf<ReceivingAccount.State>) {
 			self.fromAccount = fromAccount
@@ -38,7 +38,7 @@ public struct TransferAccountList: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Equatable, Sendable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 		case receivingAccount(id: ReceivingAccount.State.ID, action: ReceivingAccount.Action)
 	}
 
@@ -54,7 +54,7 @@ public struct TransferAccountList: Sendable, FeatureReducer {
 		)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public typealias State = RelayState<ReceivingAccount.State.ID, MainState>
 		public typealias Action = RelayAction<ReceivingAccount.State.ID, MainAction>
 
@@ -83,7 +83,7 @@ public struct TransferAccountList: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 			.forEach(\.receivingAccounts, action: /Action.child .. ChildAction.receivingAccount) {
 				ReceivingAccount()

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+View.swift
@@ -69,20 +69,20 @@ extension TransferAccountList.View {
 		}
 	}
 
-	private func destinations(_ store: StoreOf<TransferAccountList.Destinations>) -> some View {
+	private func destinations(_ store: StoreOf<TransferAccountList.Destination>) -> some View {
 		SwitchStore(store.relay()) { state in
 			switch state {
 			case .chooseAccount:
 				CaseLet(
-					/TransferAccountList.Destinations.MainState.chooseAccount,
-					action: TransferAccountList.Destinations.MainAction.chooseAccount,
+					/TransferAccountList.Destination.MainState.chooseAccount,
+					action: TransferAccountList.Destination.MainAction.chooseAccount,
 					then: { ChooseReceivingAccount.View(store: $0) }
 				)
 
 			case .addAsset:
 				CaseLet(
-					/TransferAccountList.Destinations.MainState.addAsset,
-					action: TransferAccountList.Destinations.MainAction.addAsset,
+					/TransferAccountList.Destination.MainState.addAsset,
+					action: TransferAccountList.Destination.MainAction.addAsset,
 					then: { assetsStore in
 						WithNavigationBar {
 							assetsStore.send(.view(.closeButtonTapped))

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+View.swift
@@ -59,13 +59,9 @@ extension TransferAccountList.View {
 				.flushedRight
 				.padding(.top, .medium1)
 			}
-			.sheet(
-				store: store.scope(
-					state: \.$destination,
-					action: { .child(.destination($0)) }
-				),
-				content: { destinations($0) }
-			)
+			.sheet(store: store.destination) { destinationStore in
+				destinations(destinationStore)
+			}
 		}
 	}
 
@@ -95,5 +91,11 @@ extension TransferAccountList.View {
 				)
 			}
 		}
+	}
+}
+
+private extension StoreOf<TransferAccountList> {
+	var destination: PresentationStoreOf<TransferAccountList.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/AssetsFeature/Components/FungibleAssetList/FungibleAssetList+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/FungibleAssetList/FungibleAssetList+Reducer.swift
@@ -7,7 +7,7 @@ public struct FungibleAssetList: Sendable, FeatureReducer {
 		public var sections: IdentifiedArrayOf<FungibleAssetList.Section.State>
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init(
 			sections: IdentifiedArrayOf<FungibleAssetList.Section.State> = []
@@ -17,11 +17,11 @@ public struct FungibleAssetList: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 		case section(FungibleAssetList.Section.State.ID, FungibleAssetList.Section.Action)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case details(FungibleTokenDetails.State)
 		}
@@ -47,7 +47,7 @@ public struct FungibleAssetList: Sendable, FeatureReducer {
 				FungibleAssetList.Section()
 			})
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/AssetsFeature/Components/FungibleAssetList/FungibleAssetList+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/FungibleAssetList/FungibleAssetList+View.swift
@@ -19,15 +19,27 @@ extension FungibleAssetList.View {
 		ForEachStore(
 			store.scope(
 				state: \.sections,
-				action: { childAction in
-					.child(.section(childAction.0, childAction.1))
-				}
+				action: { .child(.section($0, $1)) }
 			)
 		) {
 			FungibleAssetList.Section.View(store: $0)
 		}
-		.sheet(
-			store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+		.destinations(with: store)
+	}
+}
+
+private extension StoreOf<FungibleAssetList> {
+	var destination: PresentationStoreOf<FungibleAssetList.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<FungibleAssetList>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
 			state: /FungibleAssetList.Destination.State.details,
 			action: FungibleAssetList.Destination.Action.details,
 			content: { FungibleTokenDetails.View(store: $0) }

--- a/RadixWallet/Features/AssetsFeature/Components/FungibleAssetList/FungibleAssetList+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/FungibleAssetList/FungibleAssetList+View.swift
@@ -28,8 +28,8 @@ extension FungibleAssetList.View {
 		}
 		.sheet(
 			store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-			state: /FungibleAssetList.Destinations.State.details,
-			action: FungibleAssetList.Destinations.Action.details,
+			state: /FungibleAssetList.Destination.State.details,
+			action: FungibleAssetList.Destination.Action.details,
 			content: { FungibleTokenDetails.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+Reducer.swift
@@ -5,7 +5,7 @@ public struct NonFungibleAssetList: Sendable, FeatureReducer {
 		public var rows: IdentifiedArrayOf<NonFungibleAssetList.Row.State>
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init(rows: IdentifiedArrayOf<NonFungibleAssetList.Row.State>) {
 			self.rows = rows
@@ -14,10 +14,10 @@ public struct NonFungibleAssetList: Sendable, FeatureReducer {
 
 	public enum ChildAction: Sendable, Equatable {
 		case asset(NonFungibleAssetList.Row.State.ID, NonFungibleAssetList.Row.Action)
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case details(NonFungibleTokenDetails.State)
 		}
@@ -41,7 +41,7 @@ public struct NonFungibleAssetList: Sendable, FeatureReducer {
 				NonFungibleAssetList.Row()
 			}
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+View.swift
@@ -20,8 +20,8 @@ extension NonFungibleAssetList {
 			)
 			.sheet(
 				store: store.scope(state: \.$destination) { .child(.destination($0)) },
-				state: /NonFungibleAssetList.Destinations.State.details,
-				action: NonFungibleAssetList.Destinations.Action.details,
+				state: /NonFungibleAssetList.Destination.State.details,
+				action: NonFungibleAssetList.Destination.Action.details,
 				content: { NonFungibleTokenDetails.View(store: $0) }
 			)
 		}

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+View.swift
@@ -14,17 +14,29 @@ extension NonFungibleAssetList {
 		public var body: some SwiftUI.View {
 			ForEachStore(
 				store.scope(state: \.rows) { .child(.asset($0, $1)) },
-				content: {
-					NonFungibleAssetList.Row.View(store: $0)
-				}
+				content: { NonFungibleAssetList.Row.View(store: $0) }
 			)
-			.sheet(
-				store: store.scope(state: \.$destination) { .child(.destination($0)) },
-				state: /NonFungibleAssetList.Destination.State.details,
-				action: NonFungibleAssetList.Destination.Action.details,
-				content: { NonFungibleTokenDetails.View(store: $0) }
-			)
+			.destinations(with: store)
 		}
+	}
+}
+
+private extension StoreOf<NonFungibleAssetList> {
+	var destination: PresentationStoreOf<NonFungibleAssetList.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<NonFungibleAssetList>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: store.scope(state: \.$destination) { .child(.destination($0)) },
+			state: /NonFungibleAssetList.Destination.State.details,
+			action: NonFungibleAssetList.Destination.Action.details,
+			content: { NonFungibleTokenDetails.View(store: $0) }
+		)
 	}
 }
 

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake+View.swift
@@ -78,8 +78,8 @@ extension LSUStake {
 						state: \.$destination,
 						action: (/Action.child .. LSUStake.ChildAction.destination).embed
 					),
-					state: /Destinations.State.details,
-					action: Destinations.Action.details,
+					state: /Destination.State.details,
+					action: Destination.Action.details,
 					content: LSUDetails.View.init
 				)
 			}

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake+View.swift
@@ -73,16 +73,8 @@ extension LSUStake {
 					}
 				}
 				.padding(.medium1)
-				.sheet(
-					store: store.scope(
-						state: \.$destination,
-						action: (/Action.child .. LSUStake.ChildAction.destination).embed
-					),
-					state: /Destination.State.details,
-					action: Destination.Action.details,
-					content: LSUDetails.View.init
-				)
 			}
+			.destinations(with: store)
 		}
 
 		@ViewBuilder
@@ -192,5 +184,24 @@ extension LSUStake.State {
 				}
 			)
 		})
+	}
+}
+
+private extension StoreOf<LSUStake> {
+	var destination: PresentationStoreOf<LSUStake.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<LSUStake>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /LSUStake.Destination.State.details,
+			action: LSUStake.Destination.Action.details,
+			content: { LSUDetails.View(store: $0) }
+		)
 	}
 }

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/LSUResource/LSUStake.swift
@@ -17,7 +17,7 @@ public struct LSUStake: FeatureReducer {
 		var selectedStakeClaimAssets: OrderedSet<OnLedgerEntity.NonFungibleToken>?
 
 		@PresentationState
-		var destination: Destinations.State?
+		var destination: Destination.State?
 	}
 
 	public enum ViewAction: Sendable, Equatable {
@@ -26,10 +26,10 @@ public struct LSUStake: FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case details(LSUDetails.State)
 		}
@@ -55,7 +55,7 @@ public struct LSUStake: FeatureReducer {
 			.ifLet(
 				\.$destination,
 				action: /Action.child .. ChildAction.destination,
-				destination: Destinations.init
+				destination: Destination.init
 			)
 	}
 

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit/PoolUnit+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit/PoolUnit+View.swift
@@ -54,8 +54,8 @@ extension PoolUnit {
 					state: \.$destination,
 					action: (/Action.child .. PoolUnit.ChildAction.destination).embed
 				),
-				state: /Destinations.State.details,
-				action: Destinations.Action.details,
+				state: /Destination.State.details,
+				action: Destination.Action.details,
 				content: PoolUnitDetails.View.init
 			)
 		}

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit/PoolUnit+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit/PoolUnit+View.swift
@@ -19,11 +19,7 @@ extension PoolUnit {
 		}
 
 		public var body: some SwiftUI.View {
-			WithViewStore(
-				store,
-				observe: \.viewState,
-				send: PoolUnit.Action.view
-			) { viewStore in
+			WithViewStore(store, observe: \.viewState, send: PoolUnit.Action.view) { viewStore in
 				Section {
 					VStack(spacing: .large2) {
 						PoolUnitHeaderView(viewState: .init(iconURL: viewStore.iconURL)) {
@@ -49,15 +45,7 @@ extension PoolUnit {
 					.rowStyle()
 				}
 			}
-			.sheet(
-				store: store.scope(
-					state: \.$destination,
-					action: (/Action.child .. PoolUnit.ChildAction.destination).embed
-				),
-				state: /Destination.State.details,
-				action: Destination.Action.details,
-				content: PoolUnitDetails.View.init
-			)
+			.destinations(with: store)
 		}
 	}
 }
@@ -110,5 +98,24 @@ extension PoolUnitResourceViewState {
 					)
 				}
 		)! // Safe to unwrap, guaranteed to not be empty
+	}
+}
+
+private extension StoreOf<PoolUnit> {
+	var destination: PresentationStoreOf<PoolUnit.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<PoolUnit>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /PoolUnit.Destination.State.details,
+			action: PoolUnit.Destination.Action.details,
+			content: { PoolUnitDetails.View(store: $0) }
+		)
 	}
 }

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit/PoolUnit.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit/PoolUnit.swift
@@ -16,7 +16,7 @@ public struct PoolUnit: Sendable, FeatureReducer {
 			poolUnit: OnLedgerEntity.Account.PoolUnit,
 			resourceDetails: Loadable<OnLedgerEntitiesClient.OwnedResourcePoolDetails> = .idle,
 			isSelected: Bool? = nil,
-			destination: Destinations.State? = nil
+			destination: Destination.State? = nil
 		) {
 			self.poolUnit = poolUnit
 			self.resourceDetails = resourceDetails
@@ -25,7 +25,7 @@ public struct PoolUnit: Sendable, FeatureReducer {
 		}
 
 		@PresentationState
-		var destination: Destinations.State?
+		var destination: Destination.State?
 	}
 
 	public enum ViewAction: Sendable, Equatable {
@@ -33,10 +33,10 @@ public struct PoolUnit: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case details(PoolUnitDetails.State)
 		}
@@ -61,7 +61,7 @@ public struct PoolUnit: Sendable, FeatureReducer {
 			.ifLet(
 				\.$destination,
 				action: /Action.child .. ChildAction.destination,
-				destination: Destinations.init
+				destination: Destination.init
 			)
 	}
 

--- a/RadixWallet/Features/ChooseAccounts/ChooseAccounts+Reducer.swift
+++ b/RadixWallet/Features/ChooseAccounts/ChooseAccounts+Reducer.swift
@@ -11,7 +11,7 @@ public struct ChooseAccounts: Sendable, FeatureReducer {
 		public var canCreateNewAccount: Bool
 
 		@PresentationState
-		var destination: Destinations.State? = nil
+		var destination: Destination.State? = nil
 
 		public init(
 			selectionRequirement: SelectionRequirement,
@@ -39,10 +39,10 @@ public struct ChooseAccounts: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case createAccount(CreateAccountCoordinator.State)
 		}
@@ -66,7 +66,7 @@ public struct ChooseAccounts: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/ChooseAccounts/ChooseAccounts+View.swift
+++ b/RadixWallet/Features/ChooseAccounts/ChooseAccounts+View.swift
@@ -68,13 +68,27 @@ extension ChooseAccounts {
 				.onAppear {
 					viewStore.send(.appeared)
 				}
-				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /ChooseAccounts.Destination.State.createAccount,
-					action: ChooseAccounts.Destination.Action.createAccount,
-					content: { CreateAccountCoordinator.View(store: $0) }
-				)
 			}
+			.destinations(with: store)
 		}
+	}
+}
+
+private extension StoreOf<ChooseAccounts> {
+	var destination: PresentationStoreOf<ChooseAccounts.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<ChooseAccounts>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /ChooseAccounts.Destination.State.createAccount,
+			action: ChooseAccounts.Destination.Action.createAccount,
+			content: { CreateAccountCoordinator.View(store: $0) }
+		)
 	}
 }

--- a/RadixWallet/Features/ChooseAccounts/ChooseAccounts+View.swift
+++ b/RadixWallet/Features/ChooseAccounts/ChooseAccounts+View.swift
@@ -70,8 +70,8 @@ extension ChooseAccounts {
 				}
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /ChooseAccounts.Destinations.State.createAccount,
-					action: ChooseAccounts.Destinations.Action.createAccount,
+					state: /ChooseAccounts.Destination.State.createAccount,
+					action: ChooseAccounts.Destination.Action.createAccount,
 					content: { CreateAccountCoordinator.View(store: $0) }
 				)
 			}

--- a/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Reducer.swift
+++ b/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Reducer.swift
@@ -4,13 +4,13 @@ import SwiftUI
 // MARK: - CreateAccountCoordinator
 public struct CreateAccountCoordinator: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
-		var root: Destinations.State?
-		var path: StackState<Destinations.State> = .init()
+		var root: Destination.State?
+		var path: StackState<Destination.State> = .init()
 
 		public let config: CreateAccountConfig
 
 		public init(
-			root: Destinations.State? = nil,
+			root: Destination.State? = nil,
 			config: CreateAccountConfig
 		) {
 			self.config = config
@@ -38,7 +38,7 @@ public struct CreateAccountCoordinator: Sendable, FeatureReducer {
 		}
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case step1_nameAccount(NameAccount.State)
 			case step2_creationOfAccount(CreationOfAccount.State)
@@ -69,8 +69,8 @@ public struct CreateAccountCoordinator: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case root(Destinations.Action)
-		case path(StackActionOf<Destinations>)
+		case root(Destination.Action)
+		case path(StackActionOf<Destination>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -88,10 +88,10 @@ public struct CreateAccountCoordinator: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.root, action: /Action.child .. ChildAction.root) {
-				Destinations()
+				Destination()
 			}
 			.forEach(\.path, action: /Action.child .. ChildAction.path) {
-				Destinations()
+				Destination()
 			}
 	}
 }
@@ -146,7 +146,7 @@ extension CreateAccountCoordinator {
 }
 
 extension CreateAccountCoordinator.State {
-	public var lastStepState: CreateAccountCoordinator.Destinations.State? {
+	public var lastStepState: CreateAccountCoordinator.Destination.State? {
 		path.last
 	}
 }

--- a/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
+++ b/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
@@ -29,7 +29,7 @@ extension CreateAccountCoordinator {
 					IfLetStore(
 						store.scope(state: \.root, action: { .child(.root($0)) })
 					) {
-						destination(for: $0, shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
+						destinations(for: $0, shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
 							.toolbar {
 								if viewStore.shouldDisplayNavBar {
 									ToolbarItem(placement: .primaryAction) {
@@ -43,13 +43,13 @@ extension CreateAccountCoordinator {
 					// This is required to disable the animation of internal components during transition
 					.transaction { $0.animation = nil }
 				} destination: {
-					destination(for: $0, shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
+					destinations(for: $0, shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
 				}
 				.navigationTransition(.slide, interactivity: .disabled)
 			}
 		}
 
-		private func destination(
+		private func destinations(
 			for store: StoreOf<CreateAccountCoordinator.Destination>,
 			shouldDisplayNavBar: Bool
 		) -> some SwiftUI.View {

--- a/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
+++ b/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
@@ -50,7 +50,7 @@ extension CreateAccountCoordinator {
 		}
 
 		private func destination(
-			for store: StoreOf<CreateAccountCoordinator.Destinations>,
+			for store: StoreOf<CreateAccountCoordinator.Destination>,
 			shouldDisplayNavBar: Bool
 		) -> some SwiftUI.View {
 			ZStack {
@@ -58,20 +58,20 @@ extension CreateAccountCoordinator {
 					switch state {
 					case .step1_nameAccount:
 						CaseLet(
-							/CreateAccountCoordinator.Destinations.State.step1_nameAccount,
-							action: CreateAccountCoordinator.Destinations.Action.step1_nameAccount,
+							/CreateAccountCoordinator.Destination.State.step1_nameAccount,
+							action: CreateAccountCoordinator.Destination.Action.step1_nameAccount,
 							then: { NameAccount.View(store: $0) }
 						)
 					case .step2_creationOfAccount:
 						CaseLet(
-							/CreateAccountCoordinator.Destinations.State.step2_creationOfAccount,
-							action: CreateAccountCoordinator.Destinations.Action.step2_creationOfAccount,
+							/CreateAccountCoordinator.Destination.State.step2_creationOfAccount,
+							action: CreateAccountCoordinator.Destination.Action.step2_creationOfAccount,
 							then: { CreationOfAccount.View(store: $0) }
 						)
 					case .step3_completion:
 						CaseLet(
-							/CreateAccountCoordinator.Destinations.State.step3_completion,
-							action: CreateAccountCoordinator.Destinations.Action.step3_completion,
+							/CreateAccountCoordinator.Destination.State.step3_completion,
+							action: CreateAccountCoordinator.Destination.Action.step3_completion,
 							then: { NewAccountCompletion.View(store: $0) }
 						)
 					}

--- a/RadixWallet/Features/CreatePersona/Children/CreationOfPersona/CreationOfPersona+Reducer.swift
+++ b/RadixWallet/Features/CreatePersona/Children/CreationOfPersona/CreationOfPersona+Reducer.swift
@@ -43,10 +43,7 @@ public struct CreationOfPersona: Sendable, FeatureReducer {
 	public init() {}
 
 	public var body: some ReducerOf<Self> {
-		Scope(
-			state: \.derivePublicKeys,
-			action: /Action.child .. ChildAction.derivePublicKeys
-		) {
+		Scope(state: \.derivePublicKeys, action: /Action.child .. ChildAction.derivePublicKeys) {
 			DerivePublicKeys()
 		}
 

--- a/RadixWallet/Features/CreatePersona/Children/Introduction/IntroductionToPersonas+View.swift
+++ b/RadixWallet/Features/CreatePersona/Children/Introduction/IntroductionToPersonas+View.swift
@@ -37,13 +37,7 @@ extension IntroductionToPersonas {
 					.buttonStyle(.primaryRectangular)
 				}
 				.onAppear { viewStore.send(.appeared) }
-				.sheet(
-					store: store.scope(
-						state: \.$infoPanel,
-						action: { .child(.infoPanel($0)) }
-					),
-					content: { SlideUpPanel.View(store: $0) }
-				)
+				.destinations(with: store)
 			}
 		}
 
@@ -72,6 +66,17 @@ extension IntroductionToPersonas {
 				.font(.app.body1Regular)
 				.foregroundColor(.app.gray1)
 		}
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<IntroductionToPersonas>) -> some View {
+		let slideUpStore = store.scope(state: \.$infoPanel) { .child(.infoPanel($0)) }
+		return sheet(
+			store: slideUpStore,
+			content: { SlideUpPanel.View(store: $0) }
+		)
 	}
 }
 

--- a/RadixWallet/Features/CreatePersona/Children/Introduction/IntroductionToPersonas.swift
+++ b/RadixWallet/Features/CreatePersona/Children/Introduction/IntroductionToPersonas.swift
@@ -24,12 +24,10 @@ public struct IntroductionToPersonas: Sendable, FeatureReducer {
 	public init() {}
 
 	public var body: some ReducerOf<Self> {
-		EmptyReducer()
+		Reduce(core)
 			.ifLet(\.$infoPanel, action: /Action.child .. ChildAction.infoPanel) {
 				SlideUpPanel()
 			}
-
-		Reduce(self.core)
 	}
 
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {

--- a/RadixWallet/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+Reducer.swift
+++ b/RadixWallet/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+Reducer.swift
@@ -4,13 +4,13 @@ import SwiftUI
 // MARK: - CreatePersonaCoordinator
 public struct CreatePersonaCoordinator: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
-		var root: Destinations.State?
-		var path: StackState<Destinations.State> = .init()
+		var root: Destination.State?
+		var path: StackState<Destination.State> = .init()
 
 		public let config: CreatePersonaConfig
 
 		public init(
-			root: Destinations.State? = nil,
+			root: Destination.State? = nil,
 			config: CreatePersonaConfig
 		) {
 			self.config = config
@@ -39,7 +39,7 @@ public struct CreatePersonaCoordinator: Sendable, FeatureReducer {
 		}
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case step0_introduction(IntroductionToPersonas.State)
 			case step1_newPersonaInfo(NewPersonaInfo.State)
@@ -75,8 +75,8 @@ public struct CreatePersonaCoordinator: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case root(Destinations.Action)
-		case path(StackActionOf<Destinations>)
+		case root(Destination.Action)
+		case path(StackActionOf<Destination>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -93,10 +93,10 @@ public struct CreatePersonaCoordinator: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.root, action: /Action.child .. ChildAction.root) {
-				Destinations()
+				Destination()
 			}
 			.forEach(\.path, action: /Action.child .. ChildAction.path) {
-				Destinations()
+				Destination()
 			}
 	}
 }

--- a/RadixWallet/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+View.swift
+++ b/RadixWallet/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+View.swift
@@ -49,7 +49,7 @@ extension CreatePersonaCoordinator {
 		}
 
 		private func destination(
-			for store: StoreOf<CreatePersonaCoordinator.Destinations>,
+			for store: StoreOf<CreatePersonaCoordinator.Destination>,
 			shouldDisplayNavBar: Bool
 		) -> some SwiftUI.View {
 			ZStack {
@@ -57,29 +57,29 @@ extension CreatePersonaCoordinator {
 					switch state {
 					case .step0_introduction:
 						CaseLet(
-							/CreatePersonaCoordinator.Destinations.State.step0_introduction,
-							action: CreatePersonaCoordinator.Destinations.Action.step0_introduction,
+							/CreatePersonaCoordinator.Destination.State.step0_introduction,
+							action: CreatePersonaCoordinator.Destination.Action.step0_introduction,
 							then: { IntroductionToPersonas.View(store: $0) }
 						)
 
 					case .step1_newPersonaInfo:
 						CaseLet(
-							/CreatePersonaCoordinator.Destinations.State.step1_newPersonaInfo,
-							action: CreatePersonaCoordinator.Destinations.Action.step1_newPersonaInfo,
+							/CreatePersonaCoordinator.Destination.State.step1_newPersonaInfo,
+							action: CreatePersonaCoordinator.Destination.Action.step1_newPersonaInfo,
 							then: { NewPersonaInfo.View(store: $0) }
 						)
 
 					case .step2_creationOfPersona:
 						CaseLet(
-							/CreatePersonaCoordinator.Destinations.State.step2_creationOfPersona,
-							action: CreatePersonaCoordinator.Destinations.Action.step2_creationOfPersona,
+							/CreatePersonaCoordinator.Destination.State.step2_creationOfPersona,
+							action: CreatePersonaCoordinator.Destination.Action.step2_creationOfPersona,
 							then: { CreationOfPersona.View(store: $0) }
 						)
 
 					case .step3_completion:
 						CaseLet(
-							/CreatePersonaCoordinator.Destinations.State.step3_completion,
-							action: CreatePersonaCoordinator.Destinations.Action.step3_completion,
+							/CreatePersonaCoordinator.Destination.State.step3_completion,
+							action: CreatePersonaCoordinator.Destination.Action.step3_completion,
 							then: { NewPersonaCompletion.View(store: $0) }
 						)
 					}

--- a/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+Reducer.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+Reducer.swift
@@ -20,7 +20,7 @@ struct AccountPermissionChooseAccounts: Sendable, FeatureReducer {
 		var chooseAccounts: ChooseAccounts.State
 
 		@PresentationState
-		var destination: Destinations.State?
+		var destination: Destination.State?
 
 		init(
 			challenge: P2P.Dapp.Request.AuthChallengeNonce?,
@@ -58,7 +58,7 @@ struct AccountPermissionChooseAccounts: Sendable, FeatureReducer {
 	}
 
 	enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 		case chooseAccounts(ChooseAccounts.Action)
 	}
 
@@ -70,7 +70,7 @@ struct AccountPermissionChooseAccounts: Sendable, FeatureReducer {
 		case failedToProveOwnership(of: [Profile.Network.Account])
 	}
 
-	struct Destinations: Sendable, Reducer {
+	struct Destination: Sendable, Reducer {
 		enum State: Sendable, Hashable {
 			case signing(Signing.State)
 		}
@@ -98,7 +98,7 @@ struct AccountPermissionChooseAccounts: Sendable, FeatureReducer {
 
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+View.swift
@@ -17,8 +17,7 @@ extension AccountPermissionChooseAccounts {
 							subtitle: viewStore.subtitle
 						)
 
-						let accountsStore = store.scope(state: \.chooseAccounts, action: { .child(.chooseAccounts($0)) })
-						ChooseAccounts.View(store: accountsStore)
+						ChooseAccounts.View(store: store.chooseAccounts)
 					}
 					.padding(.horizontal, .medium1)
 					.padding(.bottom, .medium2)
@@ -32,14 +31,32 @@ extension AccountPermissionChooseAccounts {
 							.buttonStyle(.primaryRectangular)
 					}
 				}
-				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /AccountPermissionChooseAccounts.Destination.State.signing,
-					action: AccountPermissionChooseAccounts.Destination.Action.signing,
-					content: { Signing.SheetView(store: $0) }
-				)
 			}
+			.destinations(with: store)
 		}
+	}
+}
+
+private extension StoreOf<AccountPermissionChooseAccounts> {
+	var destination: PresentationStoreOf<AccountPermissionChooseAccounts.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+
+	var chooseAccounts: StoreOf<ChooseAccounts> {
+		scope(state: \.chooseAccounts, action: { .child(.chooseAccounts($0)) })
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<AccountPermissionChooseAccounts>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /AccountPermissionChooseAccounts.Destination.State.signing,
+			action: AccountPermissionChooseAccounts.Destination.Action.signing,
+			content: { Signing.SheetView(store: $0) }
+		)
 	}
 }
 

--- a/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+View.swift
@@ -34,8 +34,8 @@ extension AccountPermissionChooseAccounts {
 				}
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /AccountPermissionChooseAccounts.Destinations.State.signing,
-					action: AccountPermissionChooseAccounts.Destinations.Action.signing,
+					state: /AccountPermissionChooseAccounts.Destination.State.signing,
+					action: AccountPermissionChooseAccounts.Destination.Action.signing,
 					content: { Signing.SheetView(store: $0) }
 				)
 			}

--- a/RadixWallet/Features/DappInteractionFeature/Children/OneTimePersonaData/OneTimePersonaData+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/OneTimePersonaData/OneTimePersonaData+View.swift
@@ -87,14 +87,14 @@ extension OneTimePersonaData {
 				}
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /OneTimePersonaData.Destinations.State.editPersona,
-					action: OneTimePersonaData.Destinations.Action.editPersona,
+					state: /OneTimePersonaData.Destination.State.editPersona,
+					action: OneTimePersonaData.Destination.Action.editPersona,
 					content: { EditPersona.View(store: $0) }
 				)
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /OneTimePersonaData.Destinations.State.createPersona,
-					action: OneTimePersonaData.Destinations.Action.createPersona,
+					state: /OneTimePersonaData.Destination.State.createPersona,
+					action: OneTimePersonaData.Destination.Action.createPersona,
 					content: { CreatePersonaCoordinator.View(store: $0) }
 				)
 				.onAppear { viewStore.send(.appeared) }

--- a/RadixWallet/Features/DappInteractionFeature/Children/OneTimePersonaData/OneTimePersonaData.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/OneTimePersonaData/OneTimePersonaData.swift
@@ -12,7 +12,7 @@ struct OneTimePersonaData: Sendable, FeatureReducer {
 		var personaPrimacy: PersonaPrimacy? = nil
 
 		@PresentationState
-		var destination: Destinations.State?
+		var destination: Destination.State?
 
 		init(
 			dappMetadata: DappMetadata,
@@ -40,7 +40,7 @@ struct OneTimePersonaData: Sendable, FeatureReducer {
 
 	enum ChildAction: Sendable, Equatable {
 		case persona(id: PersonaDataPermissionBox.State.ID, action: PersonaDataPermissionBox.Action)
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	enum DelegateAction: Sendable, Equatable {
@@ -48,7 +48,7 @@ struct OneTimePersonaData: Sendable, FeatureReducer {
 		case continueButtonTapped(P2P.Dapp.Request.Response)
 	}
 
-	struct Destinations: Sendable, Reducer {
+	struct Destination: Sendable, Reducer {
 		enum State: Sendable, Hashable {
 			case editPersona(EditPersona.State)
 			case createPersona(CreatePersonaCoordinator.State)
@@ -78,7 +78,7 @@ struct OneTimePersonaData: Sendable, FeatureReducer {
 				PersonaDataPermissionBox()
 			}
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/DappInteractionFeature/Children/PersonaDataPermission/PersonaDataPermission+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/PersonaDataPermission/PersonaDataPermission+View.swift
@@ -62,8 +62,8 @@ extension PersonaDataPermission {
 				}
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /PersonaDataPermission.Destinations.State.editPersona,
-					action: PersonaDataPermission.Destinations.Action.editPersona,
+					state: /PersonaDataPermission.Destination.State.editPersona,
+					action: PersonaDataPermission.Destination.Action.editPersona,
 					content: { EditPersona.View(store: $0) }
 				)
 			}

--- a/RadixWallet/Features/DappInteractionFeature/Children/PersonaDataPermission/PersonaDataPermission+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/PersonaDataPermission/PersonaDataPermission+View.swift
@@ -60,17 +60,31 @@ extension PersonaDataPermission {
 							.buttonStyle(.primaryRectangular)
 					}
 				}
-				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /PersonaDataPermission.Destination.State.editPersona,
-					action: PersonaDataPermission.Destination.Action.editPersona,
-					content: { EditPersona.View(store: $0) }
-				)
 			}
 			.task {
 				store.send(.view(.task))
 			}
+			.destinations(with: store)
 		}
+	}
+}
+
+private extension StoreOf<PersonaDataPermission> {
+	var destination: PresentationStoreOf<PersonaDataPermission.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<PersonaDataPermission>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /PersonaDataPermission.Destination.State.editPersona,
+			action: PersonaDataPermission.Destination.Action.editPersona,
+			content: { EditPersona.View(store: $0) }
+		)
 	}
 }
 

--- a/RadixWallet/Features/DappInteractionFeature/Children/PersonaDataPermission/PersonaDataPermission.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/PersonaDataPermission/PersonaDataPermission.swift
@@ -10,7 +10,7 @@ struct PersonaDataPermission: Sendable, FeatureReducer {
 		let requested: P2P.Dapp.Request.PersonaDataRequestItem
 
 		@PresentationState
-		var destination: Destinations.State?
+		var destination: Destination.State?
 
 		init(
 			dappMetadata: DappMetadata,
@@ -34,7 +34,7 @@ struct PersonaDataPermission: Sendable, FeatureReducer {
 
 	enum ChildAction: Sendable, Equatable {
 		case persona(PersonaDataPermissionBox.Action)
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	enum DelegateAction: Sendable, Equatable {
@@ -42,7 +42,7 @@ struct PersonaDataPermission: Sendable, FeatureReducer {
 		case continueButtonTapped(P2P.Dapp.Request.Response)
 	}
 
-	struct Destinations: Sendable, Reducer {
+	struct Destination: Sendable, Reducer {
 		enum State: Sendable, Hashable {
 			case editPersona(EditPersona.State)
 		}
@@ -67,7 +67,7 @@ struct PersonaDataPermission: Sendable, FeatureReducer {
 				PersonaDataPermissionBox()
 			}
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow+View.swift
@@ -48,49 +48,49 @@ extension DappInteractionFlow {
 		}
 
 		func destination(
-			for store: StoreOf<DappInteractionFlow.Destinations>
+			for store: StoreOf<DappInteractionFlow.Destination>
 		) -> some SwiftUI.View {
 			SwitchStore(store.relay()) { state in
 				switch state {
 				case .login:
 					CaseLet(
-						/DappInteractionFlow.Destinations.MainState.login,
-						action: DappInteractionFlow.Destinations.MainAction.login,
+						/DappInteractionFlow.Destination.MainState.login,
+						action: DappInteractionFlow.Destination.MainAction.login,
 						then: { Login.View(store: $0) }
 					)
 
 				case .accountPermission:
 					CaseLet(
-						/DappInteractionFlow.Destinations.MainState.accountPermission,
-						action: DappInteractionFlow.Destinations.MainAction.accountPermission,
+						/DappInteractionFlow.Destination.MainState.accountPermission,
+						action: DappInteractionFlow.Destination.MainAction.accountPermission,
 						then: { AccountPermission.View(store: $0) }
 					)
 
 				case .chooseAccounts:
 					CaseLet(
-						/DappInteractionFlow.Destinations.MainState.chooseAccounts,
-						action: DappInteractionFlow.Destinations.MainAction.chooseAccounts,
+						/DappInteractionFlow.Destination.MainState.chooseAccounts,
+						action: DappInteractionFlow.Destination.MainAction.chooseAccounts,
 						then: { AccountPermissionChooseAccounts.View(store: $0) }
 					)
 
 				case .personaDataPermission:
 					CaseLet(
-						/DappInteractionFlow.Destinations.MainState.personaDataPermission,
-						action: DappInteractionFlow.Destinations.MainAction.personaDataPermission,
+						/DappInteractionFlow.Destination.MainState.personaDataPermission,
+						action: DappInteractionFlow.Destination.MainAction.personaDataPermission,
 						then: { PersonaDataPermission.View(store: $0) }
 					)
 
 				case .oneTimePersonaData:
 					CaseLet(
-						/DappInteractionFlow.Destinations.MainState.oneTimePersonaData,
-						action: DappInteractionFlow.Destinations.MainAction.oneTimePersonaData,
+						/DappInteractionFlow.Destination.MainState.oneTimePersonaData,
+						action: DappInteractionFlow.Destination.MainAction.oneTimePersonaData,
 						then: { OneTimePersonaData.View(store: $0) }
 					)
 
 				case .reviewTransaction:
 					CaseLet(
-						/DappInteractionFlow.Destinations.MainState.reviewTransaction,
-						action: DappInteractionFlow.Destinations.MainAction.reviewTransaction,
+						/DappInteractionFlow.Destination.MainState.reviewTransaction,
+						action: DappInteractionFlow.Destination.MainAction.reviewTransaction,
 						then: { TransactionReview.View(store: $0) }
 					)
 				}

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow+View.swift
@@ -15,7 +15,7 @@ extension DappInteractionFlow {
 				IfLetStore(
 					store.scope(state: \.root, action: { .child(.root($0)) })
 				) {
-					destination(for: $0)
+					destinations(for: $0)
 						.toolbar {
 							ToolbarItem(placement: .navigationBarLeading) {
 								CloseButton {
@@ -27,7 +27,7 @@ extension DappInteractionFlow {
 				// This is required to disable the animation of internal components during transition
 				.transaction { $0.animation = nil }
 			} destination: {
-				destination(for: $0)
+				destinations(for: $0)
 					.navigationBarBackButtonHidden()
 					.toolbar {
 						ToolbarItem(placement: .navigationBarLeading) {
@@ -47,7 +47,7 @@ extension DappInteractionFlow {
 			)
 		}
 
-		func destination(
+		func destinations(
 			for store: StoreOf<DappInteractionFlow.Destination>
 		) -> some SwiftUI.View {
 			SwitchStore(store.relay()) { state in

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -35,8 +35,8 @@ struct DappInteractionFlow: Sendable, FeatureReducer {
 		@PresentationState
 		var personaNotFoundErrorAlert: AlertState<ViewAction.PersonaNotFoundErrorAlertAction>? = nil
 
-		var root: Destinations.State?
-		var path: StackState<Destinations.State> = .init()
+		var root: Destination.State?
+		var path: StackState<Destination.State> = .init()
 
 		init?(
 			dappMetadata: DappMetadata,
@@ -47,7 +47,7 @@ struct DappInteractionFlow: Sendable, FeatureReducer {
 
 			if let interactionItems = NonEmpty(rawValue: OrderedSet<AnyInteractionItem>(for: remoteInteraction.erasedItems)) {
 				self.interactionItems = interactionItems
-				self.root = Destinations.State(
+				self.root = Destination.State(
 					for: interactionItems.first,
 					interaction: remoteInteraction,
 					dappMetadata: dappMetadata,
@@ -79,7 +79,7 @@ struct DappInteractionFlow: Sendable, FeatureReducer {
 		)
 		case presentPersonaNotFoundErrorAlert(reason: String)
 		case autofillOngoingResponseItemsIfPossible(AutofillOngoingResponseItemsPayload)
-		case delayedAppendToPath(DappInteractionFlow.Destinations.State)
+		case delayedAppendToPath(DappInteractionFlow.Destination.State)
 
 		struct AutofillOngoingResponseItemsPayload: Sendable, Equatable {
 			struct AccountsPayload: Sendable, Equatable {
@@ -101,8 +101,8 @@ struct DappInteractionFlow: Sendable, FeatureReducer {
 	}
 
 	enum ChildAction: Sendable, Equatable {
-		case root(Destinations.Action)
-		case path(StackActionOf<Destinations>)
+		case root(Destination.Action)
+		case path(StackActionOf<Destination>)
 	}
 
 	enum DelegateAction: Sendable, Equatable {
@@ -112,7 +112,7 @@ struct DappInteractionFlow: Sendable, FeatureReducer {
 		case dismiss
 	}
 
-	struct Destinations: Sendable, Reducer {
+	struct Destination: Sendable, Reducer {
 		typealias State = RelayState<DappInteractionFlow.State.AnyInteractionItem, MainState>
 		typealias Action = RelayAction<DappInteractionFlow.State.AnyInteractionItem, MainAction>
 
@@ -162,10 +162,10 @@ struct DappInteractionFlow: Sendable, FeatureReducer {
 	var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.root, action: /Action.child .. ChildAction.root) {
-				Destinations()
+				Destination()
 			}
 			.forEach(\.path, action: /Action.child .. ChildAction.path) {
-				Destinations()
+				Destination()
 			}
 			.ifLet(\.$personaNotFoundErrorAlert, action: /Action.view .. ViewAction.personaNotFoundErrorAlert)
 	}
@@ -754,7 +754,7 @@ extension DappInteractionFlow {
 	func continueEffect(for state: inout State) -> Effect<Action> {
 		if
 			let nextRequest = state.interactionItems.first(where: { state.responseItems[$0] == nil }),
-			let destination = Destinations.State(
+			let destination = Destination.State(
 				for: nextRequest,
 				interaction: state.remoteInteraction,
 				dappMetadata: state.dappMetadata,
@@ -953,7 +953,7 @@ extension OrderedSet<DappInteractionFlow.State.AnyInteractionItem> {
 }
 
 extension DappInteractionFlow.ChildAction {
-	var itemAndAction: (DappInteractionFlow.State.AnyInteractionItem, DappInteractionFlow.Destinations.MainAction)? {
+	var itemAndAction: (DappInteractionFlow.State.AnyInteractionItem, DappInteractionFlow.Destination.MainAction)? {
 		switch self {
 		case let .root(.relay(item, action)), let .path(.element(_, .relay(item, action))):
 			(item, action)
@@ -964,7 +964,7 @@ extension DappInteractionFlow.ChildAction {
 	}
 }
 
-extension DappInteractionFlow.Destinations.State {
+extension DappInteractionFlow.Destination.State {
 	init?(
 		for anyItem: DappInteractionFlow.State.AnyInteractionItem,
 		interaction: DappInteractionFlow.State.RemoteInteraction,

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor+ViewModifier.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor+ViewModifier.swift
@@ -28,8 +28,8 @@ extension DappInteractor {
 				WithViewStore(store, observe: { $0.currentModal }) { viewStore in
 					IfLetStore(
 						store.scope(state: \.$currentModal, action: { .child(.modal($0)) }),
-						state: /DappInteractor.Destinations.State.dappInteraction,
-						action: DappInteractor.Destinations.Action.dappInteraction,
+						state: /DappInteractor.Destination.State.dappInteraction,
+						action: DappInteractor.Destination.Action.dappInteraction,
 						then: { DappInteractionCoordinator.View(store: $0.relay()) }
 					)
 					.transition(.move(edge: .bottom))
@@ -38,8 +38,8 @@ extension DappInteractor {
 			}
 			.sheet(
 				store: store.scope(state: \.$currentModal, action: { .child(.modal($0)) }),
-				state: /DappInteractor.Destinations.State.dappInteractionCompletion,
-				action: DappInteractor.Destinations.Action.dappInteractionCompletion,
+				state: /DappInteractor.Destination.State.dappInteractionCompletion,
+				action: DappInteractor.Destination.Action.dappInteractionCompletion,
 				content: { Completion.View(store: $0) }
 			)
 			.alert(

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -16,7 +16,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 		var requestQueue: IdentifiedArrayOf<RequestEnvelope> = []
 
 		@PresentationState
-		var currentModal: Destinations.State?
+		var currentModal: Destination.State?
 
 		@PresentationState
 		var responseFailureAlert: AlertState<ViewAction.ResponseFailureAlertAction>?
@@ -72,10 +72,10 @@ struct DappInteractor: Sendable, FeatureReducer {
 	}
 
 	enum ChildAction: Sendable, Equatable {
-		case modal(PresentationAction<Destinations.Action>)
+		case modal(PresentationAction<Destination.Action>)
 	}
 
-	struct Destinations: Sendable, Reducer {
+	struct Destination: Sendable, Reducer {
 		enum State: Sendable, Hashable {
 			case dappInteraction(RelayState<RequestEnvelope, DappInteractionCoordinator.State>)
 			case dappInteractionCompletion(Completion.State)
@@ -109,7 +109,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 	var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$currentModal, action: /Action.child .. ChildAction.modal) {
-				Destinations()
+				Destination()
 			}
 			.ifLet(\.$responseFailureAlert, action: /Action.view .. ViewAction.responseFailureAlert)
 			.ifLet(\.$invalidRequestAlert, action: /Action.view .. ViewAction.invalidRequestAlert)

--- a/RadixWallet/Features/DappsAndPersonas/AuthorizedDApps/AuthorizedDApps+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/AuthorizedDApps/AuthorizedDApps+View.swift
@@ -58,9 +58,7 @@ extension AuthorizedDapps.View {
 				}
 			}
 			.navigationTitle(L10n.AuthorizedDapps.title)
-			.navigationDestination(store: store.presentedDapp) { store in
-				DappDetails.View(store: store)
-			}
+			.destinations(with: store)
 		}
 	}
 }
@@ -81,8 +79,21 @@ extension AuthorizedDapps.State {
 	}
 }
 
-extension AuthorizedDapps.Store {
-	var presentedDapp: PresentationStoreOf<DappDetails> {
-		scope(state: \.$presentedDapp) { .child(.presentedDapp($0)) }
+private extension StoreOf<AuthorizedDapps> {
+	var destination: PresentationStoreOf<AuthorizedDapps.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<AuthorizedDapps>) -> some View {
+		let destinationStore = store.destination
+		return navigationDestination(
+			store: destinationStore,
+			state: /AuthorizedDapps.Destination.State.presentedDapp,
+			action: AuthorizedDapps.Destination.Action.presentedDapp,
+			destination: { DappDetails.View(store: $0) }
+		)
 	}
 }

--- a/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
@@ -121,7 +121,7 @@ extension OnLedgerEntity.Resource {
 
 private extension StoreOf<DappDetails> {
 	var destination: PresentationStoreOf<DappDetails.Destination> {
-		scope(state: \.$destination, action: { .child(.destination($0)) })
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 

--- a/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
@@ -71,34 +71,58 @@ extension PersonaDetails.View {
 				}
 			}
 		}
-		.navigationDestination(
-			store: store.destination,
-			state: /PersonaDetails.Destination.State.dAppDetails,
-			action: PersonaDetails.Destination.Action.dAppDetails,
-			destination: { DappDetails.View(store: $0) }
-		)
-		.sheet(
-			store: store.destination,
-			state: /PersonaDetails.Destination.State.editPersona,
-			action: PersonaDetails.Destination.Action.editPersona,
-			content: { EditPersona.View(store: $0) }
-		)
-		.alert(
-			store: store.destination,
-			state: /PersonaDetails.Destination.State.confirmForgetAlert,
-			action: PersonaDetails.Destination.Action.confirmForgetAlert
-		)
-		.alert(
-			store: store.destination,
-			state: /PersonaDetails.Destination.State.confirmHideAlert,
-			action: PersonaDetails.Destination.Action.confirmHideAlert
-		)
+		.destinations(with: store)
 	}
 }
 
 private extension StoreOf<PersonaDetails> {
 	var destination: PresentationStoreOf<PersonaDetails.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<PersonaDetails>) -> some View {
+		let destinationStore = store.destination
+		return dAppDetails(with: destinationStore)
+			.editPersona(with: destinationStore)
+			.confirmForgetAlert(with: destinationStore)
+			.confirmHideAlert(with: destinationStore)
+	}
+
+	private func dAppDetails(with destinationStore: PresentationStoreOf<PersonaDetails.Destination>) -> some View {
+		navigationDestination(
+			store: destinationStore,
+			state: /PersonaDetails.Destination.State.dAppDetails,
+			action: PersonaDetails.Destination.Action.dAppDetails,
+			destination: { DappDetails.View(store: $0) }
+		)
+	}
+
+	private func editPersona(with destinationStore: PresentationStoreOf<PersonaDetails.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /PersonaDetails.Destination.State.editPersona,
+			action: PersonaDetails.Destination.Action.editPersona,
+			content: { EditPersona.View(store: $0) }
+		)
+	}
+
+	private func confirmForgetAlert(with destinationStore: PresentationStoreOf<PersonaDetails.Destination>) -> some View {
+		alert(
+			store: destinationStore,
+			state: /PersonaDetails.Destination.State.confirmForgetAlert,
+			action: PersonaDetails.Destination.Action.confirmForgetAlert
+		)
+	}
+
+	private func confirmHideAlert(with destinationStore: PresentationStoreOf<PersonaDetails.Destination>) -> some View {
+		alert(
+			store: destinationStore,
+			state: /PersonaDetails.Destination.State.confirmHideAlert,
+			action: PersonaDetails.Destination.Action.confirmHideAlert
+		)
 	}
 }
 

--- a/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
@@ -98,7 +98,7 @@ extension PersonaDetails.View {
 
 private extension StoreOf<PersonaDetails> {
 	var destination: PresentationStoreOf<PersonaDetails.Destination> {
-		scope(state: \.$destination, action: { .child(.destination($0)) })
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 

--- a/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails.swift
+++ b/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails.swift
@@ -90,7 +90,7 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 	// MARK: - Destination
 
 	public struct Destination: Reducer {
-		public enum State: Hashable {
+		public enum State: Sendable, Hashable {
 			case editPersona(EditPersona.State)
 			case dAppDetails(DappDetails.State)
 
@@ -98,7 +98,7 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 			case confirmHideAlert(AlertState<Action.ConfirmHideAlert>)
 		}
 
-		public enum Action: Equatable {
+		public enum Action: Sendable, Equatable {
 			case editPersona(EditPersona.Action)
 			case dAppDetails(DappDetails.Action)
 

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+View.swift
@@ -24,10 +24,16 @@ extension PersonasCoordinator {
 	}
 }
 
+extension StoreOf<PersonasCoordinator> {
+	var destination: PresentationStoreOf<PersonasCoordinator.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
 extension View {
 	@MainActor
 	fileprivate func destination(store: StoreOf<PersonasCoordinator>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+		let destinationStore = store.destination
 		return createPersonaCoordinator(with: destinationStore)
 			.personaDetails(with: destinationStore)
 	}

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+View.swift
@@ -19,7 +19,7 @@ extension PersonasCoordinator {
 				)
 			)
 			.onAppear { store.send(.view(.appeared)) }
-			.destination(store: store)
+			.destinations(with: store)
 		}
 	}
 }
@@ -30,15 +30,14 @@ extension StoreOf<PersonasCoordinator> {
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func destination(store: StoreOf<PersonasCoordinator>) -> some View {
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<PersonasCoordinator>) -> some View {
 		let destinationStore = store.destination
 		return createPersonaCoordinator(with: destinationStore)
 			.personaDetails(with: destinationStore)
 	}
 
-	@MainActor
 	private func createPersonaCoordinator(with destinationStore: PresentationStoreOf<PersonasCoordinator.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -48,7 +47,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func personaDetails(with destinationStore: PresentationStoreOf<PersonasCoordinator.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,

--- a/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
@@ -73,7 +73,7 @@ extension EditPersona {
 							EditPersonaEntries.View(
 								store: store.scope(
 									state: \.entries,
-									action: (/Action.child .. EditPersona.ChildAction.personaData).embed
+									action: (/Action.child .. EditPersona.ChildAction.entries).embed
 								)
 							)
 
@@ -107,13 +107,13 @@ extension EditPersona {
 				}
 				.confirmationDialog(
 					store: store.destination,
-					state: /EditPersona.Destinations.State.closeConfirmationDialog,
-					action: EditPersona.Destinations.Action.closeConfirmationDialog
+					state: /EditPersona.Destination.State.closeConfirmationDialog,
+					action: EditPersona.Destination.Action.closeConfirmationDialog
 				)
 				.sheet(
 					store: store.destination,
-					state: /EditPersona.Destinations.State.addFields,
-					action: EditPersona.Destinations.Action.addFields,
+					state: /EditPersona.Destination.State.addFields,
+					action: EditPersona.Destination.Action.addFields,
 					content: { EditPersonaAddEntryKinds.View(store: $0) }
 				)
 			}
@@ -122,7 +122,7 @@ extension EditPersona {
 }
 
 private extension StoreOf<EditPersona> {
-	var destination: PresentationStoreOf<EditPersona.Destinations> {
+	var destination: PresentationStoreOf<EditPersona.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 

--- a/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
@@ -58,15 +58,11 @@ extension EditPersona {
 						VStack(spacing: .medium1) {
 							PersonaThumbnail(viewStore.avatarURL, size: .veryLarge)
 
-							EditPersonaField.View(
-								store: store.scope(
-									state: \.labelField,
-									action: (/Action.child .. EditPersona.ChildAction.labelField).embed
-								)
-							)
+							EditPersonaField.View(store: store.labelField)
 
 							Separator()
 
+							// FIXME: Strings
 							Text("dApps can request permission from you to share the following fields of information.")
 								.multilineTextAlignment(.leading)
 								.textStyle(.body1HighImportance)
@@ -110,18 +106,32 @@ extension EditPersona {
 					}
 				}
 				.confirmationDialog(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+					store: store.destination,
 					state: /EditPersona.Destinations.State.closeConfirmationDialog,
 					action: EditPersona.Destinations.Action.closeConfirmationDialog
 				)
 				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+					store: store.destination,
 					state: /EditPersona.Destinations.State.addFields,
 					action: EditPersona.Destinations.Action.addFields,
 					content: { EditPersonaAddEntryKinds.View(store: $0) }
 				)
 			}
 		}
+	}
+}
+
+private extension StoreOf<EditPersona> {
+	var destination: PresentationStoreOf<EditPersona.Destinations> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+
+	var labelField: StoreOf<EditPersonaStaticField> {
+		scope(state: \.labelField) { .child(.labelField($0)) }
+	}
+
+	var personaEntries: StoreOf<EditPersonaEntries> {
+		scope(state: \.entries) { .child(.entries($0)) }
 	}
 }
 

--- a/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
@@ -105,7 +105,7 @@ extension EditPersona {
 						}
 					}
 				}
-				.destinations(with: store.destination)
+				.destinations(with: store)
 			}
 		}
 	}
@@ -125,26 +125,25 @@ private extension StoreOf<EditPersona> {
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func destinations(with store: PresentationStoreOf<EditPersona.Destination>) -> some View {
-		closeConfirmationDialog(with: store)
-			.addFields(with: store)
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<EditPersona>) -> some View {
+		let destinationStore = store.destination
+		return closeConfirmationDialog(with: destinationStore)
+			.addFields(with: destinationStore)
 	}
 
-	@MainActor
-	private func closeConfirmationDialog(with store: PresentationStoreOf<EditPersona.Destination>) -> some View {
+	private func closeConfirmationDialog(with destinationStore: PresentationStoreOf<EditPersona.Destination>) -> some View {
 		confirmationDialog(
-			store: store,
+			store: destinationStore,
 			state: /EditPersona.Destination.State.closeConfirmationDialog,
 			action: EditPersona.Destination.Action.closeConfirmationDialog
 		)
 	}
 
-	@MainActor
-	private func addFields(with store: PresentationStoreOf<EditPersona.Destination>) -> some View {
+	private func addFields(with destinationStore: PresentationStoreOf<EditPersona.Destination>) -> some View {
 		sheet(
-			store: store,
+			store: destinationStore,
 			state: /EditPersona.Destination.State.addFields,
 			action: EditPersona.Destination.Action.addFields,
 			content: { EditPersonaAddEntryKinds.View(store: $0) }

--- a/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
@@ -105,17 +105,7 @@ extension EditPersona {
 						}
 					}
 				}
-				.confirmationDialog(
-					store: store.destination,
-					state: /EditPersona.Destination.State.closeConfirmationDialog,
-					action: EditPersona.Destination.Action.closeConfirmationDialog
-				)
-				.sheet(
-					store: store.destination,
-					state: /EditPersona.Destination.State.addFields,
-					action: EditPersona.Destination.Action.addFields,
-					content: { EditPersonaAddEntryKinds.View(store: $0) }
-				)
+				.destinations(with: store.destination)
 			}
 		}
 	}
@@ -132,6 +122,33 @@ private extension StoreOf<EditPersona> {
 
 	var personaEntries: StoreOf<EditPersonaEntries> {
 		scope(state: \.entries) { .child(.entries($0)) }
+	}
+}
+
+extension View {
+	@MainActor
+	fileprivate func destinations(with store: PresentationStoreOf<EditPersona.Destination>) -> some View {
+		closeConfirmationDialog(with: store)
+			.addFields(with: store)
+	}
+
+	@MainActor
+	private func closeConfirmationDialog(with store: PresentationStoreOf<EditPersona.Destination>) -> some View {
+		confirmationDialog(
+			store: store,
+			state: /EditPersona.Destination.State.closeConfirmationDialog,
+			action: EditPersona.Destination.Action.closeConfirmationDialog
+		)
+	}
+
+	@MainActor
+	private func addFields(with store: PresentationStoreOf<EditPersona.Destination>) -> some View {
+		sheet(
+			store: store,
+			state: /EditPersona.Destination.State.addFields,
+			action: EditPersona.Destination.Action.addFields,
+			content: { EditPersonaAddEntryKinds.View(store: $0) }
+		)
 	}
 }
 

--- a/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
@@ -70,12 +70,7 @@ extension EditPersona {
 
 							Separator()
 
-							EditPersonaEntries.View(
-								store: store.scope(
-									state: \.entries,
-									action: (/Action.child .. EditPersona.ChildAction.entries).embed
-								)
-							)
+							EditPersonaEntries.View(store: store.personaEntries)
 
 							Button(action: { viewStore.send(.addAFieldButtonTapped) }) {
 								Text(L10n.EditPersona.addAField).padding(.horizontal, .medium2)

--- a/RadixWallet/Features/EditPersonaFeature/EditPersona.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersona.swift
@@ -70,7 +70,7 @@ public struct EditPersona: Sendable, FeatureReducer {
 		var labelField: EditPersonaStaticField.State
 
 		@PresentationState
-		var destination: Destinations.State? = nil
+		var destination: Destination.State? = nil
 
 		var alreadyAddedEntryKinds: [PersonaData.Entry.Kind] {
 			[entries.name?.kind, entries.emailAddress?.kind, entries.phoneNumber?.kind].compactMap(identity)
@@ -105,14 +105,14 @@ public struct EditPersona: Sendable, FeatureReducer {
 	public enum ChildAction: Sendable, Equatable {
 		case labelField(EditPersonaStaticField.Action)
 		case entries(EditPersonaEntries.Action)
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
 		case personaSaved(Profile.Network.Persona)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case closeConfirmationDialog(ConfirmationDialogState<ViewAction.CloseConfirmationDialogAction>)
 			case addFields(EditPersonaAddEntryKinds.State)
@@ -146,7 +146,7 @@ public struct EditPersona: Sendable, FeatureReducer {
 		}
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/EditPersonaFeature/EditPersona.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersona.swift
@@ -104,7 +104,7 @@ public struct EditPersona: Sendable, FeatureReducer {
 
 	public enum ChildAction: Sendable, Equatable {
 		case labelField(EditPersonaStaticField.Action)
-		case personaData(action: EditPersonaEntries.Action)
+		case entries(EditPersonaEntries.Action)
 		case destination(PresentationAction<Destinations.Action>)
 	}
 
@@ -141,7 +141,7 @@ public struct EditPersona: Sendable, FeatureReducer {
 		Scope(state: \.labelField, action: /Action.child .. ChildAction.labelField) {
 			EditPersonaField()
 		}
-		Scope(state: \.entries, action: /Action.child .. ChildAction.personaData) {
+		Scope(state: \.entries, action: /Action.child .. ChildAction.entries) {
 			EditPersonaEntries()
 		}
 		Reduce(core)

--- a/RadixWallet/Features/EditPersonaFeature/EditPersona.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersona.swift
@@ -20,7 +20,7 @@ extension EditPersona {
 						variant: $0.variant,
 						familyName: $0.family.input ?? "",
 						givenNames: $0.given.input ?? "",
-						nickname: $0.nickName.input ?? ""
+						nickname: $0.nickname.input ?? ""
 					)
 				)
 			}

--- a/RadixWallet/Features/EditPersonaFeature/EditPersonaEntries+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersonaEntries+View.swift
@@ -13,9 +13,7 @@ extension EditPersonaEntries {
 				IfLetStore(
 					store.scope(
 						state: \.name,
-						action: (/Action.child
-							.. EditPersonaEntries.ChildAction.name
-						).embed
+						action: { .child(.name($0)) }
 					)
 				) { store in
 					EditPersonaEntry.View(
@@ -29,9 +27,7 @@ extension EditPersonaEntries {
 				IfLetStore(
 					store.scope(
 						state: \.phoneNumber,
-						action: (/Action.child
-							.. EditPersonaEntries.ChildAction.phoneNumber
-						).embed
+						action: { .child(.phoneNumber($0)) }
 					)
 				) { store in
 					EditPersonaEntry.View(
@@ -44,9 +40,7 @@ extension EditPersonaEntries {
 				IfLetStore(
 					store.scope(
 						state: \.emailAddress,
-						action: (/Action.child
-							.. EditPersonaEntries.ChildAction.emailAddress
-						).embed
+						action: { .child(.emailAddress($0)) }
 					)
 				) { store in
 					EditPersonaEntry.View(

--- a/RadixWallet/Features/EditPersonaFeature/EditPersonaEntry+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersonaEntry+View.swift
@@ -46,12 +46,7 @@ extension EditPersonaEntry {
 				}
 
 				contentView(
-					store.scope(
-						state: \.content,
-						action: (/Action.child
-							.. EditPersonaEntry<ContentReducer>.ChildAction.content
-						).embed
-					)
+					store.scope(state: \.content) { .child(.content($0)) }
 				)
 			}
 		}

--- a/RadixWallet/Features/EditPersonaFeature/EditPersonaName+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersonaName+View.swift
@@ -14,10 +14,15 @@ extension EditPersonaName {
 					variantPicker(viewStore)
 
 					VStack(spacing: .medium2) {
-						if viewStore.variant == .eastern {
-							easternOrder()
-						} else {
-							westernOrder()
+						switch viewStore.variant {
+						case .eastern:
+							familyNameRow
+
+							givenNameRow
+						case .western:
+							givenNameRow
+
+							familyNameRow
 						}
 					}
 				}
@@ -28,10 +33,13 @@ extension EditPersonaName {
 		@ViewBuilder
 		func variantPicker(_ viewStore: ViewStoreOf<EditPersonaName>) -> some SwiftUI.View {
 			Menu {
-				Picker(selection: viewStore.binding(
-					get: \.variant,
-					send: ViewAction.variantPick
-				), label: EmptyView()) {
+				Picker(
+					selection: viewStore.binding(
+						get: \.variant,
+						send: ViewAction.variantPick
+					),
+					label: EmptyView()
+				) {
 					ForEach(PersonaData.Name.Variant.allCases, id: \.self) {
 						Text($0.text)
 							.textStyle(.body1Regular)
@@ -68,69 +76,31 @@ extension EditPersonaName {
 			}
 		}
 
-		// FIXME: Reordering could probably be done nicer by using a Grid probably
-		@ViewBuilder
-		func westernOrder() -> some SwiftUI.View {
+		private var givenNameRow: some SwiftUI.View {
 			HStack(alignment: .top, spacing: .medium3) {
 				EditPersonaField.View(
 					store: store.scope(
 						state: \.given,
-						action: (/Action.child
-							.. EditPersonaName.ChildAction.given
-						).embed
+						action: { .child(.given($0)) }
 					)
 				)
 
 				EditPersonaField.View(
 					store: store.scope(
-						state: \.nickName,
-						action: (/Action.child
-							.. EditPersonaName.ChildAction.nickname
-						).embed
+						state: \.nickname,
+						action: { .child(.nickname($0)) }
 					)
 				)
 			}
-
-			EditPersonaField.View(
-				store: store.scope(
-					state: \.family,
-					action: (/Action.child
-						.. EditPersonaName.ChildAction.family
-					).embed
-				)
-			)
 		}
 
-		@ViewBuilder
-		func easternOrder() -> some SwiftUI.View {
+		private var familyNameRow: some SwiftUI.View {
 			EditPersonaField.View(
 				store: store.scope(
 					state: \.family,
-					action: (/Action.child
-						.. EditPersonaName.ChildAction.family
-					).embed
+					action: { .child(.family($0)) }
 				)
 			)
-
-			HStack(alignment: .top, spacing: .medium3) {
-				EditPersonaField.View(
-					store: store.scope(
-						state: \.given,
-						action: (/Action.child
-							.. EditPersonaName.ChildAction.given
-						).embed
-					)
-				)
-
-				EditPersonaField.View(
-					store: store.scope(
-						state: \.nickName,
-						action: (/Action.child
-							.. EditPersonaName.ChildAction.nickname
-						).embed
-					)
-				)
-			}
 		}
 	}
 }

--- a/RadixWallet/Features/EditPersonaFeature/EditPersonaName.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersonaName.swift
@@ -7,7 +7,7 @@ public struct EditPersonaName: FeatureReducer, EmptyInitializable {
 		let id: PersonaDataEntryID
 		var family: EditPersonaDynamicField.State
 		var given: EditPersonaDynamicField.State
-		var nickName: EditPersonaDynamicField.State
+		var nickname: EditPersonaDynamicField.State
 		var variant: PersonaData.Name.Variant
 
 		init(
@@ -31,7 +31,7 @@ public struct EditPersonaName: FeatureReducer, EmptyInitializable {
 				isRequiredByDapp: isRequestedByDapp,
 				showsTitle: true
 			)
-			self.nickName = EditPersonaDynamicField.State(
+			self.nickname = EditPersonaDynamicField.State(
 				behaviour: .nickName,
 				entryID: id, // FIXME: refactor this whole thing
 				text: name.nickname,
@@ -68,7 +68,7 @@ public struct EditPersonaName: FeatureReducer, EmptyInitializable {
 		)
 
 		Scope(
-			state: \.nickName,
+			state: \.nickname,
 			action: /Action.child .. ChildAction.nickname,
 			child: EditPersonaField.init
 		)

--- a/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+Reducer.swift
+++ b/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+Reducer.swift
@@ -122,9 +122,6 @@ public struct GatewaySettings: Sendable, FeatureReducer {
 			// FIXME: display what is a gateway once we have copy
 			loggerGlobal.warning("What is A gateway tutorial slide up panel skipped, since no copy.")
 			return .none
-
-		default:
-			return .none
 		}
 	}
 

--- a/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+Reducer.swift
+++ b/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+Reducer.swift
@@ -60,11 +60,9 @@ public struct GatewaySettings: Sendable, FeatureReducer {
 			Scope(state: /State.addNewGateway, action: /Action.addNewGateway) {
 				AddNewGateway()
 			}
-
 			Scope(state: /State.createAccount, action: /Action.createAccount) {
 				CreateAccountCoordinator()
 			}
-
 			Scope(state: /State.slideUpPanel, action: /Action.slideUpPanel) {
 				SlideUpPanel()
 			}

--- a/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+Reducer.swift
+++ b/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+Reducer.swift
@@ -10,7 +10,7 @@ public struct GatewaySettings: Sendable, FeatureReducer {
 		var gatewayForRemoval: Radix.Gateway?
 
 		@PresentationState var removeGatewayAlert: AlertState<ViewAction.RemoveGatewayAction>?
-		@PresentationState var destination: Destinations.State?
+		@PresentationState var destination: Destination.State?
 
 		public init(
 			gatewayList: GatewayList.State = .init(gateways: [])
@@ -40,10 +40,10 @@ public struct GatewaySettings: Sendable, FeatureReducer {
 
 	public enum ChildAction: Sendable, Equatable {
 		case gatewayList(GatewayList.Action)
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case addNewGateway(AddNewGateway.State)
 			case createAccount(CreateAccountCoordinator.State)
@@ -93,7 +93,7 @@ public struct GatewaySettings: Sendable, FeatureReducer {
 		Reduce(core)
 			.ifLet(\.$removeGatewayAlert, action: /Action.view .. ViewAction.removeGateway)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+View.swift
+++ b/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+View.swift
@@ -31,8 +31,8 @@ extension GatewaySettings {
 						)
 						.sheet(
 							store: store.destination,
-							state: /Destinations.State.addNewGateway,
-							action: Destinations.Action.addNewGateway,
+							state: /Destination.State.addNewGateway,
+							action: Destination.Action.addNewGateway,
 							content: { addGatewayStore in
 								WithNavigationBar {
 									addGatewayStore.send(.view(.closeButtonTapped))
@@ -43,14 +43,14 @@ extension GatewaySettings {
 						)
 						.sheet(
 							store: store.destination,
-							state: /Destinations.State.createAccount,
-							action: Destinations.Action.createAccount,
+							state: /Destination.State.createAccount,
+							action: Destination.Action.createAccount,
 							content: { CreateAccountCoordinator.View(store: $0) }
 						)
 						.sheet(
 							store: store.destination,
-							state: /Destinations.State.slideUpPanel,
-							action: Destinations.Action.slideUpPanel,
+							state: /Destination.State.slideUpPanel,
+							action: Destination.Action.slideUpPanel,
 							content: { SlideUpPanel.View(store: $0) }
 						)
 				}
@@ -104,7 +104,7 @@ extension GatewaySettings {
 }
 
 private extension StoreOf<GatewaySettings> {
-	var destination: PresentationStoreOf<GatewaySettings.Destinations> {
+	var destination: PresentationStoreOf<GatewaySettings.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+View.swift
+++ b/RadixWallet/Features/GatewaySettingsFeature/GatewaySettings+View.swift
@@ -30,7 +30,7 @@ extension GatewaySettings {
 							)
 						)
 						.sheet(
-							store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+							store: store.destination,
 							state: /Destinations.State.addNewGateway,
 							action: Destinations.Action.addNewGateway,
 							content: { addGatewayStore in
@@ -42,18 +42,16 @@ extension GatewaySettings {
 							}
 						)
 						.sheet(
-							store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+							store: store.destination,
 							state: /Destinations.State.createAccount,
 							action: Destinations.Action.createAccount,
 							content: { CreateAccountCoordinator.View(store: $0) }
 						)
 						.sheet(
-							store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+							store: store.destination,
 							state: /Destinations.State.slideUpPanel,
 							action: Destinations.Action.slideUpPanel,
-							content: {
-								SlideUpPanel.View(store: $0)
-							}
+							content: { SlideUpPanel.View(store: $0) }
 						)
 				}
 			}
@@ -102,6 +100,12 @@ extension GatewaySettings {
 				)
 			)
 		}
+	}
+}
+
+private extension StoreOf<GatewaySettings> {
+	var destination: PresentationStoreOf<GatewaySettings.Destinations> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 

--- a/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
@@ -60,13 +60,13 @@ extension Home {
 					await viewStore.send(.task).finish()
 				}
 				.navigationDestination(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+					store: store.destination,
 					state: /Home.Destinations.State.accountDetails,
 					action: Home.Destinations.Action.accountDetails,
 					destination: { AccountDetails.View(store: $0) }
 				)
 				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+					store: store.destination,
 					state: /Home.Destinations.State.createAccount,
 					action: Home.Destinations.Action.createAccount,
 					content: { CreateAccountCoordinator.View(store: $0) }
@@ -85,6 +85,12 @@ extension Home {
 				}
 			}
 		}
+	}
+}
+
+private extension StoreOf<Home> {
+	var destination: PresentationStoreOf<Home.Destinations> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 

--- a/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
@@ -61,14 +61,14 @@ extension Home {
 				}
 				.navigationDestination(
 					store: store.destination,
-					state: /Home.Destinations.State.accountDetails,
-					action: Home.Destinations.Action.accountDetails,
+					state: /Home.Destination.State.accountDetails,
+					action: Home.Destination.Action.accountDetails,
 					destination: { AccountDetails.View(store: $0) }
 				)
 				.sheet(
 					store: store.destination,
-					state: /Home.Destinations.State.createAccount,
-					action: Home.Destinations.Action.createAccount,
+					state: /Home.Destination.State.createAccount,
+					action: Home.Destination.Action.createAccount,
 					content: { CreateAccountCoordinator.View(store: $0) }
 				)
 			}
@@ -89,7 +89,7 @@ extension Home {
 }
 
 private extension StoreOf<Home> {
-	var destination: PresentationStoreOf<Home.Destinations> {
+	var destination: PresentationStoreOf<Home.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
@@ -12,9 +12,9 @@ public struct Home: Sendable, FeatureReducer {
 			.init(uniqueElements: accountList.accounts.map(\.account))
 		}
 
-		// MARK: - Destinations
+		// MARK: - Destination
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init(
 			babylonAccountRecoveryIsNeeded: Bool
@@ -42,14 +42,14 @@ public struct Home: Sendable, FeatureReducer {
 	public enum ChildAction: Sendable, Equatable {
 		case header(Header.Action)
 		case accountList(AccountList.Action)
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
 		case displaySettings
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case accountDetails(AccountDetails.State)
 			case createAccount(CreateAccountCoordinator.State)
@@ -86,7 +86,7 @@ public struct Home: Sendable, FeatureReducer {
 		}
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
@@ -226,29 +226,29 @@ extension SwiftUI.View {
 	}
 
 	@MainActor
-	fileprivate func markMnemonicAsBackedUpAlert(with destinationStore: PresentationStoreOf<ImportMnemonic.Destinations>) -> some SwiftUI.View {
+	fileprivate func markMnemonicAsBackedUpAlert(with destinationStore: PresentationStoreOf<ImportMnemonic.Destination>) -> some SwiftUI.View {
 		alert(
 			store: destinationStore,
-			state: /ImportMnemonic.Destinations.State.markMnemonicAsBackedUp,
-			action: ImportMnemonic.Destinations.Action.markMnemonicAsBackedUp
+			state: /ImportMnemonic.Destination.State.markMnemonicAsBackedUp,
+			action: ImportMnemonic.Destination.Action.markMnemonicAsBackedUp
 		)
 	}
 
 	@MainActor
-	fileprivate func onContinueWarningAlert(with destinationStore: PresentationStoreOf<ImportMnemonic.Destinations>) -> some SwiftUI.View {
+	fileprivate func onContinueWarningAlert(with destinationStore: PresentationStoreOf<ImportMnemonic.Destination>) -> some SwiftUI.View {
 		alert(
 			store: destinationStore,
-			state: /ImportMnemonic.Destinations.State.onContinueWarning,
-			action: ImportMnemonic.Destinations.Action.onContinueWarning
+			state: /ImportMnemonic.Destination.State.onContinueWarning,
+			action: ImportMnemonic.Destination.Action.onContinueWarning
 		)
 	}
 
 	@MainActor
-	fileprivate func offDeviceMnemonicInfoSheet(with destinationStore: PresentationStoreOf<ImportMnemonic.Destinations>) -> some SwiftUI.View {
+	fileprivate func offDeviceMnemonicInfoSheet(with destinationStore: PresentationStoreOf<ImportMnemonic.Destination>) -> some SwiftUI.View {
 		sheet(
 			store: destinationStore,
-			state: /ImportMnemonic.Destinations.State.offDeviceMnemonicInfoPrompt,
-			action: ImportMnemonic.Destinations.Action.offDeviceMnemonicInfoPrompt,
+			state: /ImportMnemonic.Destination.State.offDeviceMnemonicInfoPrompt,
+			action: ImportMnemonic.Destination.Action.offDeviceMnemonicInfoPrompt,
 			content: { childStore in
 				OffDeviceMnemonicInfo.View(store: childStore)
 			}

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
@@ -190,7 +190,7 @@ extension ImportMnemonic {
 				#if !DEBUG
 					.screenshotProtected(isProtected: true)
 				#endif // !DEBUG
-					.destination(store: store)
+					.destinations(store: store)
 			}
 		}
 
@@ -216,17 +216,22 @@ extension ImportMnemonic {
 	}
 }
 
-extension SwiftUI.View {
-	@MainActor
-	func destination(store: StoreOf<ImportMnemonic>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+private extension StoreOf<ImportMnemonic> {
+	var destination: PresentationStoreOf<ImportMnemonic.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension SwiftUI.View {
+	func destinations(store: StoreOf<ImportMnemonic>) -> some View {
+		let destinationStore = store.destination
 		return offDeviceMnemonicInfoSheet(with: destinationStore)
 			.onContinueWarningAlert(with: destinationStore)
 			.markMnemonicAsBackedUpAlert(with: destinationStore)
 	}
 
-	@MainActor
-	fileprivate func markMnemonicAsBackedUpAlert(with destinationStore: PresentationStoreOf<ImportMnemonic.Destination>) -> some SwiftUI.View {
+	private func markMnemonicAsBackedUpAlert(with destinationStore: PresentationStoreOf<ImportMnemonic.Destination>) -> some SwiftUI.View {
 		alert(
 			store: destinationStore,
 			state: /ImportMnemonic.Destination.State.markMnemonicAsBackedUp,
@@ -234,8 +239,7 @@ extension SwiftUI.View {
 		)
 	}
 
-	@MainActor
-	fileprivate func onContinueWarningAlert(with destinationStore: PresentationStoreOf<ImportMnemonic.Destination>) -> some SwiftUI.View {
+	private func onContinueWarningAlert(with destinationStore: PresentationStoreOf<ImportMnemonic.Destination>) -> some SwiftUI.View {
 		alert(
 			store: destinationStore,
 			state: /ImportMnemonic.Destination.State.onContinueWarning,
@@ -243,8 +247,7 @@ extension SwiftUI.View {
 		)
 	}
 
-	@MainActor
-	fileprivate func offDeviceMnemonicInfoSheet(with destinationStore: PresentationStoreOf<ImportMnemonic.Destination>) -> some SwiftUI.View {
+	private func offDeviceMnemonicInfoSheet(with destinationStore: PresentationStoreOf<ImportMnemonic.Destination>) -> some SwiftUI.View {
 		sheet(
 			store: destinationStore,
 			state: /ImportMnemonic.Destination.State.offDeviceMnemonicInfoPrompt,

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
@@ -99,7 +99,7 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 		#endif
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public struct PersistStrategy: Sendable, Hashable {
 			public enum Location: Sendable, Hashable {
@@ -237,7 +237,7 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 		case word(id: ImportMnemonicWord.State.ID, child: ImportMnemonicWord.Action)
 	}
 
@@ -248,7 +248,7 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 		case doneViewing(markedMnemonicAsBackedUp: Bool? = nil) // `nil` means it was already marked as backed up
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case offDeviceMnemonicInfoPrompt(OffDeviceMnemonicInfo.State)
 			case markMnemonicAsBackedUp(AlertState<Action.MarkMnemonicAsBackedUpOrNot>)
@@ -301,7 +301,7 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 				ImportMnemonicWord()
 			}
 			.ifLet(\.$destination, action: /Action.child .. /ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 
@@ -638,7 +638,7 @@ extension ImportMnemonic {
 	}
 }
 
-extension ImportMnemonic.Destinations.State {
+extension ImportMnemonic.Destination.State {
 	fileprivate static func askUserIfSheHasBackedUpMnemonic(_ factorSourceID: FactorSourceID.FromHash) -> Self {
 		.markMnemonicAsBackedUp(.init(
 			title: { TextState(L10n.ImportMnemonic.BackedUpAlert.title) },

--- a/RadixWallet/Features/ImportOlympiaLedgerAccountsAndFactorSources/ImportOlympiaLedgerAccountsAndFactorSources+View.swift
+++ b/RadixWallet/Features/ImportOlympiaLedgerAccountsAndFactorSources/ImportOlympiaLedgerAccountsAndFactorSources+View.swift
@@ -83,25 +83,30 @@ extension ImportOlympiaLedgerAccountsAndFactorSources {
 					}
 					.buttonStyle(.primaryRectangular)
 				}
-				.destination(with: store)
 				.onFirstTask { @MainActor in
 					await viewStore.send(.onFirstTask).finish()
 				}
 			}
+			.destinations(with: store)
 		}
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func destination(with store: StoreOf<ImportOlympiaLedgerAccountsAndFactorSources>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+private extension StoreOf<ImportOlympiaLedgerAccountsAndFactorSources> {
+	var destination: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<ImportOlympiaLedgerAccountsAndFactorSources>) -> some View {
+		let destinationStore = store.destination
 		return addNewP2PLinkSheet(with: destinationStore)
 			.noP2PLinkAlert(with: destinationStore)
 			.nameLedgerSheet(with: destinationStore)
 	}
 
-	@MainActor
 	private func noP2PLinkAlert(with destinationStore: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destination>) -> some View {
 		alert(
 			store: destinationStore,
@@ -110,7 +115,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func addNewP2PLinkSheet(with destinationStore: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -120,7 +124,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func nameLedgerSheet(with destinationStore: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destination>) -> some View {
 		sheet(
 			store: destinationStore,

--- a/RadixWallet/Features/ImportOlympiaLedgerAccountsAndFactorSources/ImportOlympiaLedgerAccountsAndFactorSources+View.swift
+++ b/RadixWallet/Features/ImportOlympiaLedgerAccountsAndFactorSources/ImportOlympiaLedgerAccountsAndFactorSources+View.swift
@@ -83,7 +83,7 @@ extension ImportOlympiaLedgerAccountsAndFactorSources {
 					}
 					.buttonStyle(.primaryRectangular)
 				}
-				.destinations(with: store)
+				.destination(with: store)
 				.onFirstTask { @MainActor in
 					await viewStore.send(.onFirstTask).finish()
 				}
@@ -94,38 +94,38 @@ extension ImportOlympiaLedgerAccountsAndFactorSources {
 
 extension View {
 	@MainActor
-	fileprivate func destinations(with store: StoreOf<ImportOlympiaLedgerAccountsAndFactorSources>) -> some View {
-		let destinationStore = store.scope(state: \.$destinations, action: { .child(.destinations($0)) })
+	fileprivate func destination(with store: StoreOf<ImportOlympiaLedgerAccountsAndFactorSources>) -> some View {
+		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return addNewP2PLinkSheet(with: destinationStore)
 			.noP2PLinkAlert(with: destinationStore)
 			.nameLedgerSheet(with: destinationStore)
 	}
 
 	@MainActor
-	private func noP2PLinkAlert(with destinationStore: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destinations>) -> some View {
+	private func noP2PLinkAlert(with destinationStore: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destination>) -> some View {
 		alert(
 			store: destinationStore,
-			state: /ImportOlympiaLedgerAccountsAndFactorSources.Destinations.State.noP2PLink,
-			action: ImportOlympiaLedgerAccountsAndFactorSources.Destinations.Action.noP2PLink
+			state: /ImportOlympiaLedgerAccountsAndFactorSources.Destination.State.noP2PLink,
+			action: ImportOlympiaLedgerAccountsAndFactorSources.Destination.Action.noP2PLink
 		)
 	}
 
 	@MainActor
-	private func addNewP2PLinkSheet(with destinationStore: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destinations>) -> some View {
+	private func addNewP2PLinkSheet(with destinationStore: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /ImportOlympiaLedgerAccountsAndFactorSources.Destinations.State.addNewP2PLink,
-			action: ImportOlympiaLedgerAccountsAndFactorSources.Destinations.Action.addNewP2PLink,
+			state: /ImportOlympiaLedgerAccountsAndFactorSources.Destination.State.addNewP2PLink,
+			action: ImportOlympiaLedgerAccountsAndFactorSources.Destination.Action.addNewP2PLink,
 			content: { NewConnection.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func nameLedgerSheet(with destinationStore: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destinations>) -> some View {
+	private func nameLedgerSheet(with destinationStore: PresentationStoreOf<ImportOlympiaLedgerAccountsAndFactorSources.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /ImportOlympiaLedgerAccountsAndFactorSources.Destinations.State.nameLedgerAndDerivePublicKeys,
-			action: ImportOlympiaLedgerAccountsAndFactorSources.Destinations.Action.nameLedgerAndDerivePublicKeys,
+			state: /ImportOlympiaLedgerAccountsAndFactorSources.Destination.State.nameLedgerAndDerivePublicKeys,
+			action: ImportOlympiaLedgerAccountsAndFactorSources.Destination.Action.nameLedgerAndDerivePublicKeys,
 			content: { NameLedgerAndDerivePublicKeys.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/LedgerHardwareDevices/LedgerHardwareDevices+Reducer.swift
+++ b/RadixWallet/Features/LedgerHardwareDevices/LedgerHardwareDevices+Reducer.swift
@@ -28,7 +28,7 @@ public struct LedgerHardwareDevices: Sendable, FeatureReducer {
 		let selectedLedgerControlRequirements: SelectedLedgerControlRequirements? = nil
 
 		@PresentationState
-		public var destination: Destinations.State? = nil
+		public var destination: Destination.State? = nil
 
 		var pendingAction: ActionRequiringP2P? = nil
 
@@ -59,7 +59,7 @@ public struct LedgerHardwareDevices: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -68,7 +68,7 @@ public struct LedgerHardwareDevices: Sendable, FeatureReducer {
 
 	// MARK: - Destination
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case noP2PLink(AlertState<NoP2PLinkAlert>)
 			case addNewP2PLink(NewConnection.State)
@@ -103,7 +103,7 @@ public struct LedgerHardwareDevices: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/LedgerHardwareDevices/LedgerHardwareDevices+View.swift
+++ b/RadixWallet/Features/LedgerHardwareDevices/LedgerHardwareDevices+View.swift
@@ -190,31 +190,31 @@ extension View {
 	}
 
 	@MainActor
-	private func addNewLedgerSheet(with destinationStore: PresentationStoreOf<LedgerHardwareDevices.Destinations>) -> some View {
+	private func addNewLedgerSheet(with destinationStore: PresentationStoreOf<LedgerHardwareDevices.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /LedgerHardwareDevices.Destinations.State.addNewLedger,
-			action: LedgerHardwareDevices.Destinations.Action.addNewLedger,
+			state: /LedgerHardwareDevices.Destination.State.addNewLedger,
+			action: LedgerHardwareDevices.Destination.Action.addNewLedger,
 			content: { AddLedgerFactorSource.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func addNewP2PLinkSheet(with destinationStore: PresentationStoreOf<LedgerHardwareDevices.Destinations>) -> some View {
+	private func addNewP2PLinkSheet(with destinationStore: PresentationStoreOf<LedgerHardwareDevices.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /LedgerHardwareDevices.Destinations.State.addNewP2PLink,
-			action: LedgerHardwareDevices.Destinations.Action.addNewP2PLink,
+			state: /LedgerHardwareDevices.Destination.State.addNewP2PLink,
+			action: LedgerHardwareDevices.Destination.Action.addNewP2PLink,
 			content: { NewConnection.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func noP2PLinkAlert(with destinationStore: PresentationStoreOf<LedgerHardwareDevices.Destinations>) -> some View {
+	private func noP2PLinkAlert(with destinationStore: PresentationStoreOf<LedgerHardwareDevices.Destination>) -> some View {
 		alert(
 			store: destinationStore,
-			state: /LedgerHardwareDevices.Destinations.State.noP2PLink,
-			action: LedgerHardwareDevices.Destinations.Action.noP2PLink
+			state: /LedgerHardwareDevices.Destination.State.noP2PLink,
+			action: LedgerHardwareDevices.Destination.Action.noP2PLink
 		)
 	}
 }

--- a/RadixWallet/Features/LedgerHardwareDevices/LedgerHardwareDevices+View.swift
+++ b/RadixWallet/Features/LedgerHardwareDevices/LedgerHardwareDevices+View.swift
@@ -180,16 +180,21 @@ extension LedgerHardwareDevices {
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func destinations(with store: StoreOf<LedgerHardwareDevices>) -> some View {
+private extension StoreOf<LedgerHardwareDevices> {
+	var destination: PresentationStoreOf<LedgerHardwareDevices.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<LedgerHardwareDevices>) -> some View {
 		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return addNewLedgerSheet(with: destinationStore)
 			.addNewP2PLinkSheet(with: destinationStore)
 			.noP2PLinkAlert(with: destinationStore)
 	}
 
-	@MainActor
 	private func addNewLedgerSheet(with destinationStore: PresentationStoreOf<LedgerHardwareDevices.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -199,7 +204,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func addNewP2PLinkSheet(with destinationStore: PresentationStoreOf<LedgerHardwareDevices.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -209,7 +213,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func noP2PLinkAlert(with destinationStore: PresentationStoreOf<LedgerHardwareDevices.Destination>) -> some View {
 		alert(
 			store: destinationStore,

--- a/RadixWallet/Features/MainFeature/Main+Reducer.swift
+++ b/RadixWallet/Features/MainFeature/Main+Reducer.swift
@@ -7,9 +7,9 @@ public struct Main: Sendable, FeatureReducer {
 
 		public var isOnMainnet = true
 
-		// MARK: - Destinations
+		// MARK: - Destination
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init(home: Home.State) {
 			self.home = home
@@ -22,7 +22,7 @@ public struct Main: Sendable, FeatureReducer {
 
 	public enum ChildAction: Sendable, Equatable {
 		case home(Home.Action)
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -33,7 +33,7 @@ public struct Main: Sendable, FeatureReducer {
 		case currentGatewayChanged(to: Radix.Gateway)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case settings(Settings.State)
 		}
@@ -60,7 +60,7 @@ public struct Main: Sendable, FeatureReducer {
 		}
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/MainFeature/Main+View.swift
+++ b/RadixWallet/Features/MainFeature/Main+View.swift
@@ -26,7 +26,7 @@ extension Main {
 					)
 				)
 				.navigationDestination(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+					store: store.destination,
 					state: /Main.Destinations.State.settings,
 					action: Main.Destinations.Action.settings,
 					destination: { Settings.View(store: $0) }
@@ -38,6 +38,12 @@ extension Main {
 			.showDeveloperDisclaimerBanner(bannerStore)
 			.presentsDappInteractions()
 		}
+	}
+}
+
+private extension StoreOf<Main> {
+	var destination: PresentationStoreOf<Main.Destinations> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 

--- a/RadixWallet/Features/MainFeature/Main+View.swift
+++ b/RadixWallet/Features/MainFeature/Main+View.swift
@@ -27,8 +27,8 @@ extension Main {
 				)
 				.navigationDestination(
 					store: store.destination,
-					state: /Main.Destinations.State.settings,
-					action: Main.Destinations.Action.settings,
+					state: /Main.Destination.State.settings,
+					action: Main.Destination.Action.settings,
 					destination: { Settings.View(store: $0) }
 				)
 			}
@@ -42,7 +42,7 @@ extension Main {
 }
 
 private extension StoreOf<Main> {
-	var destination: PresentationStoreOf<Main.Destinations> {
+	var destination: PresentationStoreOf<Main.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/AdvancedCreateSecurityStructureFlow+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/AdvancedCreateSecurityStructureFlow+View.swift
@@ -133,46 +133,51 @@ extension AdvancedManageSecurityStructureFlow {
 						}
 					)
 				}
-				.destination(store: store)
 			}
+			.destinations(with: store)
 		}
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func destination(store: StoreOf<AdvancedManageSecurityStructureFlow>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
-		return primary(destinationStore).recovery(destinationStore).confirmation(destinationStore)
+private extension StoreOf<AdvancedManageSecurityStructureFlow> {
+	var destination: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<AdvancedManageSecurityStructureFlow>) -> some View {
+		let destinationStore = store.destination
+		return primary(with: destinationStore)
+			.recovery(with: destinationStore)
+			.confirmation(with: destinationStore)
 	}
 
-	@MainActor
-	private func primary(_ destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination>) -> some View {
+	private func primary(with destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
 			state: /AdvancedManageSecurityStructureFlow.Destination.State.factorsForPrimaryRole,
 			action: AdvancedManageSecurityStructureFlow.Destination.Action.factorsForPrimaryRole,
-			content: { store in NavigationView { FactorsForRole<PrimaryRoleTag>.View(store: store) } }
+			content: { FactorsForRole<PrimaryRoleTag>.View(store: $0).inNavigationView }
 		)
 	}
 
-	@MainActor
-	private func recovery(_ destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination>) -> some View {
+	private func recovery(with destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
 			state: /AdvancedManageSecurityStructureFlow.Destination.State.factorsForRecoveryRole,
 			action: AdvancedManageSecurityStructureFlow.Destination.Action.factorsForRecoveryRole,
-			content: { store in NavigationView { FactorsForRole<RecoveryRoleTag>.View(store: store) } }
+			content: { FactorsForRole<RecoveryRoleTag>.View(store: $0).inNavigationView }
 		)
 	}
 
-	@MainActor
-	private func confirmation(_ destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination>) -> some View {
+	private func confirmation(with destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
 			state: /AdvancedManageSecurityStructureFlow.Destination.State.factorsForConfirmationRole,
 			action: AdvancedManageSecurityStructureFlow.Destination.Action.factorsForConfirmationRole,
-			content: { store in NavigationView { FactorsForRole<ConfirmationRoleTag>.View(store: store) } }
+			content: { FactorsForRole<ConfirmationRoleTag>.View(store: $0).inNavigationView }
 		)
 	}
 }

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/AdvancedCreateSecurityStructureFlow+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/AdvancedCreateSecurityStructureFlow+View.swift
@@ -133,7 +133,7 @@ extension AdvancedManageSecurityStructureFlow {
 						}
 					)
 				}
-				.destinations(store: store)
+				.destination(store: store)
 			}
 		}
 	}
@@ -141,37 +141,37 @@ extension AdvancedManageSecurityStructureFlow {
 
 extension View {
 	@MainActor
-	fileprivate func destinations(store: StoreOf<AdvancedManageSecurityStructureFlow>) -> some View {
+	fileprivate func destination(store: StoreOf<AdvancedManageSecurityStructureFlow>) -> some View {
 		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return primary(destinationStore).recovery(destinationStore).confirmation(destinationStore)
 	}
 
 	@MainActor
-	private func primary(_ destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destinations>) -> some View {
+	private func primary(_ destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /AdvancedManageSecurityStructureFlow.Destinations.State.factorsForPrimaryRole,
-			action: AdvancedManageSecurityStructureFlow.Destinations.Action.factorsForPrimaryRole,
+			state: /AdvancedManageSecurityStructureFlow.Destination.State.factorsForPrimaryRole,
+			action: AdvancedManageSecurityStructureFlow.Destination.Action.factorsForPrimaryRole,
 			content: { store in NavigationView { FactorsForRole<PrimaryRoleTag>.View(store: store) } }
 		)
 	}
 
 	@MainActor
-	private func recovery(_ destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destinations>) -> some View {
+	private func recovery(_ destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /AdvancedManageSecurityStructureFlow.Destinations.State.factorsForRecoveryRole,
-			action: AdvancedManageSecurityStructureFlow.Destinations.Action.factorsForRecoveryRole,
+			state: /AdvancedManageSecurityStructureFlow.Destination.State.factorsForRecoveryRole,
+			action: AdvancedManageSecurityStructureFlow.Destination.Action.factorsForRecoveryRole,
 			content: { store in NavigationView { FactorsForRole<RecoveryRoleTag>.View(store: store) } }
 		)
 	}
 
 	@MainActor
-	private func confirmation(_ destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destinations>) -> some View {
+	private func confirmation(_ destinationStore: PresentationStoreOf<AdvancedManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /AdvancedManageSecurityStructureFlow.Destinations.State.factorsForConfirmationRole,
-			action: AdvancedManageSecurityStructureFlow.Destinations.Action.factorsForConfirmationRole,
+			state: /AdvancedManageSecurityStructureFlow.Destination.State.factorsForConfirmationRole,
+			action: AdvancedManageSecurityStructureFlow.Destination.Action.factorsForConfirmationRole,
 			content: { store in NavigationView { FactorsForRole<ConfirmationRoleTag>.View(store: store) } }
 		)
 	}

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/AdvancedCreateSecurityStructureFlow.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/AdvancedCreateSecurityStructureFlow.swift
@@ -17,7 +17,7 @@ public struct AdvancedManageSecurityStructureFlow: Sendable, FeatureReducer {
 		public var numberOfDaysUntilAutoConfirmation: RecoveryAutoConfirmDelayInDays
 
 		@PresentationState
-		var destination: Destinations.State? = nil
+		var destination: Destination.State? = nil
 
 		public init(mode: Mode) {
 			switch mode {
@@ -38,7 +38,7 @@ public struct AdvancedManageSecurityStructureFlow: Sendable, FeatureReducer {
 		}
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case factorsForPrimaryRole(FactorsForRole<PrimaryRoleTag>.State)
 			case factorsForRecoveryRole(FactorsForRole<RecoveryRoleTag>.State)
@@ -74,7 +74,7 @@ public struct AdvancedManageSecurityStructureFlow: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -86,7 +86,7 @@ public struct AdvancedManageSecurityStructureFlow: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/FactorsForRole+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/FactorsForRole+View.swift
@@ -176,11 +176,6 @@ extension FactorsForRole {
 					}
 				}
 				.destinations(with: store)
-				.confirmationDialog(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /FactorsForRole.Destination.State.existingRoleMadeLessSafeConfirmationDialog,
-					action: FactorsForRole.Destination.Action.existingRoleMadeLessSafeConfirmationDialog
-				)
 				.navigationTitle(viewStore.role.titleAdvancedFlow)
 				.padding()
 				.frame(maxWidth: .infinity)
@@ -189,15 +184,15 @@ extension FactorsForRole {
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func destinations(with store: StoreOf<FactorsForRole<some RoleProtocol>>) -> some SwiftUI.View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<FactorsForRole<some RoleProtocol>>) -> some SwiftUI.View {
+		let destinationStore = store.scope(state: \.$destination) { .child(.destination($0)) }
 		return addThresholdFactorSheet(with: destinationStore)
 			.addAdminFactorSheet(with: destinationStore)
+			.existingRoleMadeLessSafe(with: destinationStore)
 	}
 
-	@MainActor
 	private func addThresholdFactorSheet(with destinationStore: PresentationStoreOf<FactorsForRole<some RoleProtocol>.Destination>) -> some SwiftUI.View {
 		sheet(
 			store: destinationStore,
@@ -207,13 +202,20 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func addAdminFactorSheet(with destinationStore: PresentationStoreOf<FactorsForRole<some RoleProtocol>.Destination>) -> some SwiftUI.View {
 		sheet(
 			store: destinationStore,
 			state: /FactorsForRole.Destination.State.addAdminFactor,
 			action: FactorsForRole.Destination.Action.addAdminFactor,
 			content: { store in NavigationView { SelectFactorKindThenFactor.View(store: store) } }
+		)
+	}
+
+	private func existingRoleMadeLessSafe(with destinationStore: PresentationStoreOf<FactorsForRole<some RoleProtocol>.Destination>) -> some SwiftUI.View {
+		confirmationDialog(
+			store: destinationStore,
+			state: /FactorsForRole.Destination.State.existingRoleMadeLessSafeConfirmationDialog,
+			action: FactorsForRole.Destination.Action.existingRoleMadeLessSafeConfirmationDialog
 		)
 	}
 }

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/FactorsForRole+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/FactorsForRole+View.swift
@@ -178,8 +178,8 @@ extension FactorsForRole {
 				.destinations(with: store)
 				.confirmationDialog(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /FactorsForRole.Destinations.State.existingRoleMadeLessSafeConfirmationDialog,
-					action: FactorsForRole.Destinations.Action.existingRoleMadeLessSafeConfirmationDialog
+					state: /FactorsForRole.Destination.State.existingRoleMadeLessSafeConfirmationDialog,
+					action: FactorsForRole.Destination.Action.existingRoleMadeLessSafeConfirmationDialog
 				)
 				.navigationTitle(viewStore.role.titleAdvancedFlow)
 				.padding()
@@ -198,21 +198,21 @@ extension View {
 	}
 
 	@MainActor
-	private func addThresholdFactorSheet(with destinationStore: PresentationStoreOf<FactorsForRole<some RoleProtocol>.Destinations>) -> some SwiftUI.View {
+	private func addThresholdFactorSheet(with destinationStore: PresentationStoreOf<FactorsForRole<some RoleProtocol>.Destination>) -> some SwiftUI.View {
 		sheet(
 			store: destinationStore,
-			state: /FactorsForRole.Destinations.State.addThresholdFactor,
-			action: FactorsForRole.Destinations.Action.addThresholdFactor,
+			state: /FactorsForRole.Destination.State.addThresholdFactor,
+			action: FactorsForRole.Destination.Action.addThresholdFactor,
 			content: { store in NavigationView { SelectFactorKindThenFactor.View(store: store) } }
 		)
 	}
 
 	@MainActor
-	private func addAdminFactorSheet(with destinationStore: PresentationStoreOf<FactorsForRole<some RoleProtocol>.Destinations>) -> some SwiftUI.View {
+	private func addAdminFactorSheet(with destinationStore: PresentationStoreOf<FactorsForRole<some RoleProtocol>.Destination>) -> some SwiftUI.View {
 		sheet(
 			store: destinationStore,
-			state: /FactorsForRole.Destinations.State.addAdminFactor,
-			action: FactorsForRole.Destinations.Action.addAdminFactor,
+			state: /FactorsForRole.Destination.State.addAdminFactor,
+			action: FactorsForRole.Destination.Action.addAdminFactor,
 			content: { store in NavigationView { SelectFactorKindThenFactor.View(store: store) } }
 		)
 	}

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/FactorsForRole.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/FactorsForRole.swift
@@ -41,7 +41,7 @@ public struct FactorsForRole<R: RoleProtocol>: Sendable, FeatureReducer {
 		public var adminFactorSources: IdentifiedArrayOf<FactorSource>
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public let existing: RoleOfTier<R, FactorSource>?
 
@@ -75,14 +75,14 @@ public struct FactorsForRole<R: RoleProtocol>: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
 		case confirmedRoleWithFactors(RoleOfTier<R, FactorSource>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case addThresholdFactor(SelectFactorKindThenFactor.State)
 			case addAdminFactor(SelectFactorKindThenFactor.State)
@@ -115,7 +115,7 @@ public struct FactorsForRole<R: RoleProtocol>: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/SelectFactorKindThenFactor+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/SelectFactorKindThenFactor+View.swift
@@ -41,22 +41,42 @@ extension SelectFactorKindThenFactor {
 					}
 				}
 				.navigationTitle("Select Factor kind")
-				.sheet(
-					store: store.scope(
-						state: \.$factorSourceOfKind,
-						action: { .child(.factorSourceOfKind($0)) }
-					),
-					content: { FactorSourcesOfKindList<FactorSource>.View(store: $0) }
-				)
-				.sheet(
-					store: store.scope(
-						state: \.$selectLedger,
-						action: { .child(.selectLedger($0)) }
-					),
-					content: { LedgerHardwareDevices.View(store: $0) }
-				)
+				.destinations(with: store)
 			}
 		}
+	}
+}
+
+private extension StoreOf<SelectFactorKindThenFactor> {
+	var destination: PresentationStoreOf<SelectFactorKindThenFactor.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<SelectFactorKindThenFactor>) -> some View {
+		let destinationStore = store.destination
+		return factorSourceOfKind(with: destinationStore)
+			.selectLedger(with: destinationStore)
+	}
+
+	private func factorSourceOfKind(with destinationStore: PresentationStoreOf<SelectFactorKindThenFactor.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /SelectFactorKindThenFactor.Destination.State.factorSourceOfKind,
+			action: SelectFactorKindThenFactor.Destination.Action.factorSourceOfKind,
+			content: { FactorSourcesOfKindList<FactorSource>.View(store: $0) }
+		)
+	}
+
+	private func selectLedger(with destinationStore: PresentationStoreOf<SelectFactorKindThenFactor.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /SelectFactorKindThenFactor.Destination.State.selectLedger,
+			action: SelectFactorKindThenFactor.Destination.Action.selectLedger,
+			content: { LedgerHardwareDevices.View(store: $0) }
+		)
 	}
 }
 

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/SelectFactorKindThenFactor.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Advanced/Role/SelectFactorKindThenFactor.swift
@@ -3,44 +3,66 @@ import SwiftUI
 
 // MARK: - SelectFactorKindThenFactor
 public struct SelectFactorKindThenFactor: Sendable, FeatureReducer {
+	// MARK: State
+
 	public struct State: Sendable, Hashable {
 		public let role: SecurityStructureRole
 
 		@PresentationState
-		public var factorSourceOfKind: FactorSourcesOfKindList<FactorSource>.State?
-
-		// Uh... we have to special treat Ledger, because... it is complex and uses its own list because
-		// it requires P2P connection...
-		@PresentationState
-		public var selectLedger: LedgerHardwareDevices.State?
+		public var destination: Destination.State? = nil
 
 		public init(role: SecurityStructureRole) {
 			self.role = role
 		}
 	}
 
+	// MARK: Action
+
 	public enum ViewAction: Sendable, Equatable {
 		case selected(FactorSourceKind)
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case factorSourceOfKind(PresentationAction<FactorSourcesOfKindList<FactorSource>.Action>)
-		case selectLedger(PresentationAction<LedgerHardwareDevices.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
 		case selected(FactorSource)
 	}
 
+	// MARK: Destination
+
+	public struct Destination: Reducer, Sendable {
+		public enum State: Hashable, Sendable {
+			case factorSourceOfKind(FactorSourcesOfKindList<FactorSource>.State)
+			// Uh... we have to special treat Ledger, because... it is complex and uses its own list because
+			// it requires P2P connection...
+			case selectLedger(LedgerHardwareDevices.State)
+		}
+
+		public enum Action: Equatable, Sendable {
+			case factorSourceOfKind(FactorSourcesOfKindList<FactorSource>.Action)
+			case selectLedger(LedgerHardwareDevices.Action)
+		}
+
+		public var body: some ReducerOf<Self> {
+			Scope(state: /State.factorSourceOfKind, action: /Action.factorSourceOfKind) {
+				FactorSourcesOfKindList<FactorSource>()
+			}
+			Scope(state: /State.selectLedger, action: /Action.selectLedger) {
+				LedgerHardwareDevices()
+			}
+		}
+	}
+
+	// MARK: Reducer
+
 	public init() {}
 
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
-			.ifLet(\.$factorSourceOfKind, action: /Action.child .. ChildAction.factorSourceOfKind) {
-				FactorSourcesOfKindList<FactorSource>()
-			}
-			.ifLet(\.$selectLedger, action: /Action.child .. ChildAction.selectLedger) {
-				LedgerHardwareDevices()
+			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
+				Destination()
 			}
 	}
 
@@ -49,9 +71,9 @@ public struct SelectFactorKindThenFactor: Sendable, FeatureReducer {
 		case let .selected(kind):
 			switch kind {
 			case .ledgerHQHardwareWallet:
-				state.selectLedger = .init(context: .setupMFA)
+				state.destination = .selectLedger(.init(context: .setupMFA))
 			default:
-				state.factorSourceOfKind = .init(kind: kind, mode: .selection)
+				state.destination = .factorSourceOfKind(.init(kind: kind, mode: .selection))
 			}
 			return .none
 		}
@@ -59,13 +81,19 @@ public struct SelectFactorKindThenFactor: Sendable, FeatureReducer {
 
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
-		case let .factorSourceOfKind(.presented(.delegate(.choseFactorSource(factorSource)))):
-			state.factorSourceOfKind = nil
-			return .send(.delegate(.selected(factorSource)))
+		case let .destination(.presented(presentedAction)):
+			switch presentedAction {
+			case let .factorSourceOfKind(.delegate(.choseFactorSource(factorSource))):
+				state.destination = nil
+				return .send(.delegate(.selected(factorSource)))
 
-		case let .selectLedger(.presented(.delegate(.choseLedger(ledger)))):
-			state.selectLedger = nil
-			return .send(.delegate(.selected(ledger.embed())))
+			case let .selectLedger(.delegate(.choseLedger(ledger))):
+				state.destination = nil
+				return .send(.delegate(.selected(ledger.embed())))
+
+			default:
+				return .none
+			}
 
 		default:
 			return .none

--- a/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList+View.swift
@@ -109,11 +109,11 @@ public extension FactorSourcesOfKindList {
 					await viewStore.send(.onFirstTask).finish()
 				}
 			}
-			.destinations(with: store)
+			.destination(with: store)
 			.confirmationDialog(
 				store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-				state: /FactorSourcesOfKindList.Destinations.State.existingFactorSourceWillBeDeletedConfirmationDialog,
-				action: FactorSourcesOfKindList.Destinations.Action.existingFactorSourceWillBeDeletedConfirmationDialog
+				state: /FactorSourcesOfKindList.Destination.State.existingFactorSourceWillBeDeletedConfirmationDialog,
+				action: FactorSourcesOfKindList.Destination.Action.existingFactorSourceWillBeDeletedConfirmationDialog
 			)
 		}
 
@@ -163,17 +163,17 @@ extension FactorSource {
 
 extension View {
 	@MainActor
-	fileprivate func destinations(with store: StoreOf<FactorSourcesOfKindList<some BaseFactorSourceProtocol>>) -> some SwiftUI.View {
+	fileprivate func destination(with store: StoreOf<FactorSourcesOfKindList<some BaseFactorSourceProtocol>>) -> some SwiftUI.View {
 		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return addNewFactorSourceSheet(with: destinationStore)
 	}
 
 	@MainActor
-	private func addNewFactorSourceSheet<F>(with destinationStore: PresentationStoreOf<FactorSourcesOfKindList<F>.Destinations>) -> some SwiftUI.View where F: BaseFactorSourceProtocol {
+	private func addNewFactorSourceSheet<F>(with destinationStore: PresentationStoreOf<FactorSourcesOfKindList<F>.Destination>) -> some SwiftUI.View where F: BaseFactorSourceProtocol {
 		sheet(
 			store: destinationStore,
-			state: /FactorSourcesOfKindList.Destinations.State.addNewFactorSource,
-			action: FactorSourcesOfKindList.Destinations.Action.addNewFactorSource,
+			state: /FactorSourcesOfKindList.Destination.State.addNewFactorSource,
+			action: FactorSourcesOfKindList.Destination.Action.addNewFactorSource,
 			content: { ManageSomeFactorSource<F>.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList+View.swift
@@ -109,12 +109,7 @@ public extension FactorSourcesOfKindList {
 					await viewStore.send(.onFirstTask).finish()
 				}
 			}
-			.destination(with: store)
-			.confirmationDialog(
-				store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-				state: /FactorSourcesOfKindList.Destination.State.existingFactorSourceWillBeDeletedConfirmationDialog,
-				action: FactorSourcesOfKindList.Destination.Action.existingFactorSourceWillBeDeletedConfirmationDialog
-			)
+			.destinations(with: store)
 		}
 
 		@ViewBuilder
@@ -161,20 +156,27 @@ extension FactorSource {
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func destination(with store: StoreOf<FactorSourcesOfKindList<some BaseFactorSourceProtocol>>) -> some SwiftUI.View {
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<FactorSourcesOfKindList<some BaseFactorSourceProtocol>>) -> some View {
 		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return addNewFactorSourceSheet(with: destinationStore)
 	}
 
-	@MainActor
-	private func addNewFactorSourceSheet<F>(with destinationStore: PresentationStoreOf<FactorSourcesOfKindList<F>.Destination>) -> some SwiftUI.View where F: BaseFactorSourceProtocol {
+	private func addNewFactorSourceSheet<F>(with destinationStore: PresentationStoreOf<FactorSourcesOfKindList<F>.Destination>) -> some View where F: BaseFactorSourceProtocol {
 		sheet(
 			store: destinationStore,
 			state: /FactorSourcesOfKindList.Destination.State.addNewFactorSource,
 			action: FactorSourcesOfKindList.Destination.Action.addNewFactorSource,
 			content: { ManageSomeFactorSource<F>.View(store: $0) }
+		)
+	}
+
+	private func existingFactorSourceWillBeDeleted(with destinationStore: PresentationStoreOf<FactorSourcesOfKindList<some BaseFactorSourceProtocol>.Destination>) -> some View {
+		confirmationDialog(
+			store: destinationStore,
+			state: /FactorSourcesOfKindList.Destination.State.existingFactorSourceWillBeDeletedConfirmationDialog,
+			action: FactorSourcesOfKindList.Destination.Action.existingFactorSourceWillBeDeletedConfirmationDialog
 		)
 	}
 }

--- a/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList.swift
@@ -25,7 +25,7 @@ public struct FactorSourcesOfKindList<FactorSourceOfKind: Sendable & Hashable>: 
 		public var selectedFactorSourceID: FactorSourceOfKind.ID?
 
 		@PresentationState
-		public var destination: Destinations.State? = nil
+		public var destination: Destination.State? = nil
 
 		public init(
 			kind: FactorSourceKind,
@@ -79,7 +79,7 @@ public struct FactorSourcesOfKindList<FactorSourceOfKind: Sendable & Hashable>: 
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -88,7 +88,7 @@ public struct FactorSourcesOfKindList<FactorSourceOfKind: Sendable & Hashable>: 
 
 	// MARK: - Destination
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case addNewFactorSource(ManageSomeFactorSource<FactorSourceOfKind>.State)
 			case existingFactorSourceWillBeDeletedConfirmationDialog(ConfirmationDialogState<DeleteExistingFactorSourceConfirmationDialogAction>)
@@ -118,7 +118,7 @@ public struct FactorSourcesOfKindList<FactorSourceOfKind: Sendable & Hashable>: 
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList.swift
@@ -137,10 +137,7 @@ public struct FactorSourcesOfKindList<FactorSourceOfKind: Sendable & Hashable>: 
 		case .addNewFactorSourceButtonTapped:
 			assert(state.canAddNew)
 
-			if
-				state.canOnlyHaveOneFactorSourceOfKind,
-				let existing = state.factorSources.last
-			{
+			if state.canOnlyHaveOneFactorSourceOfKind, let existing = state.factorSources.last {
 				state.destination = .existingFactorSourceWillBeDeletedConfirmationDialog(.deletion(of: existing))
 			} else {
 				state.destination = .addNewFactorSource(.init(kind: state.kind))

--- a/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/ManageSomeFactorSource+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/ManageSomeFactorSource+View.swift
@@ -1,17 +1,8 @@
 import ComposableArchitecture
 import SwiftUI
-extension ManageSomeFactorSource.State {
-	var viewState: ManageSomeFactorSource.ViewState {
-		.init()
-	}
-}
 
 // MARK: - ManageSomeFactorSource.View
 extension ManageSomeFactorSource {
-	public struct ViewState: Equatable {
-		// TODO: declare some properties
-	}
-
 	@MainActor
 	public struct View: SwiftUI.View {
 		private let store: StoreOf<ManageSomeFactorSource>
@@ -27,25 +18,19 @@ extension ManageSomeFactorSource {
 					CaseLet(
 						/ManageSomeFactorSource.State.manageSecurityQuestions,
 						action: { ManageSomeFactorSource.Action.child(.manageSecurityQuestions($0)) },
-						then: {
-							AnswerSecurityQuestionsCoordinator.View(store: $0)
-						}
+						then: { AnswerSecurityQuestionsCoordinator.View(store: $0) }
 					)
 				case .manageTrustedContact:
 					CaseLet(
 						/ManageSomeFactorSource.State.manageTrustedContact,
 						action: { ManageSomeFactorSource.Action.child(.manageTrustedContact($0)) },
-						then: {
-							ManageTrustedContactFactorSource.View(store: $0)
-						}
+						then: { ManageTrustedContactFactorSource.View(store: $0) }
 					)
 				case .manageOffDeviceMnemonics:
 					CaseLet(
 						/ManageSomeFactorSource.State.manageOffDeviceMnemonics,
 						action: { ManageSomeFactorSource.Action.child(.manageOffDeviceMnemonics($0)) },
-						then: {
-							ImportMnemonic.View(store: $0)
-						}
+						then: { ImportMnemonic.View(store: $0) }
 					)
 				}
 			}

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Simple/SimpleCreateSecurityStructureFlow+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Simple/SimpleCreateSecurityStructureFlow+View.swift
@@ -135,27 +135,27 @@ extension SimpleManageSecurityStructureFlow {
 extension View {
 	@MainActor
 	fileprivate func modalDestination(store: StoreOf<SimpleManageSecurityStructureFlow>) -> some View {
-		let destinationStore = store.scope(state: \.$modalDestinations, action: { .child(.modalDestinations($0)) })
+		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return listConfirmerOfNewPhone(with: destinationStore)
 			.listLostPhoneHelper(with: destinationStore)
 	}
 
 	@MainActor
-	private func listConfirmerOfNewPhone(with destinationStore: PresentationStoreOf<SimpleManageSecurityStructureFlow.ModalDestinations>) -> some View {
+	private func listConfirmerOfNewPhone(with destinationStore: PresentationStoreOf<SimpleManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /SimpleManageSecurityStructureFlow.ModalDestinations.State.listConfirmerOfNewPhone,
-			action: SimpleManageSecurityStructureFlow.ModalDestinations.Action.listConfirmerOfNewPhone,
+			state: /SimpleManageSecurityStructureFlow.Destination.State.listConfirmerOfNewPhone,
+			action: SimpleManageSecurityStructureFlow.Destination.Action.listConfirmerOfNewPhone,
 			content: { ListConfirmerOfNewPhone.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func listLostPhoneHelper(with destinationStore: PresentationStoreOf<SimpleManageSecurityStructureFlow.ModalDestinations>) -> some View {
+	private func listLostPhoneHelper(with destinationStore: PresentationStoreOf<SimpleManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /SimpleManageSecurityStructureFlow.ModalDestinations.State.listLostPhoneHelper,
-			action: SimpleManageSecurityStructureFlow.ModalDestinations.Action.listLostPhoneHelper,
+			state: /SimpleManageSecurityStructureFlow.Destination.State.listLostPhoneHelper,
+			action: SimpleManageSecurityStructureFlow.Destination.Action.listLostPhoneHelper,
 			content: { ListLostPhoneHelper.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Simple/SimpleCreateSecurityStructureFlow+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Simple/SimpleCreateSecurityStructureFlow+View.swift
@@ -124,7 +124,7 @@ extension SimpleManageSecurityStructureFlow {
 					)
 				}
 			}
-			.modalDestination(store: self.store)
+			.destinations(with: store)
 		}
 
 		typealias NewPhoneConfirmer = FactorForRoleView<ConfirmationRoleTag, SecurityQuestionsFactorSource>
@@ -132,15 +132,20 @@ extension SimpleManageSecurityStructureFlow {
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func modalDestination(store: StoreOf<SimpleManageSecurityStructureFlow>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+private extension StoreOf<SimpleManageSecurityStructureFlow> {
+	var destination: PresentationStoreOf<SimpleManageSecurityStructureFlow.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<SimpleManageSecurityStructureFlow>) -> some View {
+		let destinationStore = store.destination
 		return listConfirmerOfNewPhone(with: destinationStore)
 			.listLostPhoneHelper(with: destinationStore)
 	}
 
-	@MainActor
 	private func listConfirmerOfNewPhone(with destinationStore: PresentationStoreOf<SimpleManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -150,7 +155,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func listLostPhoneHelper(with destinationStore: PresentationStoreOf<SimpleManageSecurityStructureFlow.Destination>) -> some View {
 		sheet(
 			store: destinationStore,

--- a/RadixWallet/Features/ManageSecurityStructure/Children/Simple/SimpleCreateSecurityStructureFlow.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/Simple/SimpleCreateSecurityStructureFlow.swift
@@ -28,7 +28,7 @@ public struct SimpleManageSecurityStructureFlow: Sendable, FeatureReducer {
 		public var mode: Mode
 
 		@PresentationState
-		public var modalDestinations: ModalDestinations.State?
+		public var destination: Destination.State?
 
 		public init(
 			mode: Mode = .new(.init())
@@ -49,10 +49,10 @@ public struct SimpleManageSecurityStructureFlow: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case modalDestinations(PresentationAction<ModalDestinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct ModalDestinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case listConfirmerOfNewPhone(ListConfirmerOfNewPhone.State)
 			case listLostPhoneHelper(ListLostPhoneHelper.State)
@@ -80,8 +80,8 @@ public struct SimpleManageSecurityStructureFlow: Sendable, FeatureReducer {
 
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
-			.ifLet(\.$modalDestinations, action: /Action.child .. ChildAction.modalDestinations) {
-				ModalDestinations()
+			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
+				Destination()
 			}
 	}
 
@@ -98,7 +98,7 @@ public struct SimpleManageSecurityStructureFlow: Sendable, FeatureReducer {
 			try! existing.configuration.confirmationRole.changeFactorSource(to: factorSource)
 			state.mode = .existing(existing)
 		}
-		state.modalDestinations = nil
+		state.destination = nil
 		return .none
 	}
 
@@ -115,16 +115,16 @@ public struct SimpleManageSecurityStructureFlow: Sendable, FeatureReducer {
 			try! existing.configuration.recoveryRole.changeFactorSource(to: factorSource)
 			state.mode = .existing(existing)
 		}
-		state.modalDestinations = nil
+		state.destination = nil
 		return .none
 	}
 
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
-		case let .modalDestinations(.presented(.listConfirmerOfNewPhone(.delegate(.choseFactorSource(secQFS))))):
+		case let .destination(.presented(.listConfirmerOfNewPhone(.delegate(.choseFactorSource(secQFS))))):
 			choseConfirmerOfNewPhone(secQFS, &state)
 
-		case let .modalDestinations(.presented(.listLostPhoneHelper(.delegate(.choseFactorSource(trustedContactFS))))):
+		case let .destination(.presented(.listLostPhoneHelper(.delegate(.choseFactorSource(trustedContactFS))))):
 			choseLostPhoneHelper(trustedContactFS, &state)
 
 		default: .none
@@ -157,13 +157,13 @@ public struct SimpleManageSecurityStructureFlow: Sendable, FeatureReducer {
 			switch state.mode {
 			case let .existing(structure):
 				precondition(structure.isSimple)
-				state.modalDestinations = .listConfirmerOfNewPhone(.init(
+				state.destination = .listConfirmerOfNewPhone(.init(
 					kind: .securityQuestions,
 					mode: .selection,
 					selectedFactorSource: structure.securityQuestionsFactorSource
 				))
 			case .new:
-				state.modalDestinations = .listConfirmerOfNewPhone(.init(
+				state.destination = .listConfirmerOfNewPhone(.init(
 					kind: .securityQuestions,
 					mode: .selection
 				))
@@ -174,13 +174,13 @@ public struct SimpleManageSecurityStructureFlow: Sendable, FeatureReducer {
 			switch state.mode {
 			case let .existing(structure):
 				precondition(structure.isSimple)
-				state.modalDestinations = .listLostPhoneHelper(.init(
+				state.destination = .listLostPhoneHelper(.init(
 					kind: .trustedContact,
 					mode: .selection,
 					selectedFactorSource: structure.trustedContactFactorSource
 				))
 			case .new:
-				state.modalDestinations = .listLostPhoneHelper(.init(
+				state.destination = .listLostPhoneHelper(.init(
 					kind: .trustedContact,
 					mode: .selection
 				))

--- a/RadixWallet/Features/ManageSecurityStructure/Coordinator/ManageSecurityStructureCoordinator+View.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Coordinator/ManageSecurityStructureCoordinator+View.swift
@@ -17,7 +17,6 @@ extension ManageSecurityStructureCoordinator {
 				store.scope(state: \.path, action: { .child(.path($0)) })
 			) {
 				path(for: store.scope(state: \.root, action: { .child(.root($0)) }))
-
 					// This is required to disable the animation of internal components during transition
 					.transaction { $0.animation = nil }
 			} destination: {

--- a/RadixWallet/Features/ManageSecurityStructure/Models/FactorSources+Strings.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Models/FactorSources+Strings.swift
@@ -58,7 +58,7 @@ extension SecurityStructureRole {
 		case .primary:
 			fatalError("not used")
 		case .confirmation:
-			"Set security questions that are trigger when you move to a new phone"
+			"Set security questions that are triggered when you move to a new phone"
 		case .recovery:
 			"Select a third-party who can help you recover your account if you lose your phone."
 		}

--- a/RadixWallet/Features/ManageTrustedContactFactorSource/ManageTrustedContactFactorSource+View.swift
+++ b/RadixWallet/Features/ManageTrustedContactFactorSource/ManageTrustedContactFactorSource+View.swift
@@ -95,8 +95,8 @@ extension ManageTrustedContactFactorSource {
 				.navigationTitle(viewStore.isCreatingNewFromScratch ? "Add Trusted Contact" : "Edit Trusted Contact")
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /ManageTrustedContactFactorSource.Destinations.State.scanAccountAddress,
-					action: ManageTrustedContactFactorSource.Destinations.Action.scanAccountAddress,
+					state: /ManageTrustedContactFactorSource.Destination.State.scanAccountAddress,
+					action: ManageTrustedContactFactorSource.Destination.Action.scanAccountAddress,
 					content: {
 						ScanQRCoordinator.View(store: $0)
 							// FIXME: future strings

--- a/RadixWallet/Features/ManageTrustedContactFactorSource/ManageTrustedContactFactorSource+View.swift
+++ b/RadixWallet/Features/ManageTrustedContactFactorSource/ManageTrustedContactFactorSource+View.swift
@@ -93,17 +93,8 @@ extension ManageTrustedContactFactorSource {
 				}
 				// FIXME: future strings
 				.navigationTitle(viewStore.isCreatingNewFromScratch ? "Add Trusted Contact" : "Edit Trusted Contact")
-				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /ManageTrustedContactFactorSource.Destination.State.scanAccountAddress,
-					action: ManageTrustedContactFactorSource.Destination.Action.scanAccountAddress,
-					content: {
-						ScanQRCoordinator.View(store: $0)
-							// FIXME: future strings
-							.navigationTitle("Scan address")
-					}
-				)
 			}
+			.destinations(with: store)
 		}
 
 		private func addressField(
@@ -185,6 +176,28 @@ extension ManageTrustedContactFactorSource {
 				}
 			)
 		}
+	}
+}
+
+private extension StoreOf<ManageTrustedContactFactorSource> {
+	var destination: PresentationStoreOf<ManageTrustedContactFactorSource.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<ManageTrustedContactFactorSource>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /ManageTrustedContactFactorSource.Destination.State.scanAccountAddress,
+			action: ManageTrustedContactFactorSource.Destination.Action.scanAccountAddress,
+			content: {
+				ScanQRCoordinator.View(store: $0)
+					.navigationTitle("Scan address") // FIXME: future strings
+			}
+		)
 	}
 }
 

--- a/RadixWallet/Features/ManageTrustedContactFactorSource/ManageTrustedContactFactorSource.swift
+++ b/RadixWallet/Features/ManageTrustedContactFactorSource/ManageTrustedContactFactorSource.swift
@@ -33,7 +33,7 @@ public struct ManageTrustedContactFactorSource: Sendable, FeatureReducer {
 		public var mode: Mode
 
 		@PresentationState
-		var destination: Destinations.State? = nil
+		var destination: Destination.State? = nil
 
 		public init(
 			mode: Mode = .new
@@ -60,7 +60,7 @@ public struct ManageTrustedContactFactorSource: Sendable, FeatureReducer {
 		}
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case scanAccountAddress(ScanQRCoordinator.State)
 		}
@@ -77,7 +77,7 @@ public struct ManageTrustedContactFactorSource: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Hashable {
@@ -102,7 +102,7 @@ public struct ManageTrustedContactFactorSource: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/OnboardingFeature/Children/Startup/OnboardingStartup+Reducer.swift
+++ b/RadixWallet/Features/OnboardingFeature/Children/Startup/OnboardingStartup+Reducer.swift
@@ -3,7 +3,7 @@ import SwiftUI
 public struct OnboardingStartup: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init() {}
 	}
@@ -19,10 +19,10 @@ public struct OnboardingStartup: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case restoreFromBackup(RestoreProfileFromBackupCoordinator.State)
 		}
@@ -41,7 +41,7 @@ public struct OnboardingStartup: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/OnboardingFeature/Children/Startup/OnboardingStartup+View.swift
+++ b/RadixWallet/Features/OnboardingFeature/Children/Startup/OnboardingStartup+View.swift
@@ -56,8 +56,8 @@ extension OnboardingStartup.View {
 			}
 			.sheet(
 				store: store.destination,
-				state: /OnboardingStartup.Destinations.State.restoreFromBackup,
-				action: OnboardingStartup.Destinations.Action.restoreFromBackup,
+				state: /OnboardingStartup.Destination.State.restoreFromBackup,
+				action: OnboardingStartup.Destination.Action.restoreFromBackup,
 				content: {
 					RestoreProfileFromBackupCoordinator.View(store: $0)
 				}
@@ -67,7 +67,7 @@ extension OnboardingStartup.View {
 }
 
 private extension StoreOf<OnboardingStartup> {
-	var destination: PresentationStoreOf<OnboardingStartup.Destinations> {
+	var destination: PresentationStoreOf<OnboardingStartup.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/OnboardingFeature/Children/Startup/OnboardingStartup+View.swift
+++ b/RadixWallet/Features/OnboardingFeature/Children/Startup/OnboardingStartup+View.swift
@@ -55,7 +55,7 @@ extension OnboardingStartup.View {
 				}
 			}
 			.sheet(
-				store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+				store: store.destination,
 				state: /OnboardingStartup.Destinations.State.restoreFromBackup,
 				action: OnboardingStartup.Destinations.Action.restoreFromBackup,
 				content: {
@@ -63,6 +63,12 @@ extension OnboardingStartup.View {
 				}
 			)
 		}
+	}
+}
+
+private extension StoreOf<OnboardingStartup> {
+	var destination: PresentationStoreOf<OnboardingStartup.Destinations> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 

--- a/RadixWallet/Features/OnboardingFeature/Children/Startup/OnboardingStartup+View.swift
+++ b/RadixWallet/Features/OnboardingFeature/Children/Startup/OnboardingStartup+View.swift
@@ -54,14 +54,7 @@ extension OnboardingStartup.View {
 					.buttonStyle(.primaryText())
 				}
 			}
-			.sheet(
-				store: store.destination,
-				state: /OnboardingStartup.Destination.State.restoreFromBackup,
-				action: OnboardingStartup.Destination.Action.restoreFromBackup,
-				content: {
-					RestoreProfileFromBackupCoordinator.View(store: $0)
-				}
-			)
+			.destinations(with: store)
 		}
 	}
 }
@@ -69,6 +62,19 @@ extension OnboardingStartup.View {
 private extension StoreOf<OnboardingStartup> {
 	var destination: PresentationStoreOf<OnboardingStartup.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<OnboardingStartup>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /OnboardingStartup.Destination.State.restoreFromBackup,
+			action: OnboardingStartup.Destination.Action.restoreFromBackup,
+			content: { RestoreProfileFromBackupCoordinator.View(store: $0) }
+		)
 	}
 }
 

--- a/RadixWallet/Features/P2PLinksFeature/Coordinator/P2PLinksFeature+Reducer.swift
+++ b/RadixWallet/Features/P2PLinksFeature/Coordinator/P2PLinksFeature+Reducer.swift
@@ -9,11 +9,11 @@ public struct P2PLinksFeature: Sendable, FeatureReducer {
 		public var links: IdentifiedArrayOf<P2PLinkRow.State>
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init(
 			links: IdentifiedArrayOf<P2PLinkRow.State> = .init(),
-			destination: Destinations.State? = nil
+			destination: Destination.State? = nil
 		) {
 			self.links = links
 			self.destination = destination
@@ -34,13 +34,13 @@ public struct P2PLinksFeature: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 		case connection(id: ConnectionPassword, action: P2PLinkRow.Action)
 	}
 
-	// MARK: Destinations
+	// MARK: Destination
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case newConnection(NewConnection.State)
 			case removeConnection(AlertState<Action.RemoveConnection>)
@@ -75,7 +75,7 @@ public struct P2PLinksFeature: Sendable, FeatureReducer {
 				P2PLinkRow()
 			}
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 
@@ -161,7 +161,7 @@ public struct P2PLinksFeature: Sendable, FeatureReducer {
 	}
 }
 
-extension AlertState<P2PLinksFeature.Destinations.Action.RemoveConnection> {
+extension AlertState<P2PLinksFeature.Destination.Action.RemoveConnection> {
 	static func confirmRemoval(id: ConnectionPassword) -> AlertState {
 		AlertState {
 			TextState(L10n.LinkedConnectors.RemoveConnectionAlert.title)

--- a/RadixWallet/Features/P2PLinksFeature/Coordinator/P2PLinksFeature+View.swift
+++ b/RadixWallet/Features/P2PLinksFeature/Coordinator/P2PLinksFeature+View.swift
@@ -64,18 +64,24 @@ extension P2PLinksFeature {
 					await store.send(.view(.task)).finish()
 				}
 				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+					store: store.destination,
 					state: /P2PLinksFeature.Destinations.State.newConnection,
 					action: P2PLinksFeature.Destinations.Action.newConnection,
 					content: { NewConnection.View(store: $0) }
 				)
 				.alert(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+					store: store.destination,
 					state: /P2PLinksFeature.Destinations.State.removeConnection,
 					action: P2PLinksFeature.Destinations.Action.removeConnection
 				)
 			}
 		}
+	}
+}
+
+private extension StoreOf<P2PLinksFeature> {
+	var destination: PresentationStoreOf<P2PLinksFeature.Destinations> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 

--- a/RadixWallet/Features/P2PLinksFeature/Coordinator/P2PLinksFeature+View.swift
+++ b/RadixWallet/Features/P2PLinksFeature/Coordinator/P2PLinksFeature+View.swift
@@ -65,14 +65,14 @@ extension P2PLinksFeature {
 				}
 				.sheet(
 					store: store.destination,
-					state: /P2PLinksFeature.Destinations.State.newConnection,
-					action: P2PLinksFeature.Destinations.Action.newConnection,
+					state: /P2PLinksFeature.Destination.State.newConnection,
+					action: P2PLinksFeature.Destination.Action.newConnection,
 					content: { NewConnection.View(store: $0) }
 				)
 				.alert(
 					store: store.destination,
-					state: /P2PLinksFeature.Destinations.State.removeConnection,
-					action: P2PLinksFeature.Destinations.Action.removeConnection
+					state: /P2PLinksFeature.Destination.State.removeConnection,
+					action: P2PLinksFeature.Destination.Action.removeConnection
 				)
 			}
 		}
@@ -80,7 +80,7 @@ extension P2PLinksFeature {
 }
 
 private extension StoreOf<P2PLinksFeature> {
-	var destination: PresentationStoreOf<P2PLinksFeature.Destinations> {
+	var destination: PresentationStoreOf<P2PLinksFeature.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/P2PLinksFeature/Coordinator/P2PLinksFeature+View.swift
+++ b/RadixWallet/Features/P2PLinksFeature/Coordinator/P2PLinksFeature+View.swift
@@ -63,17 +63,7 @@ extension P2PLinksFeature {
 				.task { @MainActor in
 					await store.send(.view(.task)).finish()
 				}
-				.sheet(
-					store: store.destination,
-					state: /P2PLinksFeature.Destination.State.newConnection,
-					action: P2PLinksFeature.Destination.Action.newConnection,
-					content: { NewConnection.View(store: $0) }
-				)
-				.alert(
-					store: store.destination,
-					state: /P2PLinksFeature.Destination.State.removeConnection,
-					action: P2PLinksFeature.Destination.Action.removeConnection
-				)
+				.destinations(with: store)
 			}
 		}
 	}
@@ -82,6 +72,32 @@ extension P2PLinksFeature {
 private extension StoreOf<P2PLinksFeature> {
 	var destination: PresentationStoreOf<P2PLinksFeature.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<P2PLinksFeature>) -> some View {
+		let destinationStore = store.destination
+		return newConnection(with: destinationStore)
+			.confirmDeletionAlert(with: destinationStore)
+	}
+
+	private func newConnection(with destinationStore: PresentationStoreOf<P2PLinksFeature.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /P2PLinksFeature.Destination.State.newConnection,
+			action: P2PLinksFeature.Destination.Action.newConnection,
+			content: { NewConnection.View(store: $0) }
+		)
+	}
+
+	private func confirmDeletionAlert(with destinationStore: PresentationStoreOf<P2PLinksFeature.Destination>) -> some View {
+		alert(
+			store: destinationStore,
+			state: /P2PLinksFeature.Destination.State.removeConnection,
+			action: P2PLinksFeature.Destination.Action.removeConnection
+		)
 	}
 }
 

--- a/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+Reducer.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+Reducer.swift
@@ -15,7 +15,7 @@ public struct ProfileBackupSettings: Sendable, FeatureReducer {
 		}
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		/// An exportable Profile file, either encrypted or plaintext.
 		public var profileFile: ExportableProfileFile?
@@ -41,7 +41,7 @@ public struct ProfileBackupSettings: Sendable, FeatureReducer {
 		case deleteProfileAndFactorSourcesButtonTapped
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		static let confirmCloudSyncDisableAlert: Self.State = .confirmCloudSyncDisable(.init(
 			title: {
 				TextState(L10n.AppSettings.ConfirmCloudSyncDisableAlert.title)
@@ -124,7 +124,7 @@ public struct ProfileBackupSettings: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -144,7 +144,7 @@ public struct ProfileBackupSettings: Sendable, FeatureReducer {
 	public var body: some ReducerOf<ProfileBackupSettings> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. /ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 
@@ -156,14 +156,14 @@ public struct ProfileBackupSettings: Sendable, FeatureReducer {
 
 		case let .cloudProfileSyncToggled(isEnabled):
 			if !isEnabled {
-				state.destination = Destinations.confirmCloudSyncDisableAlert
+				state.destination = Destination.confirmCloudSyncDisableAlert
 				return .none
 			} else {
 				return updateCloudSync(state: &state, isEnabled: true)
 			}
 
 		case .exportProfileButtonTapped:
-			state.destination = Destinations.optionallyEncryptProfileBeforeExportingAlert
+			state.destination = Destination.optionallyEncryptProfileBeforeExportingAlert
 			return .none
 
 		case .task:
@@ -296,7 +296,7 @@ public struct ProfileBackupSettings: Sendable, FeatureReducer {
 // MARK: - LackedPermissionToAccessSecurityScopedResource
 struct LackedPermissionToAccessSecurityScopedResource: Error {}
 
-extension ConfirmationDialogState<ProfileBackupSettings.Destinations.Action.DeleteProfileConfirmationDialogAction> {
+extension ConfirmationDialogState<ProfileBackupSettings.Destination.Action.DeleteProfileConfirmationDialogAction> {
 	static let deleteProfileConfirmationDialog = ConfirmationDialogState {
 		TextState(L10n.AppSettings.ResetWalletDialog.title)
 	} actions: {
@@ -314,7 +314,7 @@ extension ConfirmationDialogState<ProfileBackupSettings.Destinations.Action.Dele
 	}
 }
 
-extension ProfileBackupSettings.Destinations.State {
+extension ProfileBackupSettings.Destination.State {
 	fileprivate static let cloudSyncTakesLongTimeAlert = Self.syncTakesLongTimeAlert(.init(
 		title: { TextState(L10n.AppSettings.ICloudSyncEnabledAlert.title) },
 		actions: {

--- a/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+View.swift
@@ -129,7 +129,7 @@ extension ProfileBackupSettings.View {
 extension SwiftUI.View {
 	@MainActor
 	func destination(store: StoreOf<ProfileBackupSettings>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+		let destinationStore = store.destination
 		return cloudSyncTakesLongTimeAlert(with: destinationStore)
 			.disableCloudSyncConfirmationAlert(with: destinationStore)
 			.encryptBeforeExportChoiceAlert(with: destinationStore)
@@ -207,5 +207,11 @@ extension SwiftUI.View {
 			// swiftformat:enable redundantClosure
 			onCompletion: { viewStore.send(.profileExportResult($0.mapError { $0 as NSError })) }
 		)
+	}
+}
+
+extension StoreOf<ProfileBackupSettings> {
+	var destination: PresentationStoreOf<ProfileBackupSettings.Destinations> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+View.swift
@@ -138,47 +138,47 @@ extension SwiftUI.View {
 	}
 
 	@MainActor
-	fileprivate func deleteProfileConfirmationDialog(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destinations>) -> some SwiftUI.View {
+	fileprivate func deleteProfileConfirmationDialog(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destination>) -> some SwiftUI.View {
 		confirmationDialog(
 			store: destinationStore,
-			state: /ProfileBackupSettings.Destinations.State.deleteProfileConfirmationDialog,
-			action: ProfileBackupSettings.Destinations.Action.deleteProfileConfirmationDialog
+			state: /ProfileBackupSettings.Destination.State.deleteProfileConfirmationDialog,
+			action: ProfileBackupSettings.Destination.Action.deleteProfileConfirmationDialog
 		)
 	}
 
 	@MainActor
-	fileprivate func cloudSyncTakesLongTimeAlert(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destinations>) -> some SwiftUI.View {
+	fileprivate func cloudSyncTakesLongTimeAlert(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destination>) -> some SwiftUI.View {
 		alert(
 			store: destinationStore,
-			state: /ProfileBackupSettings.Destinations.State.syncTakesLongTimeAlert,
-			action: ProfileBackupSettings.Destinations.Action.syncTakesLongTimeAlert
+			state: /ProfileBackupSettings.Destination.State.syncTakesLongTimeAlert,
+			action: ProfileBackupSettings.Destination.Action.syncTakesLongTimeAlert
 		)
 	}
 
 	@MainActor
-	fileprivate func disableCloudSyncConfirmationAlert(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destinations>) -> some SwiftUI.View {
+	fileprivate func disableCloudSyncConfirmationAlert(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destination>) -> some SwiftUI.View {
 		alert(
 			store: destinationStore,
-			state: /ProfileBackupSettings.Destinations.State.confirmCloudSyncDisable,
-			action: ProfileBackupSettings.Destinations.Action.confirmCloudSyncDisable
+			state: /ProfileBackupSettings.Destination.State.confirmCloudSyncDisable,
+			action: ProfileBackupSettings.Destination.Action.confirmCloudSyncDisable
 		)
 	}
 
 	@MainActor
-	fileprivate func encryptBeforeExportChoiceAlert(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destinations>) -> some SwiftUI.View {
+	fileprivate func encryptBeforeExportChoiceAlert(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destination>) -> some SwiftUI.View {
 		alert(
 			store: destinationStore,
-			state: /ProfileBackupSettings.Destinations.State.optionallyEncryptProfileBeforeExporting,
-			action: ProfileBackupSettings.Destinations.Action.optionallyEncryptProfileBeforeExporting
+			state: /ProfileBackupSettings.Destination.State.optionallyEncryptProfileBeforeExporting,
+			action: ProfileBackupSettings.Destination.Action.optionallyEncryptProfileBeforeExporting
 		)
 	}
 
 	@MainActor
-	fileprivate func encryptBeforeExportSheet(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destinations>) -> some SwiftUI.View {
+	fileprivate func encryptBeforeExportSheet(with destinationStore: PresentationStoreOf<ProfileBackupSettings.Destination>) -> some SwiftUI.View {
 		sheet(
 			store: destinationStore,
-			state: /ProfileBackupSettings.Destinations.State.inputEncryptionPassword,
-			action: ProfileBackupSettings.Destinations.Action.inputEncryptionPassword,
+			state: /ProfileBackupSettings.Destination.State.inputEncryptionPassword,
+			action: ProfileBackupSettings.Destination.Action.inputEncryptionPassword,
 			content: { childStore in
 				NavigationView {
 					EncryptOrDecryptProfile.View(store: childStore)
@@ -211,7 +211,7 @@ extension SwiftUI.View {
 }
 
 extension StoreOf<ProfileBackupSettings> {
-	var destination: PresentationStoreOf<ProfileBackupSettings.Destinations> {
+	var destination: PresentationStoreOf<ProfileBackupSettings.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
@@ -72,8 +72,8 @@ extension ImportMnemonicControllingAccounts {
 				.onAppear { viewStore.send(.appeared) }
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /ImportMnemonicControllingAccounts.Destinations.State.importMnemonic,
-					action: ImportMnemonicControllingAccounts.Destinations.Action.importMnemonic,
+					state: /ImportMnemonicControllingAccounts.Destination.State.importMnemonic,
+					action: ImportMnemonicControllingAccounts.Destination.Action.importMnemonic,
 					content: { store_ in
 						NavigationView {
 							ImportMnemonic.View(store: store_)

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
@@ -9,7 +9,7 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 		public let entities: DisplayEntitiesControlledByMnemonic.State
 
 		@PresentationState
-		public var destination: Destinations.State? = nil
+		public var destination: Destination.State? = nil
 
 		public init(entitiesControlledByFactorSource: EntitiesControlledByFactorSource) {
 			self.entitiesControlledByFactorSource = entitiesControlledByFactorSource
@@ -35,13 +35,13 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 		case entities(DisplayEntitiesControlledByMnemonic.Action)
 	}
 
 	// MARK: - Destination
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case importMnemonic(ImportMnemonic.State)
 		}
@@ -67,7 +67,7 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator+View.swift
@@ -12,32 +12,39 @@ extension ImportMnemonicsFlowCoordinator {
 		}
 
 		public var body: some SwiftUI.View {
-			WithViewStore(store, observe: { $0 }) { viewStore in
-				Color.app.white
-					.onFirstTask { @MainActor in
-						await viewStore.send(.view(.onFirstTask)).finish()
-					}
-					// We are using `fullScreenCover` for two reasons:
-					// 1. it fixes a bug where otherwise a secondary `ImportMnemonicControllingAccounts` screen's buttons are not pressable
-					// 2. If fixes issue where user can dismiss screen with iOS gesture, which we dont want in this case
-					.fullScreenCover(
-						store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-						state: /ImportMnemonicsFlowCoordinator.Destination.State.importMnemonicControllingAccounts,
-						action: ImportMnemonicsFlowCoordinator.Destination.Action.importMnemonicControllingAccounts,
-						content: { importStore in
-							NavigationView {
-								ImportMnemonicControllingAccounts.View(store: importStore)
-									.toolbar {
-										ToolbarItem(placement: .navigationBarLeading) {
-											CloseButton {
-												viewStore.send(.view(.closeButtonTapped))
-											}
-										}
-									}
-							}
-						}
-					)
-			}
+			Color.app.white
+				.onFirstTask { @MainActor in
+					await store.send(.view(.onFirstTask)).finish()
+				}
+				.destinations(with: store)
 		}
+	}
+}
+
+private extension StoreOf<ImportMnemonicsFlowCoordinator> {
+	var destination: PresentationStoreOf<ImportMnemonicsFlowCoordinator.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<ImportMnemonicsFlowCoordinator>) -> some View {
+		let destinationStore = store.destination
+
+		// We are using `fullScreenCover` for two reasons:
+		// 1. it fixes a bug where otherwise a secondary `ImportMnemonicControllingAccounts` screen's buttons are not pressable
+		// 2. If fixes issue where user can dismiss screen with iOS gesture, which we dont want in this case
+		return fullScreenCover(
+			store: destinationStore,
+			state: /ImportMnemonicsFlowCoordinator.Destination.State.importMnemonicControllingAccounts,
+			action: ImportMnemonicsFlowCoordinator.Destination.Action.importMnemonicControllingAccounts,
+			content: { importStore in
+				ImportMnemonicControllingAccounts.View(store: importStore)
+					.withNavigationBar {
+						store.send(.view(.closeButtonTapped))
+					}
+			}
+		)
 	}
 }

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator+View.swift
@@ -22,8 +22,8 @@ extension ImportMnemonicsFlowCoordinator {
 					// 2. If fixes issue where user can dismiss screen with iOS gesture, which we dont want in this case
 					.fullScreenCover(
 						store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-						state: /ImportMnemonicsFlowCoordinator.Destinations.State.importMnemonicControllingAccounts,
-						action: ImportMnemonicsFlowCoordinator.Destinations.Action.importMnemonicControllingAccounts,
+						state: /ImportMnemonicsFlowCoordinator.Destination.State.importMnemonicControllingAccounts,
+						action: ImportMnemonicsFlowCoordinator.Destination.Action.importMnemonicControllingAccounts,
 						content: { importStore in
 							NavigationView {
 								ImportMnemonicControllingAccounts.View(store: importStore)

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator.swift
@@ -10,14 +10,14 @@ public struct ImportMnemonicsFlowCoordinator: Sendable, FeatureReducer {
 		public let profileSnapshot: ProfileSnapshot
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init(profileSnapshot: ProfileSnapshot) {
 			self.profileSnapshot = profileSnapshot
 		}
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case importMnemonicControllingAccounts(ImportMnemonicControllingAccounts.State)
 		}
@@ -37,7 +37,7 @@ public struct ImportMnemonicsFlowCoordinator: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum ViewAction: Sendable, Equatable {
@@ -74,7 +74,7 @@ public struct ImportMnemonicsFlowCoordinator: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+Reducer.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+Reducer.swift
@@ -10,7 +10,7 @@ public struct SelectBackup: Sendable, FeatureReducer {
 		public var thisDeviceID: UUID?
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public var profileFile: ExportableProfileFile?
 
@@ -36,7 +36,7 @@ public struct SelectBackup: Sendable, FeatureReducer {
 		case tappedUseCloudBackup(ProfileSnapshot.Header)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case inputEncryptionPassword(EncryptOrDecryptProfile.State)
 		}
@@ -63,7 +63,7 @@ public struct SelectBackup: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	@Dependency(\.errorQueue) var errorQueue
@@ -78,7 +78,7 @@ public struct SelectBackup: Sendable, FeatureReducer {
 	public var body: some ReducerOf<SelectBackup> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. /ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
@@ -47,16 +47,7 @@ extension SelectBackup {
 						}
 					)
 				}
-				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /SelectBackup.Destination.State.inputEncryptionPassword,
-					action: SelectBackup.Destination.Action.inputEncryptionPassword,
-					content: { store in
-						NavigationView {
-							EncryptOrDecryptProfile.View(store: store)
-						}
-					}
-				)
+				.destinations(with: store)
 				.fileImporter(
 					isPresented: viewStore.binding(
 						get: \.isDisplayingFileImporter,
@@ -71,6 +62,25 @@ extension SelectBackup {
 			}
 			.navigationTitle(L10n.RecoverProfileBackup.Header.title)
 		}
+	}
+}
+
+private extension StoreOf<SelectBackup> {
+	var destination: PresentationStoreOf<SelectBackup.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<SelectBackup>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /SelectBackup.Destination.State.inputEncryptionPassword,
+			action: SelectBackup.Destination.Action.inputEncryptionPassword,
+			content: { EncryptOrDecryptProfile.View(store: $0).inNavigationView }
+		)
 	}
 }
 

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
@@ -49,8 +49,8 @@ extension SelectBackup {
 				}
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /SelectBackup.Destinations.State.inputEncryptionPassword,
-					action: SelectBackup.Destinations.Action.inputEncryptionPassword,
+					state: /SelectBackup.Destination.State.inputEncryptionPassword,
+					action: SelectBackup.Destination.Action.inputEncryptionPassword,
 					content: { store in
 						NavigationView {
 							EncryptOrDecryptProfile.View(store: store)

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Coordinator/RestoreProfileFromBackupCoordinator+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Coordinator/RestoreProfileFromBackupCoordinator+View.swift
@@ -21,7 +21,7 @@ extension RestoreProfileFromBackupCoordinator {
 			}
 		}
 
-		func path(
+		private func path(
 			for store: StoreOf<RestoreProfileFromBackupCoordinator.Path>
 		) -> some SwiftUI.View {
 			SwitchStore(store) { state in

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Coordinator/RestoreProfileFromBackupCoordinator.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Coordinator/RestoreProfileFromBackupCoordinator.swift
@@ -94,7 +94,6 @@ public struct RestoreProfileFromBackupCoordinator: Sendable, FeatureReducer {
 			loggerGlobal.notice("Starting import snapshot process...")
 			guard let profileSelection = state.profileSelection else {
 				preconditionFailure("Expected to have a profile")
-				return .none
 			}
 			return .run { send in
 				loggerGlobal.notice("Importing snapshot...")

--- a/RadixWallet/Features/ProfileBackupsFeature/Shared/EncryptOrDecryptProfile+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/Shared/EncryptOrDecryptProfile+View.swift
@@ -149,19 +149,43 @@ extension EncryptOrDecryptProfile {
 					.buttonStyle(.primaryRectangular)
 					.controlState(viewStore.controlState)
 				}
-				.alert(
-					store: store.destination,
-					state: /EncryptOrDecryptProfile.Destination.State.incorrectPasswordAlert,
-					action: EncryptOrDecryptProfile.Destination.Action.incorrectPasswordAlert
-				)
+				.destinations(with: store)
 				.onAppear { viewStore.send(.appeared) }
+			}
+		}
+	}
+
+	@MainActor
+	public struct SheetView: SwiftUI.View {
+		private let store: StoreOf<EncryptOrDecryptProfile>
+		@FocusState private var focusedField: State.Field?
+
+		public init(store: StoreOf<EncryptOrDecryptProfile>) {
+			self.store = store
+		}
+
+		public var body: some SwiftUI.View {
+			NavigationView {
+				EncryptOrDecryptProfile.View(store: store)
 			}
 		}
 	}
 }
 
-extension StoreOf<EncryptOrDecryptProfile> {
-	fileprivate var destination: PresentationStoreOf<EncryptOrDecryptProfile.Destination> {
+private extension StoreOf<EncryptOrDecryptProfile> {
+	var destination: PresentationStoreOf<EncryptOrDecryptProfile.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<EncryptOrDecryptProfile>) -> some View {
+		let destinationStore = store.destination
+		return alert(
+			store: destinationStore,
+			state: /EncryptOrDecryptProfile.Destination.State.incorrectPasswordAlert,
+			action: EncryptOrDecryptProfile.Destination.Action.incorrectPasswordAlert
+		)
 	}
 }

--- a/RadixWallet/Features/ProfileBackupsFeature/Shared/EncryptOrDecryptProfile+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/Shared/EncryptOrDecryptProfile+View.swift
@@ -162,6 +162,6 @@ extension EncryptOrDecryptProfile {
 
 extension StoreOf<EncryptOrDecryptProfile> {
 	fileprivate var destination: PresentationStoreOf<EncryptOrDecryptProfile.Destination> {
-		scope(state: \.$destination, action: { .child(.destination($0)) })
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/SecurityStructureConfigurationList/Coordinator/SecurityStructureConfigurationListCoordinator+View.swift
+++ b/RadixWallet/Features/SecurityStructureConfigurationList/Coordinator/SecurityStructureConfigurationListCoordinator+View.swift
@@ -18,7 +18,7 @@ extension SecurityStructureConfigurationListCoordinator {
 					action: { .child(.configList($0)) }
 				)
 			)
-			.destinations(with: store.destination)
+			.destinations(with: store)
 		}
 	}
 }
@@ -29,16 +29,17 @@ private extension StoreOf<SecurityStructureConfigurationListCoordinator> {
 	}
 }
 
-extension View {
+private extension View {
 	@MainActor
-	fileprivate func destinations(with store: PresentationStoreOf<SecurityStructureConfigurationListCoordinator.Destination>) -> some View {
-		manageSecurityStructureCoordinator(with: store)
+	func destinations(with store: StoreOf<SecurityStructureConfigurationListCoordinator>) -> some View {
+		let destinationStore = store.destination
+		return manageSecurityStructureCoordinator(with: destinationStore)
 	}
 
 	@MainActor
-	private func manageSecurityStructureCoordinator(with store: PresentationStoreOf<SecurityStructureConfigurationListCoordinator.Destination>) -> some View {
+	private func manageSecurityStructureCoordinator(with destinationStore: PresentationStoreOf<SecurityStructureConfigurationListCoordinator.Destination>) -> some View {
 		sheet(
-			store: store,
+			store: destinationStore,
 			state: /SecurityStructureConfigurationListCoordinator.Destination.State.manageSecurityStructureCoordinator,
 			action: SecurityStructureConfigurationListCoordinator.Destination.Action.manageSecurityStructureCoordinator,
 			content: { ManageSecurityStructureCoordinator.View(store: $0) }

--- a/RadixWallet/Features/SecurityStructureConfigurationList/Coordinator/SecurityStructureConfigurationListCoordinator+View.swift
+++ b/RadixWallet/Features/SecurityStructureConfigurationList/Coordinator/SecurityStructureConfigurationListCoordinator+View.swift
@@ -26,8 +26,7 @@ extension SecurityStructureConfigurationListCoordinator {
 extension View {
 	@MainActor
 	fileprivate func destination(store: StoreOf<SecurityStructureConfigurationListCoordinator>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
-		return manageSecurityStructureCoordinator(with: destinationStore)
+		manageSecurityStructureCoordinator(with: store.destination)
 	}
 
 	@MainActor
@@ -38,6 +37,12 @@ extension View {
 			action: SecurityStructureConfigurationListCoordinator.Destination.Action.manageSecurityStructureCoordinator,
 			content: { ManageSecurityStructureCoordinator.View(store: $0) }
 		)
+	}
+}
+
+private extension StoreOf<SecurityStructureConfigurationListCoordinator> {
+	var destination: PresentationStoreOf<SecurityStructureConfigurationListCoordinator.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 

--- a/RadixWallet/Features/SecurityStructureConfigurationList/Coordinator/SecurityStructureConfigurationListCoordinator+View.swift
+++ b/RadixWallet/Features/SecurityStructureConfigurationList/Coordinator/SecurityStructureConfigurationListCoordinator+View.swift
@@ -18,31 +18,31 @@ extension SecurityStructureConfigurationListCoordinator {
 					action: { .child(.configList($0)) }
 				)
 			)
-			.destination(store: store)
+			.destinations(with: store.destination)
 		}
-	}
-}
-
-extension View {
-	@MainActor
-	fileprivate func destination(store: StoreOf<SecurityStructureConfigurationListCoordinator>) -> some View {
-		manageSecurityStructureCoordinator(with: store.destination)
-	}
-
-	@MainActor
-	private func manageSecurityStructureCoordinator(with destinationStore: PresentationStoreOf<SecurityStructureConfigurationListCoordinator.Destination>) -> some View {
-		sheet(
-			store: destinationStore,
-			state: /SecurityStructureConfigurationListCoordinator.Destination.State.manageSecurityStructureCoordinator,
-			action: SecurityStructureConfigurationListCoordinator.Destination.Action.manageSecurityStructureCoordinator,
-			content: { ManageSecurityStructureCoordinator.View(store: $0) }
-		)
 	}
 }
 
 private extension StoreOf<SecurityStructureConfigurationListCoordinator> {
 	var destination: PresentationStoreOf<SecurityStructureConfigurationListCoordinator.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+extension View {
+	@MainActor
+	fileprivate func destinations(with store: PresentationStoreOf<SecurityStructureConfigurationListCoordinator.Destination>) -> some View {
+		manageSecurityStructureCoordinator(with: store)
+	}
+
+	@MainActor
+	private func manageSecurityStructureCoordinator(with store: PresentationStoreOf<SecurityStructureConfigurationListCoordinator.Destination>) -> some View {
+		sheet(
+			store: store,
+			state: /SecurityStructureConfigurationListCoordinator.Destination.State.manageSecurityStructureCoordinator,
+			action: SecurityStructureConfigurationListCoordinator.Destination.Action.manageSecurityStructureCoordinator,
+			content: { ManageSecurityStructureCoordinator.View(store: $0) }
+		)
 	}
 }
 

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/AccountSecurity+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/AccountSecurity+Reducer.swift
@@ -9,14 +9,14 @@ public struct AccountSecurity: Sendable, FeatureReducer {
 
 	public struct State: Sendable, Hashable {
 		@PresentationState
-		public var destination: Destinations.State? = nil
+		public var destination: Destination.State? = nil
 		public var preferences: AppPreferences? = nil
 
 		public var canImportOlympiaWallet = false
 
 		public static let importOlympia = Self(destination: .importOlympiaWallet(.init()))
 
-		public init(destination: Destinations.State? = nil) {
+		public init(destination: Destination.State? = nil) {
 			self.destination = destination
 		}
 	}
@@ -38,14 +38,14 @@ public struct AccountSecurity: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
 		case gotoAccountList
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case mnemonics(DisplayMnemonics.State)
 			case ledgerHardwareWallets(LedgerHardwareDevices.State)
@@ -86,7 +86,7 @@ public struct AccountSecurity: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/AccountSecurity+View.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/AccountSecurity+View.swift
@@ -19,11 +19,9 @@ extension AccountSecurity {
 	@MainActor
 	public struct View: SwiftUI.View {
 		private let store: Store
-		private let destinationStore: PresentationStoreOf<Destination>
 
 		public init(store: Store) {
 			self.store = store
-			self.destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		}
 	}
 }
@@ -53,14 +51,11 @@ extension AccountSecurity.View {
 			.navigationBarTitleColor(.app.gray1)
 			.navigationBarTitleDisplayMode(.inline)
 			.navigationBarInlineTitleFont(.app.secondaryHeader)
-			.mnemonics(with: destinationStore)
-			.ledgerHardwareWallets(with: destinationStore)
-			.depositGuarantees(with: destinationStore)
-			.importFromOlympiaLegacyWallet(with: destinationStore)
 			.tint(.app.gray1)
 			.foregroundColor(.app.gray1)
 			.presentsLoadingViewOverlay()
 		}
+		.destinations(with: store)
 	}
 
 	@MainActor
@@ -104,9 +99,23 @@ extension AccountSecurity.View {
 
 // MARK: - Extensions
 
+private extension StoreOf<AccountSecurity> {
+	var destination: PresentationStoreOf<AccountSecurity.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
 private extension View {
-	@MainActor
-	func mnemonics(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
+	func destinations(with store: StoreOf<AccountSecurity>) -> some View {
+		let destinationStore = store.destination
+		return mnemonics(with: destinationStore)
+			.ledgerHardwareWallets(with: destinationStore)
+			.depositGuarantees(with: destinationStore)
+			.importFromOlympiaLegacyWallet(with: destinationStore)
+	}
+
+	private func mnemonics(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AccountSecurity.Destination.State.mnemonics,
@@ -115,8 +124,7 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	func ledgerHardwareWallets(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
+	private func ledgerHardwareWallets(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AccountSecurity.Destination.State.ledgerHardwareWallets,
@@ -130,8 +138,7 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	func depositGuarantees(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
+	private func depositGuarantees(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AccountSecurity.Destination.State.depositGuarantees,
@@ -140,8 +147,7 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	func importFromOlympiaLegacyWallet(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
+	private func importFromOlympiaLegacyWallet(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
 			state: /AccountSecurity.Destination.State.importOlympiaWallet,

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/AccountSecurity+View.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/AccountSecurity+View.swift
@@ -19,7 +19,7 @@ extension AccountSecurity {
 	@MainActor
 	public struct View: SwiftUI.View {
 		private let store: Store
-		private let destinationStore: PresentationStoreOf<Destinations>
+		private let destinationStore: PresentationStoreOf<Destination>
 
 		public init(store: Store) {
 			self.store = store
@@ -106,21 +106,21 @@ extension AccountSecurity.View {
 
 private extension View {
 	@MainActor
-	func mnemonics(with destinationStore: PresentationStoreOf<AccountSecurity.Destinations>) -> some View {
+	func mnemonics(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AccountSecurity.Destinations.State.mnemonics,
-			action: AccountSecurity.Destinations.Action.mnemonics,
+			state: /AccountSecurity.Destination.State.mnemonics,
+			action: AccountSecurity.Destination.Action.mnemonics,
 			destination: { DisplayMnemonics.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func ledgerHardwareWallets(with destinationStore: PresentationStoreOf<AccountSecurity.Destinations>) -> some View {
+	func ledgerHardwareWallets(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AccountSecurity.Destinations.State.ledgerHardwareWallets,
-			action: AccountSecurity.Destinations.Action.ledgerHardwareWallets,
+			state: /AccountSecurity.Destination.State.ledgerHardwareWallets,
+			action: AccountSecurity.Destination.Action.ledgerHardwareWallets,
 			destination: {
 				LedgerHardwareDevices.View(store: $0)
 					.background(.app.gray5)
@@ -131,21 +131,21 @@ private extension View {
 	}
 
 	@MainActor
-	func depositGuarantees(with destinationStore: PresentationStoreOf<AccountSecurity.Destinations>) -> some View {
+	func depositGuarantees(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AccountSecurity.Destinations.State.depositGuarantees,
-			action: AccountSecurity.Destinations.Action.depositGuarantees,
+			state: /AccountSecurity.Destination.State.depositGuarantees,
+			action: AccountSecurity.Destination.Action.depositGuarantees,
 			destination: { DefaultDepositGuarantees.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func importFromOlympiaLegacyWallet(with destinationStore: PresentationStoreOf<AccountSecurity.Destinations>) -> some View {
+	func importFromOlympiaLegacyWallet(with destinationStore: PresentationStoreOf<AccountSecurity.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /AccountSecurity.Destinations.State.importOlympiaWallet,
-			action: AccountSecurity.Destinations.Action.importOlympiaWallet,
+			state: /AccountSecurity.Destination.State.importOlympiaWallet,
+			action: AccountSecurity.Destination.Action.importOlympiaWallet,
 			content: { ImportOlympiaWalletCoordinator.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/SettingsFeature/AppSettings/AppSettings+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/AppSettings/AppSettings+Reducer.swift
@@ -7,7 +7,7 @@ public struct AppSettings: Sendable, FeatureReducer {
 
 	public struct State: Sendable, Hashable {
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public var preferences: AppPreferences?
 		var exportLogs: URL?
@@ -35,16 +35,16 @@ public struct AppSettings: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
 		case deleteProfileAndFactorSources(keepInICloudIfPresent: Bool)
 	}
 
-	// MARK: Destinations
+	// MARK: Destination
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case manageP2PLinks(P2PLinksFeature.State)
 			case gatewaySettings(GatewaySettings.State)
@@ -84,7 +84,7 @@ public struct AppSettings: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/AppSettings/AppSettings+View.swift
+++ b/RadixWallet/Features/SettingsFeature/AppSettings/AppSettings+View.swift
@@ -145,41 +145,41 @@ extension AppSettings {
 
 private extension View {
 	@MainActor
-	func manageP2PLinks(with destinationStore: PresentationStoreOf<AppSettings.Destinations>) -> some View {
+	func manageP2PLinks(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AppSettings.Destinations.State.manageP2PLinks,
-			action: AppSettings.Destinations.Action.manageP2PLinks,
+			state: /AppSettings.Destination.State.manageP2PLinks,
+			action: AppSettings.Destination.Action.manageP2PLinks,
 			destination: { P2PLinksFeature.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func gatewaySettings(with destinationStore: PresentationStoreOf<AppSettings.Destinations>) -> some View {
+	func gatewaySettings(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AppSettings.Destinations.State.gatewaySettings,
-			action: AppSettings.Destinations.Action.gatewaySettings,
+			state: /AppSettings.Destination.State.gatewaySettings,
+			action: AppSettings.Destination.Action.gatewaySettings,
 			destination: { GatewaySettings.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func profileBackupSettings(with destinationStore: PresentationStoreOf<AppSettings.Destinations>) -> some View {
+	func profileBackupSettings(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AppSettings.Destinations.State.profileBackupSettings,
-			action: AppSettings.Destinations.Action.profileBackupSettings,
+			state: /AppSettings.Destination.State.profileBackupSettings,
+			action: AppSettings.Destination.Action.profileBackupSettings,
 			destination: { ProfileBackupSettings.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	func accountAndPersonasHiding(with destinationStore: PresentationStoreOf<AppSettings.Destinations>) -> some View {
+	func accountAndPersonasHiding(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /AppSettings.Destinations.State.accountAndPersonasHiding,
-			action: AppSettings.Destinations.Action.accountAndPersonasHiding,
+			state: /AppSettings.Destination.State.accountAndPersonasHiding,
+			action: AppSettings.Destination.Action.accountAndPersonasHiding,
 			destination: { AccountAndPersonaHiding.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/SettingsFeature/AppSettings/AppSettings+View.swift
+++ b/RadixWallet/Features/SettingsFeature/AppSettings/AppSettings+View.swift
@@ -43,7 +43,6 @@ extension AppSettings {
 
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
-				let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 				ScrollView {
 					VStack(spacing: .zero) {
 						VStack(spacing: .zero) {
@@ -68,11 +67,8 @@ extension AppSettings {
 					.navigationTitle(L10n.AppSettings.title)
 					.onAppear { viewStore.send(.appeared) }
 				}
-				.manageP2PLinks(with: destinationStore)
-				.gatewaySettings(with: destinationStore)
-				.profileBackupSettings(with: destinationStore)
-				.accountAndPersonasHiding(with: destinationStore)
 			}
+			.destinations(with: store)
 		}
 
 		private var rows: [SettingsRowModel<AppSettings>] {
@@ -143,9 +139,23 @@ extension AppSettings {
 	}
 }
 
+private extension StoreOf<AppSettings> {
+	var destination: PresentationStoreOf<AppSettings.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
 private extension View {
-	@MainActor
-	func manageP2PLinks(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
+	func destinations(with store: StoreOf<AppSettings>) -> some View {
+		let destinationStore = store.destination
+		return manageP2PLinks(with: destinationStore)
+			.gatewaySettings(with: destinationStore)
+			.profileBackupSettings(with: destinationStore)
+			.accountAndPersonasHiding(with: destinationStore)
+	}
+
+	private func manageP2PLinks(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AppSettings.Destination.State.manageP2PLinks,
@@ -154,8 +164,7 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	func gatewaySettings(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
+	private func gatewaySettings(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AppSettings.Destination.State.gatewaySettings,
@@ -164,8 +173,7 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	func profileBackupSettings(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
+	private func profileBackupSettings(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AppSettings.Destination.State.profileBackupSettings,
@@ -174,8 +182,7 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	func accountAndPersonasHiding(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
+	private func accountAndPersonasHiding(with destinationStore: PresentationStoreOf<AppSettings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
 			state: /AppSettings.Destination.State.accountAndPersonasHiding,

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugKeychainTest/DebugKeychainTest.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugKeychainTest/DebugKeychainTest.swift
@@ -36,6 +36,7 @@ public struct DebugKeychainTest: Sendable, FeatureReducer {
 	}
 
 	@Dependency(\.keychainClient) var keychainClient
+
 	public init() {}
 
 	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugManageFactorSourcesFeature/DebugManageFactorSources+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugManageFactorSourcesFeature/DebugManageFactorSources+View.swift
@@ -22,7 +22,6 @@ extension DebugManageFactorSources {
 
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
-
 				VStack(alignment: .leading) {
 					if let factorSources = viewStore.factorSources {
 						ScrollView(showsIndicators: false) {
@@ -53,26 +52,8 @@ extension DebugManageFactorSources {
 					await store.send(.view(.task)).finish()
 				}
 				.navigationTitle("Factor Sources")
-				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /DebugManageFactorSources.Destination.State.importMnemonic,
-					action: DebugManageFactorSources.Destination.Action.importMnemonic,
-					content: { importMnemonicStore in
-						NavigationView {
-							// We depend on `.toolbar` to display buttons on top of
-							// keyboard. And they are not displayed if we are not
-							// inside a NavigationView
-							ImportMnemonic.View(store: importMnemonicStore)
-						}
-					}
-				)
-				.sheet(
-					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /DebugManageFactorSources.Destination.State.addLedger,
-					action: DebugManageFactorSources.Destination.Action.addLedger,
-					content: { AddLedgerFactorSource.View(store: $0) }
-				)
 			}
+			.destinations(with: store)
 		}
 	}
 }
@@ -94,6 +75,45 @@ extension FactorSourceView {
 		}
 		.padding()
 		.border(Color.app.gray1, width: 2)
+	}
+}
+
+private extension StoreOf<DebugManageFactorSources> {
+	var destination: PresentationStoreOf<DebugManageFactorSources.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<DebugManageFactorSources>) -> some View {
+		let destinationStore = store.destination
+		return importMnemonic(with: destinationStore)
+			.addLedger(with: destinationStore)
+	}
+
+	private func importMnemonic(with destinationStore: PresentationStoreOf<DebugManageFactorSources.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /DebugManageFactorSources.Destination.State.importMnemonic,
+			action: DebugManageFactorSources.Destination.Action.importMnemonic,
+			content: {
+				// We depend on `.toolbar` to display buttons on top of
+				// keyboard. And they are not displayed if we are not
+				// inside a NavigationView
+				ImportMnemonic.View(store: $0)
+					.inNavigationView
+			}
+		)
+	}
+
+	private func addLedger(with destinationStore: PresentationStoreOf<DebugManageFactorSources.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /DebugManageFactorSources.Destination.State.addLedger,
+			action: DebugManageFactorSources.Destination.Action.addLedger,
+			content: { AddLedgerFactorSource.View(store: $0) }
+		)
 	}
 }
 

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugManageFactorSourcesFeature/DebugManageFactorSources+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugManageFactorSourcesFeature/DebugManageFactorSources+View.swift
@@ -55,8 +55,8 @@ extension DebugManageFactorSources {
 				.navigationTitle("Factor Sources")
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /DebugManageFactorSources.Destinations.State.importMnemonic,
-					action: DebugManageFactorSources.Destinations.Action.importMnemonic,
+					state: /DebugManageFactorSources.Destination.State.importMnemonic,
+					action: DebugManageFactorSources.Destination.Action.importMnemonic,
 					content: { importMnemonicStore in
 						NavigationView {
 							// We depend on `.toolbar` to display buttons on top of
@@ -68,8 +68,8 @@ extension DebugManageFactorSources {
 				)
 				.sheet(
 					store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
-					state: /DebugManageFactorSources.Destinations.State.addLedger,
-					action: DebugManageFactorSources.Destinations.Action.addLedger,
+					state: /DebugManageFactorSources.Destination.State.addLedger,
+					action: DebugManageFactorSources.Destination.Action.addLedger,
 					content: { AddLedgerFactorSource.View(store: $0) }
 				)
 			}

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugManageFactorSourcesFeature/DebugManageFactorSources.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugManageFactorSourcesFeature/DebugManageFactorSources.swift
@@ -8,12 +8,12 @@ public struct DebugManageFactorSources: Sendable, FeatureReducer {
 		public var factorSources: FactorSources?
 
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init() {}
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case importMnemonic(ImportMnemonic.State)
 			case addLedger(AddLedgerFactorSource.State)
@@ -47,7 +47,7 @@ public struct DebugManageFactorSources: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	@Dependency(\.errorQueue) var errorQueue
@@ -58,7 +58,7 @@ public struct DebugManageFactorSources: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugUserDefaultsContents/DebugUserDefaultsContents.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugUserDefaultsContents/DebugUserDefaultsContents.swift
@@ -28,6 +28,7 @@ public struct DebugUserDefaultsContents: Sendable, FeatureReducer {
 	}
 
 	@Dependency(\.userDefaultsClient) var userDefaultsClient
+
 	public init() {}
 
 	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+Reducer.swift
@@ -9,7 +9,7 @@ public struct DebugSettingsCoordinator: Sendable, FeatureReducer {
 
 	public struct State: Sendable, Hashable {
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public init() {}
 	}
@@ -29,10 +29,10 @@ public struct DebugSettingsCoordinator: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case debugUserDefaultsContents(DebugUserDefaultsContents.State)
 			case debugInspectProfile(DebugInspectProfile.State)
@@ -83,7 +83,7 @@ public struct DebugSettingsCoordinator: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+View.swift
@@ -85,12 +85,12 @@ extension DebugSettingsCoordinator.View {
 private extension View {
 	@MainActor
 	func debugUserDefaultsContents(
-		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destinations>
+		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /DebugSettingsCoordinator.Destinations.State.debugUserDefaultsContents,
-			action: DebugSettingsCoordinator.Destinations.Action.debugUserDefaultsContents,
+			state: /DebugSettingsCoordinator.Destination.State.debugUserDefaultsContents,
+			action: DebugSettingsCoordinator.Destination.Action.debugUserDefaultsContents,
 			destination: { DebugUserDefaultsContents.View(store: $0) }
 		)
 	}
@@ -98,12 +98,12 @@ private extension View {
 	#if DEBUG
 	@MainActor
 	func debugKeychainTest(
-		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destinations>
+		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /DebugSettingsCoordinator.Destinations.State.debugKeychainTest,
-			action: DebugSettingsCoordinator.Destinations.Action.debugKeychainTest,
+			state: /DebugSettingsCoordinator.Destination.State.debugKeychainTest,
+			action: DebugSettingsCoordinator.Destination.Action.debugKeychainTest,
 			destination: { DebugKeychainTest.View(store: $0) }
 		)
 	}
@@ -111,36 +111,36 @@ private extension View {
 
 	@MainActor
 	func factorSources(
-		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destinations>
+		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /DebugSettingsCoordinator.Destinations.State.debugManageFactorSources,
-			action: DebugSettingsCoordinator.Destinations.Action.debugManageFactorSources,
+			state: /DebugSettingsCoordinator.Destination.State.debugManageFactorSources,
+			action: DebugSettingsCoordinator.Destination.Action.debugManageFactorSources,
 			destination: { DebugManageFactorSources.View(store: $0) }
 		)
 	}
 
 	@MainActor
 	func debugInspectProfile(
-		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destinations>
+		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /DebugSettingsCoordinator.Destinations.State.debugInspectProfile,
-			action: DebugSettingsCoordinator.Destinations.Action.debugInspectProfile,
+			state: /DebugSettingsCoordinator.Destination.State.debugInspectProfile,
+			action: DebugSettingsCoordinator.Destination.Action.debugInspectProfile,
 			destination: { DebugInspectProfile.View(store: $0) }
 		)
 	}
 
 	@MainActor
 	func securityStructureConfigs(
-		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destinations>
+		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /DebugSettingsCoordinator.Destinations.State.securityStructureConfigs,
-			action: DebugSettingsCoordinator.Destinations.Action.securityStructureConfigs,
+			state: /DebugSettingsCoordinator.Destination.State.securityStructureConfigs,
+			action: DebugSettingsCoordinator.Destination.Action.securityStructureConfigs,
 			destination: { SecurityStructureConfigurationListCoordinator.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+View.swift
@@ -16,7 +16,6 @@ extension DebugSettingsCoordinator {
 extension DebugSettingsCoordinator.View {
 	public var body: some View {
 		WithViewStore(store, observe: { $0 }, send: { .view($0) }) { viewStore in
-			let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 			ScrollView {
 				VStack(spacing: .zero) {
 					ForEach(rows) { row in
@@ -31,15 +30,9 @@ extension DebugSettingsCoordinator.View {
 			.navigationBarTitleColor(.app.gray1)
 			.navigationBarTitleDisplayMode(.inline)
 			.navigationBarInlineTitleFont(.app.secondaryHeader)
-			.factorSources(with: destinationStore)
-			.debugUserDefaultsContents(with: destinationStore)
-			#if DEBUG
-				.debugKeychainTest(with: destinationStore)
-			#endif // DEBUG
-				.debugInspectProfile(with: destinationStore)
-				.securityStructureConfigs(with: destinationStore)
-				.tint(.app.gray1)
-				.foregroundColor(.app.gray1)
+			.destinations(with: store.destination)
+			.tint(.app.gray1)
+			.foregroundColor(.app.gray1)
 		}
 		.presentsLoadingViewOverlay()
 	}
@@ -82,9 +75,27 @@ extension DebugSettingsCoordinator.View {
 
 // MARK: - Extensions
 
+private extension StoreOf<DebugSettingsCoordinator> {
+	var destination: PresentationStoreOf<DebugSettingsCoordinator.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
 private extension View {
-	@MainActor
-	func debugUserDefaultsContents(
+	func destinations(
+		with store: PresentationStoreOf<DebugSettingsCoordinator.Destination>
+	) -> some View {
+		factorSources(with: store)
+			.debugUserDefaultsContents(with: store)
+		#if DEBUG
+			.debugKeychainTest(with: store)
+		#endif
+			.debugInspectProfile(with: store)
+			.securityStructureConfigs(with: store)
+	}
+
+	private func debugUserDefaultsContents(
 		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(
@@ -96,8 +107,7 @@ private extension View {
 	}
 
 	#if DEBUG
-	@MainActor
-	func debugKeychainTest(
+	private func debugKeychainTest(
 		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(
@@ -109,8 +119,7 @@ private extension View {
 	}
 	#endif // DEBUG
 
-	@MainActor
-	func factorSources(
+	private func factorSources(
 		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(
@@ -121,8 +130,7 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	func debugInspectProfile(
+	private func debugInspectProfile(
 		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(
@@ -133,8 +141,7 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	func securityStructureConfigs(
+	private func securityStructureConfigs(
 		with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
 	) -> some View {
 		navigationDestination(

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics+View.swift
@@ -47,14 +47,14 @@ extension DisplayMnemonics {
 					await viewStore.send(.onFirstTask).finish()
 				}
 			}
-			.destinations(with: store)
+			.destination(with: store)
 		}
 	}
 }
 
 extension View {
 	@MainActor
-	fileprivate func destinations(
+	fileprivate func destination(
 		with store: StoreOf<DisplayMnemonics>
 	) -> some View {
 		let destinationStore = store.scope(
@@ -68,21 +68,21 @@ extension View {
 	}
 
 	@MainActor
-	private func displayMnemonicSheet(with destinationStore: PresentationStoreOf<DisplayMnemonics.Destinations>) -> some View {
+	private func displayMnemonicSheet(with destinationStore: PresentationStoreOf<DisplayMnemonics.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /DisplayMnemonics.Destinations.State.displayMnemonic,
-			action: DisplayMnemonics.Destinations.Action.displayMnemonic,
+			state: /DisplayMnemonics.Destination.State.displayMnemonic,
+			action: DisplayMnemonics.Destination.Action.displayMnemonic,
 			destination: { DisplayMnemonic.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func importMnemonicsSheet(with destinationStore: PresentationStoreOf<DisplayMnemonics.Destinations>) -> some View {
+	private func importMnemonicsSheet(with destinationStore: PresentationStoreOf<DisplayMnemonics.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /DisplayMnemonics.Destinations.State.importMnemonicControllingAccounts,
-			action: DisplayMnemonics.Destinations.Action.importMnemonicControllingAccounts,
+			state: /DisplayMnemonics.Destination.State.importMnemonicControllingAccounts,
+			action: DisplayMnemonics.Destination.Action.importMnemonicControllingAccounts,
 			destination: { importStore in
 				NavigationView {
 					ImportMnemonicControllingAccounts.View(

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
@@ -5,7 +5,7 @@ import SwiftUI
 public struct DisplayMnemonics: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
 		@PresentationState
-		public var destination: Destinations.State? = nil
+		public var destination: Destination.State? = nil
 
 		public var deviceFactorSources: IdentifiedArrayOf<DisplayEntitiesControlledByMnemonic.State> = []
 
@@ -22,10 +22,10 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 
 	public enum ChildAction: Sendable, Equatable {
 		case row(id: DisplayEntitiesControlledByMnemonic.State.ID, action: DisplayEntitiesControlledByMnemonic.Action)
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
-	public struct Destinations: Sendable, Equatable, Reducer {
+	public struct Destination: Sendable, Equatable, Reducer {
 		public enum State: Sendable, Hashable {
 			case displayMnemonic(DisplayMnemonic.State)
 			case importMnemonicControllingAccounts(ImportMnemonicControllingAccounts.State)
@@ -61,7 +61,7 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 				DisplayEntitiesControlledByMnemonic()
 			}
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator+View.swift
+++ b/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator+View.swift
@@ -50,10 +50,9 @@ extension ImportOlympiaWalletCoordinator.Path {
 					CaseLet(
 						/State.importMnemonic,
 						action: Action.importMnemonic,
-						then: { childStore in
-							NavigationView {
-								ImportMnemonic.View(store: childStore)
-							}
+						then: {
+							ImportMnemonic.View(store: $0)
+								.inNavigationView
 						}
 					)
 				case .importOlympiaLedgerAccountsAndFactorSources:

--- a/RadixWallet/Features/SettingsFeature/Settings+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/Settings+Reducer.swift
@@ -11,7 +11,7 @@ public struct Settings: Sendable, FeatureReducer {
 
 	public struct State: Sendable, Hashable {
 		@PresentationState
-		public var destination: Destinations.State?
+		public var destination: Destination.State?
 
 		public var shouldShowMigrateOlympiaButton: Bool = false
 		public var userHasNoP2PLinks: Bool? = nil
@@ -40,14 +40,14 @@ public struct Settings: Sendable, FeatureReducer {
 	}
 
 	public enum ChildAction: Sendable, Equatable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
 		case deleteProfileAndFactorSources(keepInICloudIfPresent: Bool)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case manageP2PLinks(P2PLinksFeature.State)
 
@@ -102,7 +102,7 @@ public struct Settings: Sendable, FeatureReducer {
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/Settings+View.swift
+++ b/RadixWallet/Features/SettingsFeature/Settings+View.swift
@@ -183,7 +183,7 @@ extension Settings.View {
 
 extension View {
 	@MainActor
-	fileprivate func navigationDestinations(with destinationStore: PresentationStoreOf<Settings.Destinations>) -> some View {
+	fileprivate func navigationDestinations(with destinationStore: PresentationStoreOf<Settings.Destination>) -> some View {
 		self
 			.manageP2PLinks(with: destinationStore)
 			.authorizedDapps(with: destinationStore)
@@ -196,62 +196,62 @@ extension View {
 	}
 
 	@MainActor
-	private func manageP2PLinks(with destinationStore: PresentationStoreOf<Settings.Destinations>) -> some View {
+	private func manageP2PLinks(with destinationStore: PresentationStoreOf<Settings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /Settings.Destinations.State.manageP2PLinks,
-			action: Settings.Destinations.Action.manageP2PLinks,
+			state: /Settings.Destination.State.manageP2PLinks,
+			action: Settings.Destination.Action.manageP2PLinks,
 			destination: { P2PLinksFeature.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func authorizedDapps(with destinationStore: PresentationStoreOf<Settings.Destinations>) -> some View {
+	private func authorizedDapps(with destinationStore: PresentationStoreOf<Settings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /Settings.Destinations.State.authorizedDapps,
-			action: Settings.Destinations.Action.authorizedDapps,
+			state: /Settings.Destination.State.authorizedDapps,
+			action: Settings.Destination.Action.authorizedDapps,
 			destination: { AuthorizedDapps.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func personas(with destinationStore: PresentationStoreOf<Settings.Destinations>) -> some View {
+	private func personas(with destinationStore: PresentationStoreOf<Settings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /Settings.Destinations.State.personas,
-			action: Settings.Destinations.Action.personas,
+			state: /Settings.Destination.State.personas,
+			action: Settings.Destination.Action.personas,
 			destination: { PersonasCoordinator.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func accountSecurity(with destinationStore: PresentationStoreOf<Settings.Destinations>) -> some View {
+	private func accountSecurity(with destinationStore: PresentationStoreOf<Settings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /Settings.Destinations.State.accountSecurity,
-			action: Settings.Destinations.Action.accountSecurity,
+			state: /Settings.Destination.State.accountSecurity,
+			action: Settings.Destination.Action.accountSecurity,
 			destination: { AccountSecurity.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func appSettings(with destinationStore: PresentationStoreOf<Settings.Destinations>) -> some View {
+	private func appSettings(with destinationStore: PresentationStoreOf<Settings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /Settings.Destinations.State.appSettings,
-			action: Settings.Destinations.Action.appSettings,
+			state: /Settings.Destination.State.appSettings,
+			action: Settings.Destination.Action.appSettings,
 			destination: { AppSettings.View(store: $0) }
 		)
 	}
 
 	#if DEBUG
 	@MainActor
-	private func debugSettings(with destinationStore: PresentationStoreOf<Settings.Destinations>) -> some View {
+	private func debugSettings(with destinationStore: PresentationStoreOf<Settings.Destination>) -> some View {
 		navigationDestination(
 			store: destinationStore,
-			state: /Settings.Destinations.State.debugSettings,
-			action: Settings.Destinations.Action.debugSettings,
+			state: /Settings.Destination.State.debugSettings,
+			action: Settings.Destination.Action.debugSettings,
 			destination: { DebugSettingsCoordinator.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/SplashFeature/Splash+View.swift
+++ b/RadixWallet/Features/SplashFeature/Splash+View.swift
@@ -26,7 +26,7 @@ extension Splash {
 							Image(systemName: "lock.circle.fill")
 								.resizable()
 								.frame(.small)
-							Text("Tap anywhere to unlock")
+							Text("Tap anywhere to unlock") // FIXME: Strings
 								.textStyle(.body1HighImportance)
 						}
 					}
@@ -48,17 +48,34 @@ extension Splash {
 					}
 				}
 				.edgesIgnoringSafeArea(.all)
-				.alert(
-					store: store.scope(
-						state: \.$passcodeCheckFailedAlert,
-						action: { .view(.passcodeCheckFailedAlert($0)) }
-					)
-				)
+				.destinations(with: store)
 				.onAppear {
 					viewStore.send(.appeared)
 				}
 			}
 		}
+	}
+}
+
+private extension StoreOf<Splash> {
+	var destination: PresentationStoreOf<Splash.Destination> {
+		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<Splash>) -> some View {
+		let destinationStore = store.destination
+		return passcodeCheckFailed(with: destinationStore)
+	}
+
+	private func passcodeCheckFailed(with destinationStore: PresentationStoreOf<Splash.Destination>) -> some View {
+		alert(
+			store: destinationStore,
+			state: /Splash.Destination.State.passcodeCheckFailed,
+			action: Splash.Destination.Action.passcodeCheckFailed
+		)
 	}
 }
 

--- a/RadixWallet/Features/SplashFeature/Splash.swift
+++ b/RadixWallet/Features/SplashFeature/Splash.swift
@@ -5,14 +5,14 @@ import SwiftUI
 public struct Splash: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
 		@PresentationState
-		public var passcodeCheckFailedAlert: AlertState<ViewAction.PasscodeCheckFailedAlertAction>?
+		public var destination: Destination.State?
 
 		var biometricsCheckFailed: Bool = false
 
 		public init(
-			passcodeCheckFailedAlert: AlertState<ViewAction.PasscodeCheckFailedAlertAction>? = nil
+			destination: Destination.State? = nil
 		) {
-			self.passcodeCheckFailedAlert = passcodeCheckFailedAlert
+			self.destination = destination
 		}
 	}
 
@@ -37,6 +37,29 @@ public struct Splash: Sendable, FeatureReducer {
 		case completed(Profile, accountRecoveryNeeded: Bool)
 	}
 
+	public enum ChildAction: Sendable, Equatable {
+		case destination(PresentationAction<Destination.Action>)
+	}
+
+	public struct Destination: Reducer {
+		public enum State: Sendable, Hashable {
+			case passcodeCheckFailed(AlertState<Action.PasscodeCheckFailedAlert>)
+		}
+
+		public enum Action: Sendable, Equatable {
+			case passcodeCheckFailed(PasscodeCheckFailedAlert)
+
+			public enum PasscodeCheckFailedAlert: Sendable, Equatable {
+				case retryButtonTapped
+				case openSettingsButtonTapped
+			}
+		}
+
+		public var body: some ReducerOf<Self> {
+			EmptyReducer()
+		}
+	}
+
 	@Dependency(\.networkSwitchingClient) var networkSwitchingClient
 	@Dependency(\.errorQueue) var errorQueue
 	@Dependency(\.continuousClock) var clock
@@ -49,7 +72,9 @@ public struct Splash: Sendable, FeatureReducer {
 
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
-			.ifLet(\.$passcodeCheckFailedAlert, action: /Action.view .. ViewAction.passcodeCheckFailedAlert)
+			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
+				Destination()
+			}
 	}
 
 	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
@@ -82,7 +107,8 @@ public struct Splash: Sendable, FeatureReducer {
 
 			guard config?.isPasscodeSetUp == true else {
 				state.biometricsCheckFailed = true
-				state.passcodeCheckFailedAlert = .init(
+
+				state.destination = .passcodeCheckFailed(.init(
 					title: { .init(L10n.Splash.PasscodeCheckFailedAlert.title) },
 					actions: {
 						ButtonState(
@@ -97,7 +123,7 @@ public struct Splash: Sendable, FeatureReducer {
 						)
 					},
 					message: { .init(L10n.Splash.PasscodeCheckFailedAlert.message) }
-				)
+				))
 
 				return .none
 			}

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
@@ -118,8 +118,8 @@ extension CustomizeFees {
 			}
 			.sheet(
 				store: store.destination,
-				state: /CustomizeFees.Destinations.State.selectFeePayer,
-				action: CustomizeFees.Destinations.Action.selectFeePayer,
+				state: /CustomizeFees.Destination.State.selectFeePayer,
+				action: CustomizeFees.Destination.Action.selectFeePayer,
 				content: { SelectFeePayer.View(store: $0) }
 			)
 		}
@@ -181,7 +181,7 @@ extension CustomizeFees {
 }
 
 private extension StoreOf<CustomizeFees> {
-	var destination: PresentationStoreOf<CustomizeFees.Destinations> {
+	var destination: PresentationStoreOf<CustomizeFees.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
@@ -90,17 +90,13 @@ extension CustomizeFees {
 									CaseLet(
 										/CustomizeFees.State.CustomizationModeState.normal,
 										action: CustomizeFees.ChildAction.normalFeesCustomization,
-										then: {
-											NormalFeesCustomization.View(store: $0)
-										}
+										then: { NormalFeesCustomization.View(store: $0) }
 									)
 								case .advanced:
 									CaseLet(
 										/CustomizeFees.State.CustomizationModeState.advanced,
 										action: CustomizeFees.ChildAction.advancedFeesCustomization,
-										then: {
-											AdvancedFeesCustomization.View(store: $0)
-										}
+										then: { AdvancedFeesCustomization.View(store: $0) }
 									)
 								}
 							}
@@ -116,12 +112,7 @@ extension CustomizeFees {
 					}
 				}
 			}
-			.sheet(
-				store: store.destination,
-				state: /CustomizeFees.Destination.State.selectFeePayer,
-				action: CustomizeFees.Destination.Action.selectFeePayer,
-				content: { SelectFeePayer.View(store: $0) }
-			)
+			.destinations(with: store)
 		}
 
 		@ViewBuilder
@@ -183,5 +174,18 @@ extension CustomizeFees {
 private extension StoreOf<CustomizeFees> {
 	var destination: PresentationStoreOf<CustomizeFees.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<CustomizeFees>) -> some View {
+		let destinationStore = store.destination
+		return sheet(
+			store: destinationStore,
+			state: /CustomizeFees.Destination.State.selectFeePayer,
+			action: CustomizeFees.Destination.Action.selectFeePayer,
+			content: { SelectFeePayer.View(store: $0) }
+		)
 	}
 }

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
@@ -77,9 +77,9 @@ extension CustomizeFees {
 					ScrollView {
 						VStack(spacing: .zero) {
 							VStack {
-								infoView(viewStore)
+								infoView(viewStore.state)
 								Divider()
-								feePayerView(viewStore)
+								feePayerView(viewStore.state)
 									.padding(.top, .small1)
 							}
 							.padding([.horizontal, .bottom], .medium1)
@@ -117,7 +117,7 @@ extension CustomizeFees {
 				}
 			}
 			.sheet(
-				store: store.scope(state: \.$destination, action: { .child(.destination($0)) }),
+				store: store.destination,
 				state: /CustomizeFees.Destinations.State.selectFeePayer,
 				action: CustomizeFees.Destinations.Action.selectFeePayer,
 				content: { SelectFeePayer.View(store: $0) }
@@ -125,14 +125,14 @@ extension CustomizeFees {
 		}
 
 		@ViewBuilder
-		func infoView(_ viewStore: ViewStoreOf<CustomizeFees>) -> some SwiftUI.View {
+		func infoView(_ viewState: CustomizeFees.ViewState) -> some SwiftUI.View {
 			VStack {
-				Text(viewStore.title)
+				Text(viewState.title)
 					.textStyle(.sheetTitle)
 					.foregroundColor(.app.gray1)
 					.multilineTextAlignment(.center)
 					.padding(.bottom, .small1)
-				Text(viewStore.description)
+				Text(viewState.description)
 					.textStyle(.body1Regular)
 					.foregroundColor(.app.gray1)
 					.multilineTextAlignment(.center)
@@ -141,7 +141,7 @@ extension CustomizeFees {
 		}
 
 		@ViewBuilder
-		func feePayerView(_ viewStore: ViewStoreOf<CustomizeFees>) -> some SwiftUI.View {
+		func feePayerView(_ viewState: CustomizeFees.ViewState) -> some SwiftUI.View {
 			VStack(alignment: .leading) {
 				HStack {
 					Text(L10n.CustomizeNetworkFees.payFeeFrom)
@@ -150,13 +150,14 @@ extension CustomizeFees {
 						.textCase(.uppercase)
 
 					Spacer()
+
 					Button(L10n.CustomizeNetworkFees.changeButtonTitle) {
-						viewStore.send(.changeFeePayerTapped)
+						store.send(.view(.changeFeePayerTapped))
 					}
 					.textStyle(.body1StandaloneLink)
 					.foregroundColor(.app.blue2)
 				}
-				if let feePayer = viewStore.feePayer?.account {
+				if let feePayer = viewState.feePayer?.account {
 					SmallAccountCard(
 						feePayer.displayName.rawValue,
 						identifiable: .address(of: feePayer),
@@ -166,15 +167,21 @@ extension CustomizeFees {
 				} else {
 					AppTextField(
 						placeholder: "",
-						text: .constant(viewStore.noFeePayerText)
+						text: .constant(viewState.noFeePayerText)
 					)
 					.disabled(true)
 				}
 
-				if let insufficientBalanceMessage = viewStore.insufficientBalanceMessage {
+				if let insufficientBalanceMessage = viewState.insufficientBalanceMessage {
 					WarningErrorView(text: insufficientBalanceMessage, type: .error)
 				}
 			}
 		}
+	}
+}
+
+private extension StoreOf<CustomizeFees> {
+	var destination: PresentationStoreOf<CustomizeFees.Destinations> {
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
@@ -27,7 +27,7 @@ public struct CustomizeFees: FeatureReducer {
 		}
 
 		@PresentationState
-		public var destination: Destinations.State? = nil
+		public var destination: Destination.State? = nil
 
 		init(
 			reviewedTransaction: ReviewedTransaction,
@@ -48,7 +48,7 @@ public struct CustomizeFees: FeatureReducer {
 	}
 
 	public enum ChildAction: Equatable, Sendable {
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 		case normalFeesCustomization(NormalFeesCustomization.Action)
 		case advancedFeesCustomization(AdvancedFeesCustomization.Action)
 	}
@@ -61,7 +61,7 @@ public struct CustomizeFees: FeatureReducer {
 		case updated(TaskResult<ReviewedTransaction>)
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case selectFeePayer(SelectFeePayer.State)
 		}
@@ -93,7 +93,7 @@ public struct CustomizeFees: FeatureReducer {
 
 		Reduce(core)
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -90,7 +90,7 @@ extension TransactionReview {
 							}
 						}
 					}
-					.destinations(with: store.destination)
+					.destinations(with: store)
 					.onAppear {
 						viewStore.send(.appeared)
 					}
@@ -268,19 +268,19 @@ extension StoreOf<TransactionReview> {
 	}
 }
 
-extension View {
-	@MainActor
-	fileprivate func destinations(with store: PresentationStoreOf<TransactionReview.Destination>) -> some View {
-		customizeGuarantees(with: store)
-			.dApp(with: store)
-			.fungibleTokenDetails(with: store)
-			.nonFungibleTokenDetails(with: store)
-			.customizeFees(with: store)
-			.signing(with: store)
-			.submitting(with: store)
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<TransactionReview>) -> some View {
+		let destinationStore = store.destination
+		return customizeGuarantees(with: destinationStore)
+			.dApp(with: destinationStore)
+			.fungibleTokenDetails(with: destinationStore)
+			.nonFungibleTokenDetails(with: destinationStore)
+			.customizeFees(with: destinationStore)
+			.signing(with: destinationStore)
+			.submitting(with: destinationStore)
 	}
 
-	@MainActor
 	private func customizeGuarantees(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -290,7 +290,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func dApp(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -306,7 +305,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func fungibleTokenDetails(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -316,7 +314,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func nonFungibleTokenDetails(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -326,7 +323,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func customizeFees(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -336,7 +332,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func signing(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
@@ -346,7 +341,6 @@ extension View {
 		)
 	}
 
-	@MainActor
 	private func submitting(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -263,7 +263,7 @@ extension TransactionReview {
 }
 
 extension StoreOf<TransactionReview> {
-	var destination: PresentationStoreOf<TransactionReview.Destinations> {
+	var destination: PresentationStoreOf<TransactionReview.Destination> {
 		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
@@ -271,7 +271,7 @@ extension StoreOf<TransactionReview> {
 extension View {
 	@MainActor
 	fileprivate func destinations(with store: StoreOf<TransactionReview>) -> some View {
-		let destinationStore = store.destination
+		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
 		return customizeGuarantees(with: destinationStore)
 			.dApp(with: destinationStore)
 			.fungibleTokenDetails(with: destinationStore)
@@ -282,21 +282,21 @@ extension View {
 	}
 
 	@MainActor
-	private func customizeGuarantees(with destinationStore: PresentationStoreOf<TransactionReview.Destinations>) -> some View {
+	private func customizeGuarantees(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /TransactionReview.Destinations.State.customizeGuarantees,
-			action: TransactionReview.Destinations.Action.customizeGuarantees,
+			state: /TransactionReview.Destination.State.customizeGuarantees,
+			action: TransactionReview.Destination.Action.customizeGuarantees,
 			content: { TransactionReviewGuarantees.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func dApp(with destinationStore: PresentationStoreOf<TransactionReview.Destinations>) -> some View {
+	private func dApp(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /TransactionReview.Destinations.State.dApp,
-			action: TransactionReview.Destinations.Action.dApp,
+			state: /TransactionReview.Destination.State.dApp,
+			action: TransactionReview.Destination.Action.dApp,
 			content: { detailsStore in
 				WithNavigationBar {
 					destinationStore.send(.dismiss)
@@ -308,51 +308,51 @@ extension View {
 	}
 
 	@MainActor
-	private func fungibleTokenDetails(with destinationStore: PresentationStoreOf<TransactionReview.Destinations>) -> some View {
+	private func fungibleTokenDetails(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /TransactionReview.Destinations.State.fungibleTokenDetails,
-			action: TransactionReview.Destinations.Action.fungibleTokenDetails,
+			state: /TransactionReview.Destination.State.fungibleTokenDetails,
+			action: TransactionReview.Destination.Action.fungibleTokenDetails,
 			content: { FungibleTokenDetails.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func nonFungibleTokenDetails(with destinationStore: PresentationStoreOf<TransactionReview.Destinations>) -> some View {
+	private func nonFungibleTokenDetails(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /TransactionReview.Destinations.State.nonFungibleTokenDetails,
-			action: TransactionReview.Destinations.Action.nonFungibleTokenDetails,
+			state: /TransactionReview.Destination.State.nonFungibleTokenDetails,
+			action: TransactionReview.Destination.Action.nonFungibleTokenDetails,
 			content: { NonFungibleTokenDetails.View(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func customizeFees(with destinationStore: PresentationStoreOf<TransactionReview.Destinations>) -> some View {
+	private func customizeFees(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /TransactionReview.Destinations.State.customizeFees,
-			action: TransactionReview.Destinations.Action.customizeFees,
+			state: /TransactionReview.Destination.State.customizeFees,
+			action: TransactionReview.Destination.Action.customizeFees,
 			content: { store in NavigationView { CustomizeFees.View(store: store) } }
 		)
 	}
 
 	@MainActor
-	private func signing(with destinationStore: PresentationStoreOf<TransactionReview.Destinations>) -> some View {
+	private func signing(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /TransactionReview.Destinations.State.signing,
-			action: TransactionReview.Destinations.Action.signing,
+			state: /TransactionReview.Destination.State.signing,
+			action: TransactionReview.Destination.Action.signing,
 			content: { Signing.SheetView(store: $0) }
 		)
 	}
 
 	@MainActor
-	private func submitting(with destinationStore: PresentationStoreOf<TransactionReview.Destinations>) -> some View {
+	private func submitting(with destinationStore: PresentationStoreOf<TransactionReview.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
-			state: /TransactionReview.Destinations.State.submitting,
-			action: TransactionReview.Destinations.Action.submitting,
+			state: /TransactionReview.Destination.State.submitting,
+			action: TransactionReview.Destination.Action.submitting,
 			content: { SubmitTransaction.View(store: $0) }
 		)
 	}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -264,14 +264,14 @@ extension TransactionReview {
 
 extension StoreOf<TransactionReview> {
 	var destination: PresentationStoreOf<TransactionReview.Destinations> {
-		scope(state: \.$destination, action: { .child(.destination($0)) })
+		scope(state: \.$destination) { .child(.destination($0)) }
 	}
 }
 
 extension View {
 	@MainActor
 	fileprivate func destinations(with store: StoreOf<TransactionReview>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
+		let destinationStore = store.destination
 		return customizeGuarantees(with: destinationStore)
 			.dApp(with: destinationStore)
 			.fungibleTokenDetails(with: destinationStore)

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -90,7 +90,7 @@ extension TransactionReview {
 							}
 						}
 					}
-					.destinations(with: store)
+					.destinations(with: store.destination)
 					.onAppear {
 						viewStore.send(.appeared)
 					}
@@ -270,15 +270,14 @@ extension StoreOf<TransactionReview> {
 
 extension View {
 	@MainActor
-	fileprivate func destinations(with store: StoreOf<TransactionReview>) -> some View {
-		let destinationStore = store.scope(state: \.$destination, action: { .child(.destination($0)) })
-		return customizeGuarantees(with: destinationStore)
-			.dApp(with: destinationStore)
-			.fungibleTokenDetails(with: destinationStore)
-			.nonFungibleTokenDetails(with: destinationStore)
-			.customizeFees(with: destinationStore)
-			.signing(with: destinationStore)
-			.submitting(with: destinationStore)
+	fileprivate func destinations(with store: PresentationStoreOf<TransactionReview.Destination>) -> some View {
+		customizeGuarantees(with: store)
+			.dApp(with: store)
+			.fungibleTokenDetails(with: store)
+			.nonFungibleTokenDetails(with: store)
+			.customizeFees(with: store)
+			.signing(with: store)
+			.submitting(with: store)
 	}
 
 	@MainActor

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -28,7 +28,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		var sliderResetDate: Date = .now
 
 		@PresentationState
-		public var destination: Destinations.State? = nil
+		public var destination: Destination.State? = nil
 
 		public func printFeePayerInfo(line: UInt = #line, function: StaticString = #function) {
 			#if DEBUG
@@ -105,7 +105,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		case accountDepositSettings(AccountDepositSettings.Action)
 		case networkFee(TransactionReviewNetworkFee.Action)
 
-		case destination(PresentationAction<Destinations.Action>)
+		case destination(PresentationAction<Destination.Action>)
 	}
 
 	public enum InternalAction: Sendable, Equatable {
@@ -122,7 +122,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		case dismiss
 	}
 
-	public struct Destinations: Sendable, Reducer {
+	public struct Destination: Sendable, Reducer {
 		public enum State: Sendable, Hashable {
 			case customizeGuarantees(TransactionReviewGuarantees.State)
 			case signing(Signing.State)
@@ -199,7 +199,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 				AccountDepositSettings()
 			}
 			.ifLet(\.$destination, action: /Action.child .. ChildAction.destination) {
-				Destinations()
+				Destination()
 			}
 	}
 
@@ -334,7 +334,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		}
 	}
 
-	public func reduce(into state: inout State, presentedAction: Destinations.Action) -> Effect<Action> {
+	public func reduce(into state: inout State, presentedAction: Destination.Action) -> Effect<Action> {
 		switch presentedAction {
 		case let .customizeGuarantees(.delegate(.applyGuarantees(guaranteeStates))):
 			for guaranteeState in guaranteeStates {

--- a/RadixWallet/Profile/Entity/PersonaData/EntryKinds/PostalAddress/PersonaData+PostalAddress+Countries+Fields.swift
+++ b/RadixWallet/Profile/Entity/PersonaData/EntryKinds/PostalAddress/PersonaData+PostalAddress+Countries+Fields.swift
@@ -3,14 +3,23 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 	var fields: [[PersonaData.PostalAddress.Field.Discriminator]] {
 		switch self {
 		// MARK: A
-		case .afghanistan:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-		case .albania:
+
+		case .afghanistan, .albania, .angola, .antiguaAndBarbuda, .aruba,
+		     .barbados, .benin, .bhutan, .bolivia, .botswana, .burundi,
+		     .cameroon, .centralAfricanRepublic, .chad, .comoros, .curacao,
+		     .djibouti, .dominica,
+		     .equatorialGuinea, .eritrea,
+		     .ghana, .grenada, .guyana,
+		     .libya,
+		     .mali, .mauritania,
+		     .namibia,
+		     .republicOfTheCongo, .rwanda,
+		     .saintLucia, .saintVincentAndTheGrenadines, .samoa, .saoTomeAndPrincipe, .seychelles, .sierraLeone, .sintMaarten, .solomonIslands,
+		     .tanzania, .theGambia, .timorLeste, .togo, .tonga, .trinidadAndTobago,
+		     .tuvalu,
+		     .uganda,
+		     .vanuatu,
+		     .zimbabwe:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -18,7 +27,27 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .algeria:
+		case .algeria, .andorra, .armenia, .austria, .azerbaijan,
+		     .belgium, .bosniaAndHerzegovinia, .bulgaria,
+		     .capeVerde, .chile, .costaRica, .coteDIvoire, .croatia, .cuba, .cyprus, .czechRepublic,
+		     .denmark,
+		     .estonia, .ethiopia,
+		     .faroeIslands, .finland, .france, .frenchGuiana,
+		     .gabon, .georgia, .germany, .greece, .greenland, .guadeloupe, .guatemala, .guinea, .guineaBissau,
+		     .haiti,
+		     .iceland, .iran,
+		     .laos, .liberia, .liechtenstein, .lithuania, .luxembourg,
+		     .madagascar, .marshallIslands, .martinique, .mayotte, .moldova, .monaco, .montenegro, .morocco,
+		     .netherlands, .newCaledonia, .niger, .northMacedonia, .norway,
+		     .palestinianTerritories, .paraguay, .poland, .portugal,
+		     .qatar,
+		     .reunion, .romania,
+		     .saintBarthelemy, .saintMartin, .senegal, .serbia, .slovakia, .slovenia,
+		     .sweden, .switzerland, .syria,
+		     .tajikistan, .tunisia, .turkmenistan,
+		     .vatican,
+		     .yemen,
+		     .zambia:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -26,23 +55,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .andorra:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .angola:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .anguilla:
+		case .anguilla, .nauru:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -50,36 +63,12 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .antiguaAndBarbuda:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .argentina:
+		case .argentina, .belarus, .kuwait, .mozambique, .panama, .sanMarino:
 			[
 				[.streetLine0],
 				[.streetLine1],
 				[.postalCode, .city],
 				[.province],
-				[.countryOrRegion],
-			]
-
-		case .armenia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .aruba:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
 				[.countryOrRegion],
 			]
 
@@ -92,61 +81,21 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .austria:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .azerbaijan:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
 		// MARK: B
-		case .bahrain:
+
+		case .bahrain, .bangladesh, .bermuda, .bruneiDarussalam, .burkinaFaso,
+		     .cambodia,
+		     .democraticRepublicOfTheCongo,
+		     .jamaica,
+		     .latvia, .lebanon, .lesotho,
+		     .malawi, .maldives, .mongolia, .myanmar,
+		     .nepal,
+		     .pakistan, .peru,
+		     .singapore:
 			[
 				[.streetLine0],
 				[.streetLine1],
 				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .bangladesh:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .barbados:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .belarus:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.province],
-				[.countryOrRegion],
-			]
-
-		case .belgium:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
 				[.countryOrRegion],
 			]
 
@@ -156,54 +105,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.streetLine1],
 				[.city],
 				[.province],
-				[.countryOrRegion],
-			]
-
-		case .benin:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .bermuda:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .bhutan:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .bolivia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .bosniaAndHerzegovinia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .botswana:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
 				[.countryOrRegion],
 			]
 
@@ -218,7 +119,8 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .britishVirginIslands:
+		case .britishVirginIslands,
+		     .montserrat:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -226,55 +128,10 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .bruneiDarussalam:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .bulgaria:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .burkinaFaso:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .burundi:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
 		// MARK: C
-		case .cambodia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
 
-		case .cameroon:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-		case .canada:
+		case .canada,
+		     .indonesia:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -283,15 +140,9 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .capeVerde:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .carribeanNetherlands:
+		case .carribeanNetherlands,
+		     .kiribati,
+		     .theBahamas:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -300,35 +151,13 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .caymanIslands:
+		case .caymanIslands,
+		     .cookIslands,
+		     .turksAndCaicosIslans:
 			[
 				[.streetLine0],
 				[.streetLine1],
 				[.islandName],
-				[.countryOrRegion],
-			]
-
-		case .centralAfricanRepublic:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .chad:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .chile:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
 				[.countryOrRegion],
 			]
 
@@ -352,110 +181,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .comoros:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .cookIslands:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.islandName],
-				[.countryOrRegion],
-			]
-
-		case .costaRica:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .coteDIvoire:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .croatia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .cuba:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .curacao:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .cyprus:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .czechRepublic:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
 		// MARK: D
-		case .democraticRepublicOfTheCongo:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .denmark:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .djibouti:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .dominica:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
 
 		case .dominicanRepublic:
 			[
@@ -467,7 +193,17 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 			]
 
 		// MARK: E
-		case .ecuador:
+
+		case .elSalvador, .honduras, .uruguay:
+			[
+				[.streetLine0],
+				[.streetLine1],
+				[.postalCode, .city],
+				[.department],
+				[.countryOrRegion],
+			]
+
+		case .ecuador, .mauritius, .southSudan, .sudan:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -485,74 +221,16 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .elSalvador:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.department],
-				[.countryOrRegion],
-			]
-
-		case .equatorialGuinea:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .eritrea:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .estonia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .eswatini:
+		case .eswatini, .falklandIslands, .iraq, .isleOfMan, .kenya, .malta, .saintHelena, .southGeorgiaAndSouthSandwichIslands, .sriLanka:
 			[
 				[.streetLine0],
 				[.streetLine1],
 				[.city],
 				[.postalCode],
-				[.countryOrRegion],
-			]
-
-		case .ethiopia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
 				[.countryOrRegion],
 			]
 
         // MARK: F
-
-		case .falklandIslands:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.postalCode],
-				[.countryOrRegion],
-			]
-
-		case .faroeIslands:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
 
 		case .fiji:
 			[
@@ -563,31 +241,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .finland:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .france:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .frenchGuiana:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .frenchPolynesia:
+		case .frenchPolynesia, .saintKittsAndNevis:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -597,37 +251,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 			]
 
 		// MARK: G
-		case .gabon:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .georgia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .germany:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .ghana:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
 
 		case .gibraltar:
 			[
@@ -638,87 +261,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .greece:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .greenland:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .grenada:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .guadeloupe:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .guatemala:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .guinea:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .guineaBissau:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .guyana:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
 		// MARK: H
-		case .haiti:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .honduras:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.department],
-				[.countryOrRegion],
-			]
 
 		case .hongKong:
 			[
@@ -728,7 +271,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.streetLine1],
 			]
 
-		case .hungary:
+		case .hungary, .kyrgyzstan:
 			[
 				[.postalCode, .city],
 				[.streetLine0],
@@ -737,13 +280,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 			]
 
 		// MARK: I
-		case .iceland:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
 
 		case .india:
 			[
@@ -751,32 +287,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.streetLine1],
 				[.city, .postcode],
 				[.state],
-				[.countryOrRegion],
-			]
-
-		case .indonesia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.province, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .iran:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .iraq:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.postalCode],
 				[.countryOrRegion],
 			]
 
@@ -789,24 +299,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .isleOfMan:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.postalCode],
-				[.countryOrRegion],
-			]
-
-		case .isreal:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.province, .countryOrRegion],
-			]
-
-		case .italy:
+		case .israel, .italy, .spain:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -815,13 +308,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 			]
 
 		// MARK: J
-		case .jamaica:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
 
 		case .japan:
 			[
@@ -842,6 +328,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 			]
 
 		// MARK: K
+
 		case .kazakhstan:
 			[
 				[.streetLine0],
@@ -853,115 +340,8 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.postalCode],
 			]
 
-		case .kenya:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.postalCode],
-				[.countryOrRegion],
-			]
-
-		case .kiribati:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.islandName],
-				[.countryOrRegion],
-			]
-
-		case .kuwait:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.province],
-				[.countryOrRegion],
-			]
-
-		case .kyrgyzstan:
-			[
-				[.postalCode, .city],
-				[.streetLine0],
-				[.streetLine1],
-				[.countryOrRegion],
-			]
-
-		// MARK: L
-		case .laos:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .latvia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .lebanon:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .lesotho:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .liberia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .libya:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .liechtenstein:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .lithuania:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .luxembourg:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
 		// MARK: M
+
 		case .macao:
 			[
 				[.countryOrRegion],
@@ -970,23 +350,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.streetLine1],
 			]
 
-		case .madagascar:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .malawi:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .malaysia:
+		case .malaysia, .mexico:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -995,82 +359,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .maldives:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .mali:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .malta:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.postalCode],
-				[.countryOrRegion],
-			]
-
-		case .marshallIslands:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .martinique:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .mauritania:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .mauritius:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .mayotte:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .mexico:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.state],
-				[.countryOrRegion],
-			]
-
-		case .micronesia:
+		case .micronesia, .puertoRico, .unitedStates, .usVirginIslands:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -1079,111 +368,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .moldova:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .monaco:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .mongolia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .montenegro:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .montserrat:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postcode],
-				[.countryOrRegion],
-			]
-
-		case .morocco:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .mozambique:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.province],
-				[.countryOrRegion],
-			]
-
-		case .myanmar:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
 		// MARK: N
-		case .namibia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .nauru:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.district],
-				[.countryOrRegion],
-			]
-
-		case .nepal:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .netherlands:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .newCaledonia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
 
 		case .newZealand:
 			[
@@ -1204,15 +389,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .niger:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .nigeria:
+		case .nigeria, .venezuela:
 			[
 				[.streetLine0],
 				[.streetLine1],
@@ -1230,23 +407,8 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.streetLine1],
 			]
 
-		case .northMacedonia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .norway:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
 		// MARK: O
+
 		case .oman:
 			[
 				[.streetLine0],
@@ -1258,13 +420,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 			]
 
 		// MARK: P
-		case .pakistan:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
 
 		case .palau:
 			[
@@ -1273,23 +428,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.city],
 				[.state],
 				[.zip],
-				[.countryOrRegion],
-			]
-
-		case .palestinianTerritories:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .panama:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.province],
 				[.countryOrRegion],
 			]
 
@@ -1302,22 +440,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .paraguay:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .peru:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
 		case .philippines:
 			[
 				[.streetLine0],
@@ -1326,64 +448,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.city, .countryOrRegion],
 			]
 
-		case .poland:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .portugal:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .puertoRico:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.state, .zip],
-				[.countryOrRegion],
-			]
-
-		// MARK: Q
-		case .qatar:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
 		// MARK: R
-		case .republicOfTheCongo:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .reunion:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .romania:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
 
 		case .russia:
 			[
@@ -1395,89 +460,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.postalCode],
 			]
 
-		case .rwanda:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
 		// MARK: S
-		case .saintBarthelemy:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .saintHelena:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.postalCode],
-				[.countryOrRegion],
-			]
-
-		case .saintKittsAndNevis:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.islandName],
-				[.countryOrRegion],
-			]
-
-		case .saintLucia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .saintMartin:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .saintVincentAndTheGrenadines:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .samoa:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .sanMarino:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.province],
-				[.countryOrRegion],
-			]
-
-		case .saoTomeAndPrincipe:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
 
 		case .saudiArabia:
 			[
@@ -1485,78 +468,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.streetLine1],
 				[.district],
 				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .senegal:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .serbia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .seychelles:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .sierraLeone:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .singapore:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .sintMaarten:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .slovakia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .slovenia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .solomonIslands:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
 				[.countryOrRegion],
 			]
 
@@ -1569,21 +480,12 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .southAfrica:
+		case .southAfrica, .ukraine:
 			[
 				[.streetLine0],
 				[.streetLine1],
 				[.city],
 				[.province],
-				[.postalCode],
-				[.countryOrRegion],
-			]
-
-		case .southGeorgiaAndSouthSandwichIslands:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
 				[.postalCode],
 				[.countryOrRegion],
 			]
@@ -1598,41 +500,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.postalCode],
 			]
 
-		case .southSudan:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .spain:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.province, .countryOrRegion],
-			]
-
-		case .sriLanka:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.postalCode],
-				[.countryOrRegion],
-			]
-
-		case .sudan:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode],
-				[.city],
-				[.countryOrRegion],
-			]
-
 		case .suriname:
 			[
 				[.streetLine0],
@@ -1642,31 +509,8 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .sweden:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .switzerland:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .syria:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
 		// MARK: T
+
 		case .taiwan:
 			[
 				[.countryOrRegion],
@@ -1674,22 +518,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.townshipSlashDistrict],
 				[.streetLine0],
 				[.streetLine1],
-			]
-
-		case .tajikistan:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .tanzania:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
 			]
 
 		case .thailand:
@@ -1701,63 +529,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .theBahamas:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.islandName],
-				[.countryOrRegion],
-			]
-
-		case .theGambia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .timorLeste:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .togo:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .tonga:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .trinidadAndTobago:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .tunisia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
 		case .turkey:
 			[
 				[.streetLine0],
@@ -1766,57 +537,7 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.city, .countryOrRegion],
 			]
 
-		case .turkmenistan:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .turksAndCaicosIslans:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.islandName],
-				[.countryOrRegion],
-			]
-
-		case .tuvalu:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
 		// MARK: U
-		case .usVirginIslands:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.state, .zip],
-				[.countryOrRegion],
-			]
-
-		case .uganda:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .ukraine:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.province],
-				[.postalCode],
-				[.countryOrRegion],
-			]
 
 		case .unitedArabEmirates:
 			[
@@ -1837,24 +558,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.countryOrRegion],
 			]
 
-		case .unitedStates:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.state, .zip],
-				[.countryOrRegion],
-			]
-
-		case .uruguay:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.department],
-				[.countryOrRegion],
-			]
-
 		case .uzbekistan:
 			[
 				[.streetLine0],
@@ -1865,30 +568,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 			]
 
 		// MARK: V
-		case .vanuatu:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
-				[.countryOrRegion],
-			]
-
-		case .vatican:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .venezuela:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city, .postalCode],
-				[.state],
-				[.countryOrRegion],
-			]
 
 		case .vietnam:
 			[
@@ -1896,30 +575,6 @@ extension PersonaData.PostalAddress.CountryOrRegion {
 				[.streetLine1],
 				[.province],
 				[.city, .postalCode],
-				[.countryOrRegion],
-			]
-
-		case .yemen:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .zambia:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.postalCode, .city],
-				[.countryOrRegion],
-			]
-
-		case .zimbabwe:
-			[
-				[.streetLine0],
-				[.streetLine1],
-				[.city],
 				[.countryOrRegion],
 			]
 		}

--- a/RadixWallet/Profile/Entity/PersonaData/EntryKinds/PostalAddress/PersonaData+PostalAddress+Country.swift
+++ b/RadixWallet/Profile/Entity/PersonaData/EntryKinds/PostalAddress/PersonaData+PostalAddress+Country.swift
@@ -126,7 +126,7 @@ extension PersonaData.PostalAddress {
 		case iraq
 		case ireland
 		case isleOfMan
-		case isreal
+		case israel
 		case italy
 		public static let ivoryCoast = Self.coteDIvoire
 

--- a/RadixWalletTests/Clients/ROLAClientTests/ROLAClientTests.swift
+++ b/RadixWalletTests/Clients/ROLAClientTests/ROLAClientTests.swift
@@ -74,12 +74,6 @@ final class ROLAClientTests: TestCase {
 					origin: .init(string: vector.origin)
 				)
 
-				let otherPayload = try _payloadToHash(
-					challenge: .init(rawValue: .init(hex: vector.challenge)),
-					dAppDefinitionAddress: .init(validatingAddress: vector.dAppDefinitionAddress),
-					origin: .init(string: vector.origin)
-				)
-
 				XCTAssertEqual(otherPayload.hex, vector.payloadToHash)
 
 				XCTAssertEqual(payload.hex, vector.payloadToHash)
@@ -105,7 +99,7 @@ final class ROLAClientTests: TestCase {
 				try (UInt8.zero ..< 10).map { seed -> TestVector in
 					/// deterministic derivation of a challenge, this is not `blakeHashOfPayload`
 					let challenge = try blake2b(data: Data((origin.urlString.rawValue + dAppDefinitionAddress.address).utf8) + [seed])
-					let payload = try payloadToHash(
+					let payload = try ROLAClient.payloadToHash(
 						challenge: .init(rawValue: .init(data: challenge)),
 						dAppDefinitionAddress: dAppDefinitionAddress,
 						origin: origin
@@ -136,7 +130,7 @@ final class ROLAClientTests: TestCase {
 		XCTAssertEqual(publicKey.compressedRepresentation.hex, "0a4b894208a1f6b1bd7e823b59909f01aae0172b534baa2905b25f1bcbbb4f0a")
 
 		let hash: Data = try {
-			let payload = try payloadToHash(
+			let payload = try ROLAClient.payloadToHash(
 				challenge: .init(.init(data: Data(hex: "2596b7902d56a32d17ca90ce2a1ee0a18a9cac6a82fb9f186d904e4a3eeeb627"))),
 				dAppDefinitionAddress: .init(validatingAddress: "account_rdx168fghy4kapzfnwpmq7t7753425lwklk65r82ys7pz2xzleehk2ap0k"),
 				origin: .init(string: "https://radix-dapp-toolkit-dev.rdx-works-main.extratools.works")

--- a/RadixWalletTests/Clients/ROLAClientTests/ROLAClientTests.swift
+++ b/RadixWalletTests/Clients/ROLAClientTests/ROLAClientTests.swift
@@ -68,11 +68,20 @@ final class ROLAClientTests: TestCase {
 			jsonName: "rola_challenge_payload_hash_vectors"
 		) { (vectors: [TestVector]) in
 			for vector in vectors {
-				let payload = try payloadToHash(
+				let payload = try ROLAClient.payloadToHash(
 					challenge: .init(rawValue: .init(hex: vector.challenge)),
 					dAppDefinitionAddress: .init(validatingAddress: vector.dAppDefinitionAddress),
 					origin: .init(string: vector.origin)
 				)
+
+				let otherPayload = try _payloadToHash(
+					challenge: .init(rawValue: .init(hex: vector.challenge)),
+					dAppDefinitionAddress: .init(validatingAddress: vector.dAppDefinitionAddress),
+					origin: .init(string: vector.origin)
+				)
+
+				XCTAssertEqual(otherPayload.hex, vector.payloadToHash)
+
 				XCTAssertEqual(payload.hex, vector.payloadToHash)
 				let blakeHashOfPayload = try blake2b(data: payload)
 				XCTAssertEqual(blakeHashOfPayload.hex, vector.blakeHashOfPayload)

--- a/RadixWalletTests/Features/AccountPreferencesTests/AccountPreferencesTests.swift
+++ b/RadixWalletTests/Features/AccountPreferencesTests/AccountPreferencesTests.swift
@@ -12,7 +12,7 @@ final class AccountPreferencesTests: TestCase {
 		)
 
 		await store.send(.view(.hideAccountTapped)) { state in
-			state.destinations = .confirmHideAccount(.init(
+			state.destination = .confirmHideAccount(.init(
 				title: .init(L10n.AccountSettings.hideThisAccount),
 				message: .init(L10n.AccountSettings.hideAccountConfirmation),
 				buttons: [
@@ -34,8 +34,8 @@ final class AccountPreferencesTests: TestCase {
 			}
 		}
 
-		await store.send(.child(.destinations(.presented(.confirmHideAccount(.confirmTapped))))) { state in
-			state.destinations = nil
+		await store.send(.child(.destination(.presented(.confirmHideAccount(.confirmTapped))))) { state in
+			state.destination = nil
 		}
 
 		let updatedAccount = await updateAccount.value

--- a/RadixWalletTests/Features/GatewaySettingsFeatureTests/GatewaySettingsFeatureTests.swift
+++ b/RadixWalletTests/Features/GatewaySettingsFeatureTests/GatewaySettingsFeatureTests.swift
@@ -72,7 +72,7 @@ final class GatewaySettingsFeatureTests: TestCase {
 		// when
 		await store.send(.child(.gatewayList(.delegate(.removeGateway(gatewayToBeDeleted))))) {
 			// then
-			$0.removeGatewayAlert = .removeGateway(row: gatewayToBeDeleted)
+			$0.destination = .removeGateway(.removeGateway(row: gatewayToBeDeleted))
 		}
 	}
 
@@ -92,7 +92,7 @@ final class GatewaySettingsFeatureTests: TestCase {
 		)
 
 		var initialState = GatewaySettings.State()
-		initialState.removeGatewayAlert = .removeGateway(row: gatewayToBeDeleted)
+		initialState.destination = .removeGateway(.removeGateway(row: gatewayToBeDeleted))
 		initialState.currentGateway = currentGateway
 		initialState.gatewayList = .init(gateways: .init(
 			uniqueElements: gateways.all.elements.map {
@@ -131,9 +131,9 @@ final class GatewaySettingsFeatureTests: TestCase {
 		store.exhaustivity = .off
 
 		// when
-		await store.send(.view(.removeGateway(.presented(.removeButtonTapped(gatewayToBeDeleted))))) {
+		await store.send(.child(.destination(.presented(.removeGateway(.removeButtonTapped(gatewayToBeDeleted)))))) {
 			// then
-			$0.removeGatewayAlert = nil
+			$0.destination = nil
 		}
 
 		// when

--- a/RadixWalletTests/Features/SplashFeatureTests/SplashFeatureTests.swift
+++ b/RadixWalletTests/Features/SplashFeatureTests/SplashFeatureTests.swift
@@ -29,7 +29,7 @@ final class SplashFeatureTests: TestCase {
 		await clock.advance(by: .seconds(0.4))
 		await store.receive(.internal(.passcodeConfigResult(.success(authBiometricsConfig)))) {
 			$0.biometricsCheckFailed = true
-			$0.passcodeCheckFailedAlert = .init(
+			$0.destination = .passcodeCheckFailed(.init(
 				title: { .init(L10n.Splash.PasscodeCheckFailedAlert.title) },
 				actions: {
 					ButtonState(
@@ -44,7 +44,7 @@ final class SplashFeatureTests: TestCase {
 					)
 				},
 				message: { .init(L10n.Splash.PasscodeCheckFailedAlert.message) }
-			)
+			))
 		}
 	}
 }


### PR DESCRIPTION
## Description

Tries to improve type checking, by providing more context to the type checker. Also unifies how we handle destinations, so it looks the same everywhere.

**ADDED:** I used a built in profiling command in the terminal to find all the difficult functions, I managed to rewrite all of them except one - `body` in `DappInteractor` - because of Relay. Will do that later.

Makes other simplifications.

The next step is to move destination actions out of `ChildAction` and give them their own case in `FeatureAction`.

Applies the following pattern to all destinations (and turns non-destinations into destinations):
```swift
private extension StoreOf<ResourcesList> {
	var destination: PresentationStoreOf<ResourcesList.Destination> {
		scope(state: \.$destination) { .child(.destination($0)) }
	}
}

@MainActor
private extension View {
	func destinations(with store: StoreOf<ResourcesList>) -> some View {
		let destinationStore = store.destination
		return addAsset(with: destinationStore)
			.confirmDeletionAlert(with: destinationStore)
	}

	private func addAsset(with destinationStore: PresentationStoreOf<ResourcesList.Destination>) -> some View {
		sheet(
			store: destinationStore,
			state: /ResourcesList.Destination.State.addAsset,
			action: ResourcesList.Destination.Action.addAsset,
			content: { AddAsset.View(store: $0) }
		)
	}

	private func confirmDeletionAlert(with destinationStore: PresentationStoreOf<ResourcesList.Destination>) -> some View {
		alert(
			store: destinationStore,
			state: /ResourcesList.Destination.State.confirmAssetDeletion,
			action: ResourcesList.Destination.Action.confirmAssetDeletion
		)
	}
}
```

## How to test
This should not affect any behaviour anywhere, but it touches every single "destination", which is when we present alerts, sheets etc, or push another view onto the stack.

These things should probably be tested with extra care:

- removing gateway alert
- overlay alert
- splash alert
- authorised dapps - presentDappDetails + dismissing on forgetDapp

- ImportMnemonicsFlowCoordinator
- ImportMnemonicControllingAccounts
- AssetTransferMessage
- TransferAccountList
- introduction to personas slideup

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
