### PR TITLE
Max XRD transfer

### DIFF
--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+Reducer.swift
@@ -24,6 +24,9 @@ public struct FungibleResourceAsset: Sendable, FeatureReducer {
 
 		// MARK: - Mutable state
 
+		@PresentationState
+		public var alert: AlertState<ViewAction.AlertAction>?
+
 		public var transferAmountStr: String = ""
 		public var transferAmount: RETDecimal? = nil
 
@@ -44,6 +47,18 @@ public struct FungibleResourceAsset: Sendable, FeatureReducer {
 		case maxAmountTapped
 		case focusChanged(Bool)
 		case removeTapped
+
+		case alertAction(PresentationAction<AlertAction>)
+
+		public enum AlertAction: Hashable, Sendable {
+			case chooseXRDAmountAlert(ChooseXRDAmountAlert)
+			case needsToPayFeeFromOtherAccount(EqVoid)
+
+			public enum ChooseXRDAmountAlert: Hashable, Sendable {
+				case deductFee(RETDecimal)
+				case sendAll(RETDecimal)
+			}
+		}
 	}
 
 	public enum DelegateAction: Equatable, Sendable {
@@ -64,9 +79,21 @@ public struct FungibleResourceAsset: Sendable, FeatureReducer {
 			return .send(.delegate(.amountChanged))
 
 		case .maxAmountTapped:
-			let fee: RETDecimal = state.isXRD ? .temporaryStandardFee : .zero
 			let sumOfOthers = state.totalTransferSum - (state.transferAmount ?? .zero)
-			let remainingAmount = (state.balance - sumOfOthers - fee).clamped
+			let remainingAmount = (state.balance - sumOfOthers).clamped
+
+			if state.isXRD {
+				if remainingAmount >= 1 {
+					state.alert = .chooseXRDAmount(
+						feeDeductedAmount: remainingAmount - 1,
+						maxAmount: remainingAmount
+					)
+					return .none
+				} else {
+					state.alert = .willNeedToPayFeeFromOtherAccount()
+				}
+			}
+
 			state.transferAmount = remainingAmount
 			state.transferAmountStr = remainingAmount.formattedPlain(useGroupingSeparator: false)
 			return .send(.delegate(.amountChanged))
@@ -77,6 +104,47 @@ public struct FungibleResourceAsset: Sendable, FeatureReducer {
 
 		case .removeTapped:
 			return .send(.delegate(.removed))
+
+		case let .alertAction(action):
+			state.alert = nil
+			switch action {
+			case let .presented(.chooseXRDAmountAlert(.deductFee(amount))),
+			     let .presented(.chooseXRDAmountAlert(.sendAll(amount))):
+				state.transferAmount = amount
+				state.transferAmountStr = amount.formattedPlain(useGroupingSeparator: false)
+				return .send(.delegate(.amountChanged))
+			case .presented(.needsToPayFeeFromOtherAccount):
+				return .none
+			case .dismiss:
+				return .none
+			}
 		}
+	}
+}
+
+extension AlertState where Action == FungibleResourceAsset.ViewAction.AlertAction {
+	fileprivate static func chooseXRDAmount(feeDeductedAmount: RETDecimal, maxAmount: RETDecimal) -> Self {
+		.init(
+			title: .init(L10n.AssetTransfer.MaxAmountDialog.title),
+			message: .init(L10n.AssetTransfer.MaxAmountDialog.body),
+			buttons:
+			[
+				.default(
+					.init(L10n.AssetTransfer.MaxAmountDialog.saveXrdForFeeButton(feeDeductedAmount.formatted())),
+					action: .send(.chooseXRDAmountAlert(.deductFee(feeDeductedAmount)))
+				),
+				.default(
+					.init(L10n.AssetTransfer.MaxAmountDialog.sendAllButton(maxAmount.formatted())),
+					action: .send(.chooseXRDAmountAlert(.sendAll(maxAmount)))
+				),
+			]
+		)
+	}
+
+	fileprivate static func willNeedToPayFeeFromOtherAccount() -> Self {
+		.init(
+			title: .init(L10n.AssetTransfer.MaxAmountDialog.title),
+			message: .init("Sending the full amount of XRD in this account will require you to pay the transaction fee from a different account")
+		)
 	}
 }

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+Reducer.swift
@@ -25,7 +25,7 @@ public struct FungibleResourceAsset: Sendable, FeatureReducer {
 		// MARK: - Mutable state
 
 		@PresentationState
-		public var alert: AlertState<ViewAction.AlertAction>?
+		public var alert: AlertState<ViewAction.Alert>?
 
 		public var transferAmountStr: String = ""
 		public var transferAmount: RETDecimal? = nil
@@ -48,9 +48,9 @@ public struct FungibleResourceAsset: Sendable, FeatureReducer {
 		case focusChanged(Bool)
 		case removeTapped
 
-		case alertAction(PresentationAction<AlertAction>)
+		case alert(PresentationAction<Alert>)
 
-		public enum AlertAction: Hashable, Sendable {
+		public enum Alert: Hashable, Sendable {
 			case chooseXRDAmountAlert(ChooseXRDAmountAlert)
 			case needsToPayFeeFromOtherAccount(NeedsToPayFeeFromOtherAccount)
 
@@ -111,7 +111,7 @@ public struct FungibleResourceAsset: Sendable, FeatureReducer {
 		case .removeTapped:
 			return .send(.delegate(.removed))
 
-		case let .alertAction(action):
+		case let .alert(action):
 			state.alert = nil
 			switch action {
 			case let .presented(.chooseXRDAmountAlert(.deductFee(amount))),
@@ -131,19 +131,19 @@ public struct FungibleResourceAsset: Sendable, FeatureReducer {
 	}
 }
 
-extension AlertState where Action == FungibleResourceAsset.ViewAction.AlertAction {
+extension AlertState where Action == FungibleResourceAsset.ViewAction.Alert {
 	fileprivate static func chooseXRDAmount(feeDeductedAmount: RETDecimal, maxAmount: RETDecimal) -> Self {
-		.init(
-			title: .init(L10n.AssetTransfer.MaxAmountDialog.title),
-			message: .init(L10n.AssetTransfer.MaxAmountDialog.body),
+		AlertState(
+			title: TextState(L10n.AssetTransfer.MaxAmountDialog.title),
+			message: TextState(L10n.AssetTransfer.MaxAmountDialog.body),
 			buttons:
 			[
-				.default(
-					.init(L10n.AssetTransfer.MaxAmountDialog.saveXrdForFeeButton(feeDeductedAmount.formatted())),
+				ButtonState.default(
+					TextState(L10n.AssetTransfer.MaxAmountDialog.saveXrdForFeeButton(feeDeductedAmount.formatted())),
 					action: .send(.chooseXRDAmountAlert(.deductFee(feeDeductedAmount)))
 				),
-				.default(
-					.init(L10n.AssetTransfer.MaxAmountDialog.sendAllButton(maxAmount.formatted())),
+				ButtonState.default(
+					TextState(L10n.AssetTransfer.MaxAmountDialog.sendAllButton(maxAmount.formatted())),
 					action: .send(.chooseXRDAmountAlert(.sendAll(maxAmount)))
 				),
 			]
@@ -151,17 +151,17 @@ extension AlertState where Action == FungibleResourceAsset.ViewAction.AlertActio
 	}
 
 	fileprivate static func willNeedToPayFeeFromOtherAccount(_ amount: RETDecimal) -> Self {
-		.init(
-			title: .init(L10n.AssetTransfer.MaxAmountDialog.title),
-			message: .init("Sending the full amount of XRD in this account will require you to pay the transaction fee from a different account"),
+		AlertState(
+			title: TextState(L10n.AssetTransfer.MaxAmountDialog.title),
+			message: TextState("Sending the full amount of XRD in this account will require you to pay the transaction fee from a different account"),
 			buttons:
 			[
-				.default(
-					.init(L10n.Common.ok),
+				ButtonState.default(
+					TextState(L10n.Common.ok),
 					action: .send(.needsToPayFeeFromOtherAccount(.confirm(amount)))
 				),
-				.default(
-					.init(L10n.Common.cancel),
+				ButtonState.default(
+					TextState(L10n.Common.cancel),
 					action: .send(.needsToPayFeeFromOtherAccount(.cancel))
 				),
 			]

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+View.swift
@@ -78,7 +78,13 @@ extension FungibleResourceAsset.View {
 				}
 			}
 			.padding(.medium3)
-			.alert(store: store.scope(state: \.$alert, action: { .view(.alertAction($0)) }))
+			.alert(store: store.alert)
 		}
+	}
+}
+
+private extension StoreOf<FungibleResourceAsset> {
+	var alert: AlertPresentationStore<FungibleResourceAsset.ViewAction.Alert> {
+		scope(state: \.$alert, action: { .view(.alert($0)) })
 	}
 }

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/FungibleResourceAsset+View.swift
@@ -78,6 +78,7 @@ extension FungibleResourceAsset.View {
 				}
 			}
 			.padding(.medium3)
+			.alert(store: store.scope(state: \.$alert, action: { .view(.alertAction($0)) }))
 		}
 	}
 }


### PR DESCRIPTION
JIRA - https://radixdlt.atlassian.net/browse/ABW-2497

Display contextual alerts when user tries to transfer the max amount of XRD. 

By setting the `defaultFee=1 XRD` the following logic is applied:
- When tapping Max button the remaining XRD amount is used as Max.
- If the remaining `XRD >= defaultFee`, we do display the alert allowing users to choose the amount.
- If the remaining `XRD < defaultFee`, we do display the alert informing the user that they will have to pay the fee from other account.

#Demo


https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/ea855b02-29c7-4321-934d-961b9a21fb46

