### PR TITLE
[ABW-2575] WIP Fix cornercase bug where wallet ends up in bad state if user deletes iOS passcode before creating first account

### DIFF
--- a/RadixWallet/Clients/ProfileStore/ProfileStore.swift
+++ b/RadixWallet/Clients/ProfileStore/ProfileStore.swift
@@ -166,15 +166,20 @@ extension ProfileStore {
 		)
 
 		if let idOfEphemeralProfileToDelete {
-			do {
-				try secureStorageClient.deleteProfileAndMnemonicsByFactorSourceIDs(
-					profileID: idOfEphemeralProfileToDelete,
-					keepInICloudIfPresent: false
-				)
-			} catch {
-				// Not important enought to fail
-				logAssertionFailure("Failed to delete empty ephemeral profile ID, error: \(error)")
-			}
+			Self.deleteEphemeralProfile(id: idOfEphemeralProfileToDelete)
+		}
+	}
+
+	private static func deleteEphemeralProfile(id: ProfileSnapshot.Header.ID) {
+		@Dependency(\.secureStorageClient) var secureStorageClient
+		do {
+			try secureStorageClient.deleteProfileAndMnemonicsByFactorSourceIDs(
+				profileID: id,
+				keepInICloudIfPresent: false
+			)
+		} catch {
+			// Not important enought to fail
+			logAssertionFailure("Failed to delete empty ephemeral profile ID, error: \(error)")
 		}
 	}
 
@@ -425,12 +430,47 @@ extension ProfileStore {
 
 // MARK: Private Static
 extension ProfileStore {
+	typealias NewProfileTuple = (deviceInfo: DeviceInfo, profile: Profile, conflictingOwners: ConflictingOwners?)
+
 	private static func _loadSavedElseNewProfile(
 		metaDeviceInfo: MetaDeviceInfo
-	) -> (deviceInfo: DeviceInfo, profile: Profile, conflictingOwners: ConflictingOwners?) {
+	) -> NewProfileTuple {
+		@Dependency(\.secureStorageClient) var secureStorageClient
 		let deviceInfo = metaDeviceInfo.deviceInfo
+
+		func newProfile() throws -> NewProfileTuple {
+			try (
+				deviceInfo: metaDeviceInfo.deviceInfo,
+				profile: _tryGenerateAndSaveNewProfile(deviceInfo: deviceInfo),
+				conflictingOwners: nil
+			)
+		}
+
 		do {
 			if var existing = try _tryLoadSavedProfile() {
+				if
+					let bdfs = existing.factorSources.compactMap({ $0.extract(DeviceFactorSource.self) }).filter(\.isExplicitMainBDFS).first,
+					!secureStorageClient.containsMnemonicIdentifiedByFactorSourceID(bdfs.id),
+					existing.networks.isEmpty
+				{
+					// Unlikely corner case, but possible. The Profile does not contain any accounts and
+					// the BDFS mnemonic is missing => treat this scenario as if there is no Profile ->
+					// let user start fresh. It is possible for users to end up in this corner case scenario
+					// if the do this:
+					// 1. Start wallet without any Profile => a new Profile and BDFS is saved into keychain (and BDFS mnemonic)
+					// 2. Before they create the first account, they delete the passcode from their device and re-enabling it, this
+					// 		will delete the mnemonic from keychain, but not the Profile.
+					// 3. Start wallet again, and they are met with onboarding screen to create their first acocunt into the empty
+					// 		Profile created in step 1. HOWEVER, they user is now stuck in a bad state. The account creation will
+					// 		try to use a missing mnemonic which silently fails and user gets back to the screen where they are asked
+					//		to name the account.
+					//
+					//	The solution is simple, this Profile has no value! It has no accounts! So we just toss it and generate a new
+					//	(Profile, BDFS) pair, with the mnemonic of this new BDFS intact in keychain.
+					Self.deleteEphemeralProfile(id: existing.header.id)
+					return try newProfile()
+				}
+
 				// Read: https://radixdlt.atlassian.net/l/cp/fmoH9KcN
 				let matchingIDs = existing.header.lastUsedOnDevice.id == deviceInfo.id
 				if metaDeviceInfo.fromDeprecatedDeviceID, matchingIDs {
@@ -446,11 +486,7 @@ extension ProfileStore {
 					)
 				)
 			} else {
-				return try (
-					deviceInfo: metaDeviceInfo.deviceInfo,
-					profile: _tryGenerateAndSaveNewProfile(deviceInfo: deviceInfo),
-					conflictingOwners: nil
-				)
+				return try newProfile()
 			}
 		} catch {
 			fatalError("Unable to use app. error: \(error)")

--- a/RadixWallet/Clients/ProfileStore/ProfileStore.swift
+++ b/RadixWallet/Clients/ProfileStore/ProfileStore.swift
@@ -449,7 +449,7 @@ extension ProfileStore {
 		do {
 			if var existing = try _tryLoadSavedProfile() {
 				if
-					let bdfs = existing.factorSources.compactMap({ $0.extract(DeviceFactorSource.self) }).filter(\.isExplicitMainBDFS).first,
+					case let bdfs = existing.factorSources.babylonDevice,
 					!secureStorageClient.containsMnemonicIdentifiedByFactorSourceID(bdfs.id),
 					existing.networks.isEmpty
 				{

--- a/RadixWalletTests/ProfileTests/Utils/ProfileBuilder.swift
+++ b/RadixWalletTests/ProfileTests/Utils/ProfileBuilder.swift
@@ -15,13 +15,15 @@ public final class ProfileBuilder {
 }
 
 extension ProfileBuilder {
-	public func build() -> Profile {
+	public func build(allowEmpty: Bool = false) -> Profile {
 		guard let bdfs else { fatalError("No BDFS, unable to create Profile.") }
 		let deviceInfo = DeviceInfo(description: "Builder", id: UUID(), date: .now)
 		let networksDictionary: OrderedDictionary<NetworkID, Profile.Network> = .init(uniqueKeysWithValues: self.networks.map {
 			(key: $0.id, value: Profile.Network(networkID: $0.id, accounts: .init(rawValue: $0.accounts)!, personas: [], authorizedDapps: []))
 		})
-		assert(networksDictionary.keys.contains(.mainnet))
+		if !allowEmpty {
+			assert(networksDictionary.keys.contains(.mainnet))
+		}
 		let profile = Profile(
 			header: .init(
 				creatingDevice: deviceInfo,
@@ -34,7 +36,9 @@ extension ProfileBuilder {
 			appPreferences: .init(gateways: .init(current: .mainnet)),
 			networks: .init(dictionary: networksDictionary)
 		)
-		assert(!profile.network!.getAccounts().isEmpty)
+		if !allowEmpty {
+			assert(!profile.network!.getAccounts().isEmpty)
+		}
 		return profile
 	}
 }

--- a/RadixWalletTests/TestExtensions/TestUtils.swift
+++ b/RadixWalletTests/TestExtensions/TestUtils.swift
@@ -245,6 +245,7 @@ private func configureTestClients(
 	d.secureStorageClient.loadProfileHeaderList = { nil }
 	d.secureStorageClient.saveProfileHeaderList = { _ in }
 	d.secureStorageClient.deleteDeprecatedDeviceID = {}
+	d.secureStorageClient.containsMnemonicIdentifiedByFactorSourceID = { _ in true }
 	d.secureStorageClient.deleteProfileAndMnemonicsByFactorSourceIDs = { _, _ in }
 	d.secureStorageClient.deleteMnemonicByFactorSourceID = { _ in }
 	d.secureStorageClient.saveMnemonicForFactorSource = { _ in }


### PR DESCRIPTION
## [ABW-2575](https://radixdlt.atlassian.net/browse/ABW-2575)

# Description

Fixes an unlikely corner case, but possible. The Profile does not contain any accounts and
the BDFS mnemonic is missing => treat this scenario as if there is no Profile ->
let user start fresh. It is possible for users to end up in this corner case scenario
if the do this:
1. Start wallet without any Profile => a new Profile and BDFS is saved into keychain (and BDFS mnemonic)
2. Before they create the first account, they delete the passcode from their device and re-enabling it, this will delete the mnemonic from keychain, but not the Profile.
3. Start wallet again, and they are met with onboarding screen to create their first account into the empty Profile created in step 1. HOWEVER, they user is now stuck in a bad state. The account creation will try to use a missing mnemonic which silently fails and user gets back to the screen where they are asked to name the account.

The solution is simple, this Profile has no value! It has no accounts! So we just toss it and generate a new (Profile, BDFS) pair, with the mnemonic of this new BDFS intact in keychain.

# Demo

## Before (bug: user stuck in bad state)


https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/f422950b-4bed-4655-90d8-920cb150fe05

## After

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/587848ee-31c8-4e40-9c45-0256a7d8b7a1



[ABW-2575]: https://radixdlt.atlassian.net/browse/ABW-2575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ