### PR TITLE
Support creation of MAIN BDFS from outside of onboarding

### DIFF
--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -97,7 +97,7 @@ extension DisplayEntitiesControlledByMnemonic {
 
 					if viewStore.accounts.isEmpty {
 						if viewStore.hasHiddenAccounts {
-							NoContentView("Hidden Accounts only.")
+							NoContentView("Hidden Accounts only.") // FIXME: Strings
 						}
 					} else {
 						VStack(alignment: .leading, spacing: .small3) {

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -98,8 +98,6 @@ extension DisplayEntitiesControlledByMnemonic {
 					if viewStore.accounts.isEmpty {
 						if viewStore.hasHiddenAccounts {
 							NoContentView("Hidden Accounts only.")
-						} else {
-							NoContentView("No accounts yet.")
 						}
 					} else {
 						VStack(alignment: .leading, spacing: .small3) {

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -21,7 +21,8 @@ extension DisplayEntitiesControlledByMnemonic.State {
 				}
 			}(),
 			promptUserToBackUpMnemonic: mode == .mnemonicCanBeDisplayed && !accountsForDeviceFactorSource.isMnemonicMarkedAsBackedUp,
-			accounts: accountsForDeviceFactorSource.accounts
+			accounts: accountsForDeviceFactorSource.accounts,
+			hasHiddenAccounts: !accountsForDeviceFactorSource.hiddenAccounts.isEmpty
 		)
 	}
 }
@@ -42,6 +43,7 @@ extension DisplayEntitiesControlledByMnemonic {
 		public let buttonState: ButtonState?
 		public let promptUserToBackUpMnemonic: Bool
 		public let accounts: [Profile.Network.Account]
+		public let hasHiddenAccounts: Bool
 	}
 }
 
@@ -94,7 +96,11 @@ extension DisplayEntitiesControlledByMnemonic {
 					}
 
 					if viewStore.accounts.isEmpty {
-						NoContentView("Hidden Accounts only")
+						if viewStore.hasHiddenAccounts {
+							NoContentView("Hidden Accounts only.")
+						} else {
+							NoContentView("No accounts yet.")
+						}
 					} else {
 						VStack(alignment: .leading, spacing: .small3) {
 							ForEach(viewStore.accounts) { account in

--- a/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
@@ -201,8 +201,8 @@ public struct Home: Sendable, FeatureReducer {
 			state.destination = nil
 			switch delegateAction {
 			case .finishedEarly: break
-			case let .finishedImportingMnemonics(_, imported, newMainBDFS):
-				assert(newMainBDFS == nil, "Discrepancy, should not have been able to create new BDFS from outside of onboarding.")
+			case let .finishedImportingMnemonics(_, imported, notYetSavedNewMainBDFS):
+				assert(notYetSavedNewMainBDFS == nil, "Discrepancy, new Main BDFS should already have been saved.")
 				if !imported.isEmpty {
 					return checkAccountsAccessToMnemonic(state: state)
 				}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Coordinator/RestoreProfileFromBackupCoordinator.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Coordinator/RestoreProfileFromBackupCoordinator.swift
@@ -91,7 +91,7 @@ public struct RestoreProfileFromBackupCoordinator: Sendable, FeatureReducer {
 					))))
 			}
 
-		case let .path(.element(_, action: .importMnemonicsFlow(.delegate(.finishedImportingMnemonics(skipList, _, newMainBDFS))))):
+		case let .path(.element(_, action: .importMnemonicsFlow(.delegate(.finishedImportingMnemonics(skipList, _, notYetSavedNewMainBDFS))))):
 			loggerGlobal.notice("Starting import snapshot process...")
 			guard let profileSelection = state.profileSelection else {
 				preconditionFailure("Expected to have a profile")
@@ -101,8 +101,8 @@ public struct RestoreProfileFromBackupCoordinator: Sendable, FeatureReducer {
 				loggerGlobal.notice("Importing snapshot...")
 				try await backupsClient.importSnapshot(profileSelection.snapshot, fromCloud: profileSelection.isInCloud)
 
-				if let newMainBDFS {
-					try await factorSourcesClient.saveNewMainBDFS(newMainBDFS)
+				if let notYetSavedNewMainBDFS {
+					try await factorSourcesClient.saveNewMainBDFS(notYetSavedNewMainBDFS)
 				}
 
 				await send(.delegate(.profileImported(

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
@@ -150,8 +150,8 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 			case .finishedEarly:
 				state.destination = nil
 				return .none
-			case let .finishedImportingMnemonics(_, importedIDs, newMainBDFS):
-				assert(newMainBDFS == nil, "Discrepancy, should not have been able to create new BDFS from outside of onboarding.")
+			case let .finishedImportingMnemonics(_, importedIDs, notYetSavedNewMainBDFS):
+				assert(notYetSavedNewMainBDFS == nil, "Discrepancy, new Main BDFS should already have been saved.")
 				for imported in importedIDs {
 					state.deviceFactorSources[id: imported.factorSourceID]?.imported()
 				}

--- a/RadixWalletTests/TestExtensions/TestUtils.swift
+++ b/RadixWalletTests/TestExtensions/TestUtils.swift
@@ -253,8 +253,6 @@ private func configureTestClients(
 	d.secureStorageClient.loadProfileSnapshot = { _ in nil }
 	d.secureStorageClient.loadProfile = { _ in nil }
 	d.date = .constant(Date(timeIntervalSince1970: 0))
-//	d.userDefaults.stringForKey = { _ in nil }
-//	d.userDefaults.setString = { _, _ in }
 }
 
 extension ProfileSnapshot.Header {


### PR DESCRIPTION
Make it possible to create Main BDFS outside of onboarding.

# Demo
https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/5cf75b83-8859-4160-8ef0-33dbe3e0008f


