### PR TITLE
Specific message for third-party deposits failure

### DIFF
--- a/RadixWallet/Clients/TransactionClient/Models/TransactionFailure.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionFailure.swift
@@ -35,7 +35,9 @@ extension TransactionFailure {
 		case .failedToPrepareTXReview(.failedToRetrieveTXPreview),
 		     .failedToPrepareTXReview(.failedToExtractTXReceiptBytes),
 		     .failedToPrepareTXReview(.failedToGenerateTXReview),
-		     .failedToPrepareTXReview(.failedToRetrieveTXReceipt):
+		     .failedToPrepareTXReview(.failedToRetrieveTXReceipt),
+		     .failedToPrepareTXReview(.manifestWithReservedInstructions),
+		     .failedToPrepareTXReview(.oneOfRecevingAccountsDoesNotAllowDeposits):
 			(errorKind: .failedToPrepareTransaction, message: self.errorDescription)
 
 		case let .failedToCompileOrSign(error):
@@ -47,9 +49,6 @@ extension TransactionFailure {
 			}
 		case .failedToSubmit:
 			(errorKind: .failedToSubmitTransaction, message: nil)
-
-		case .failedToPrepareTXReview(.manifestWithReservedInstructions):
-			(errorKind: .failedToPrepareTransaction, message: self.errorDescription)
 
 //		case let .failedToSubmit(error):
 //			switch error {
@@ -83,6 +82,7 @@ extension TransactionFailure {
 		case failedToExtractTXReceiptBytes(Error)
 		case failedToGenerateTXReview(Error)
 		case manifestWithReservedInstructions([ReservedInstruction])
+		case oneOfRecevingAccountsDoesNotAllowDeposits
 
 		public var errorDescription: String? {
 			switch self {
@@ -98,6 +98,8 @@ extension TransactionFailure {
 				"Failed to retrive TX receipt from gateway: \(message)"
 			case .manifestWithReservedInstructions:
 				"Transaction Manifest contains forbidden instructions"
+			case .oneOfRecevingAccountsDoesNotAllowDeposits:
+				"One of the receiving accounts does not allow Third-Party deposits"
 			}
 		}
 	}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -1190,12 +1190,19 @@ extension ResourceTracker {
 public struct TransactionReviewFailure: LocalizedError {
 	public let underylying: Swift.Error
 	public var errorDescription: String? {
-		// https://rdxworks.slack.com/archives/C031A0V1A1W/p1694087946050189?thread_ts=1694085688.749539&cid=C031A0V1A1W
-		#if DEBUG
-		L10n.Error.TransactionFailure.reviewFailure + "\n[DEBUG] Underlying error: \(String(describing: underylying))"
-		#else
-		L10n.Error.TransactionFailure.reviewFailure
-		#endif
+		L10n.Error.TransactionFailure.reviewFailure + {
+			// https://rdxworks.slack.com/archives/C031A0V1A1W/p1694087946050189?thread_ts=1694085688.749539&cid=C031A0V1A1W
+			#if DEBUG
+			"\n[DEBUG] Underlying error: \(String(describing: underylying))"
+			#else
+			if case TransactionFailure.failedToPrepareTXReview(.oneOfRecevingAccountsDoesNotAllowDeposits) = underylying {
+				// FIXME: strings
+				"\n\n One of the receiving accounts does not allow Third-Party deposits"
+			} else {
+				""
+			}
+			#endif
+		}()
 	}
 }
 


### PR DESCRIPTION
JIRA - https://radixdlt.atlassian.net/browse/ABW-2524

Display additional error message when a TX review failed due the receiving account Third-Party deposits config.

# Demo


https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/d6677d2c-d199-4617-a855-4ed39bd3befa

