### PR TITLE
[ABW-2569] Success Screen Alignment and Various Small Fixes

### DIFF
--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressView.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressView.swift
@@ -86,10 +86,20 @@ extension AddressView {
 	}
 
 	private var addressView: some View {
-		Text("\(identifiable.address.formatted(format)) \(image)")
-			.lineLimit(format == .full ? nil : 1)
-			.multilineTextAlignment(.leading)
-			.minimumScaleFactor(0.5)
+		Group {
+			if format == .full {
+				Text("\(identifiable.address.formatted(format))\(image)")
+					.lineLimit(nil)
+			} else {
+				HStack(spacing: .small3) {
+					Text(identifiable.address.formatted(format))
+						.lineLimit(1)
+					image
+				}
+			}
+		}
+		.multilineTextAlignment(.leading)
+		.minimumScaleFactor(0.5)
 	}
 
 	private var image: Image {

--- a/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
@@ -38,7 +38,9 @@ extension Completion {
 
 		var body: some SwiftUI.View {
 			WithViewStore(store, observe: ViewState.init) { viewStore in
-				WithNavigationBar(closeAction: dismiss.callAsFunction) {
+				WithNavigationBar {
+					store.send(.view(.dismissTapped))
+				} content: {
 					VStack(spacing: .small3) {
 						Image(asset: AssetResource.successCheckmark)
 
@@ -56,6 +58,8 @@ extension Completion {
 								Text(L10n.TransactionReview.SubmitTransaction.txID)
 								AddressView(.identifier(.transaction(txID)))
 							}
+							.foregroundColor(.app.gray1)
+							.textStyle(.body1Regular)
 						}
 					}
 					.padding(.horizontal, .medium2)

--- a/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion.swift
@@ -15,4 +15,19 @@ struct Completion: Sendable, FeatureReducer {
 			self.dappMetadata = dappMetadata
 		}
 	}
+
+	enum ViewAction: Sendable, Equatable {
+		case dismissTapped
+	}
+
+	@Dependency(\.dismiss) var dismiss
+
+	func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
+		switch viewAction {
+		case .dismissTapped:
+			.run { _ in
+				await dismiss()
+			}
+		}
+	}
 }

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -95,17 +95,18 @@ extension DisplayEntitiesControlledByMnemonic {
 						)
 					}
 
-					if viewStore.accounts.isEmpty {
-						if viewStore.hasHiddenAccounts {
-							NoContentView("Hidden Accounts only.") // FIXME: Strings
-						}
-					} else {
+					if !viewStore.accounts.isEmpty {
 						VStack(alignment: .leading, spacing: .small3) {
 							ForEach(viewStore.accounts) { account in
 								SmallAccountCard(account: account)
 									.cornerRadius(.small1)
 							}
 						}
+					} else if viewStore.hasHiddenAccounts {
+						NoContentView("Hidden Accounts only.") // FIXME: Strings
+							.frame(maxWidth: .infinity)
+							.frame(height: .huge2)
+							.padding(.vertical, .medium1)
 					}
 				}
 			}

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
@@ -82,6 +82,8 @@ extension SubmitTransaction {
 							Text(L10n.TransactionReview.SubmitTransaction.txID)
 							AddressView(.identifier(.transaction(viewStore.txID)))
 						}
+						.foregroundColor(.app.gray1)
+						.textStyle(.body1Regular)
 					}
 					.padding(.horizontal, .medium2)
 					.padding(.bottom, .medium3)


### PR DESCRIPTION
Jira ticket: ABW-2569

## Description
- Alignment of transaction id in Completion and In progress slide ups
- Color and font for the label "Transaction id" in the same screens
- Use the TCA dismiss dependency in the Completion slide up
- Appearance of "Hidden Accounts Only" box in Seed Phrases

## Screenshot
<img width="200" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/f4c61c62-7896-4d1c-a437-7444d3cea359">

<img width="200" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/3f107639-442d-499c-9ded-35dae740fff6">

<img width="200" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/9392f375-f4bc-40df-9487-0344353a28d0">




## Video
paste link here

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
