### PR TITLE
[ABW-2558] Investigate, potentially fix dApps issue

### DIFF
--- a/RadixWallet/Clients/CacheClient/CacheClient+Interface.swift
+++ b/RadixWallet/Clients/CacheClient/CacheClient+Interface.swift
@@ -156,7 +156,7 @@ extension CacheClient {
 		var lifetime: TimeInterval {
 			switch self {
 			case .networkName, .onLedgerEntity:
-				360 * 60 * 24 // On day cache
+				60 * 60 * 24 // On day cache
 			case .dAppRequestMetadata, .rolaDappVerificationMetadata, .rolaWellKnownFileVerification:
 				60
 			}

--- a/RadixWallet/Clients/DappInteractionClient/DappInteractionClient+Interfce.swift
+++ b/RadixWallet/Clients/DappInteractionClient/DappInteractionClient+Interfce.swift
@@ -73,7 +73,7 @@ extension DappInteractionClient {
 			case wrongNetworkID(connectorExtensionSent: NetworkID, walletUses: NetworkID)
 			case invalidDappDefinitionAddress(gotStringWhichIsAnInvalidAccountAddress: String)
 			case invalidOrigin(invalidURLString: String)
-			case dAppValidationError
+			case dAppValidationError(String)
 			case badContent(BadContent)
 			public enum BadContent: Sendable, Hashable {
 				case numberOfAccountsInvalid

--- a/RadixWallet/Clients/DappInteractionClient/DappInteractionClient+Live.swift
+++ b/RadixWallet/Clients/DappInteractionClient/DappInteractionClient+Live.swift
@@ -122,13 +122,9 @@ extension DappInteractionClient {
 			}
 		}
 
-		guard let originURL = URL(string: nonvalidatedMeta.origin),
-		      let nonEmptyOriginURLString = NonEmptyString(rawValue: nonvalidatedMeta.origin)
-		else {
+		guard let origin = try? DappOrigin(string: nonvalidatedMeta.origin) else {
 			return invalidRequest(.invalidOrigin(invalidURLString: nonvalidatedMeta.origin))
 		}
-
-		let origin = DappOrigin(urlString: nonEmptyOriginURLString, url: originURL)
 
 		let metadataValidDappDefAddress = P2P.Dapp.Request.Metadata(
 			version: nonvalidatedMeta.version,
@@ -144,7 +140,7 @@ extension DappInteractionClient {
 				try await rolaClient.performWellKnownFileCheck(metadataValidDappDefAddress)
 			} catch {
 				loggerGlobal.warning("\(error)")
-				return invalidRequest(.dAppValidationError)
+				return invalidRequest(.dAppValidationError(error.localizedDescription))
 			}
 		}
 

--- a/RadixWallet/Clients/ROLAClient/ROLAClient+Live.swift
+++ b/RadixWallet/Clients/ROLAClient/ROLAClient+Live.swift
@@ -43,14 +43,9 @@ extension ROLAClient {
 
 		return Self(
 			performDappDefinitionVerification: { metadata async throws in
-				_ = try await cacheClient.withCaching(
-					cacheEntry: .rolaDappVerificationMetadata(metadata.dAppDefinitionAddress.address),
-					request: {
-						try await onLedgerEntitiesClient.getDappMetadata(
-							metadata.dAppDefinitionAddress,
-							validatingWebsite: metadata.origin.url
-						)
-					}
+				_ = try await onLedgerEntitiesClient.getDappMetadata(
+					metadata.dAppDefinitionAddress,
+					validatingWebsite: metadata.origin.url
 				)
 			},
 			performWellKnownFileCheck: { metadata async throws in
@@ -83,10 +78,7 @@ extension ROLAClient {
 					}
 				}
 
-				let response = try await cacheClient.withCaching(
-					cacheEntry: .rolaWellKnownFileVerification(url.absoluteString),
-					request: fetchWellKnownFile
-				)
+				let response = try await fetchWellKnownFile()
 
 				let dAppDefinitionAddresses = response.dApps.map(\.dAppDefinitionAddress)
 				guard dAppDefinitionAddresses.contains(metadata.dAppDefinitionAddress) else {

--- a/RadixWallet/Core/DesignSystem/Components/Thumbnails.swift
+++ b/RadixWallet/Core/DesignSystem/Components/Thumbnails.swift
@@ -182,7 +182,7 @@ public struct LoadableImage<Placeholder: View>: View {
 					imageView(image: image, imageSize: state.imageContainer?.image.size)
 				} else {
 					brokenImageView
-					let _ = loggerGlobal.warning("Could not load thumbnail \(url): \(state.error)")
+					let _ = loggerGlobal.warning("Could not load thumbnail from \(url): \(state.error)")
 				}
 			}
 		} else {

--- a/RadixWallet/Profile/AuthorizedDapp/AuthorizedDapp.swift
+++ b/RadixWallet/Profile/AuthorizedDapp/AuthorizedDapp.swift
@@ -59,6 +59,7 @@ public struct DappOrigin: Sendable, Hashable, Codable {
 
 	public let urlString: NonEmptyString
 	public let url: URL
+
 	public func encode(to encoder: Encoder) throws {
 		var singleValueContainer = encoder.singleValueContainer()
 		try singleValueContainer.encode(urlString.rawValue)
@@ -70,6 +71,7 @@ public struct DappOrigin: Sendable, Hashable, Codable {
 	}
 
 	struct InvalidOriginURL: Error {}
+
 	public init(string: String) throws {
 		guard
 			let urlNonEmpty = NonEmptyString(rawValue: string),


### PR DESCRIPTION
Jira ticket: [ABW-2558](https://radixdlt.atlassian.net/browse/ABW-2558)

## Description
Tries to fix the issue where some users can't connect to dApps anymore, by removing caching of dApp metadata for validation requests.

Also propagates the underlying error to the dApp response (and the UI if in dev mode), so that we can debug this issue if it persists.

## How to test
Try to connect to dApps like Gable. This should work, and if it doesn't, please screenshot the error message!

## Screenshot
<img width="200" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/09ce68d8-401c-4394-b1a9-e3cc59ce20b8">

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2558]: https://radixdlt.atlassian.net/browse/ABW-2558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ