### PR TITLE
[ABW-2602] Fix Dapp Details Navigation

### DIFF
--- a/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
@@ -81,6 +81,9 @@ private extension View {
 	func destinations(with store: StoreOf<DappDetails>) -> some View {
 		let destinationStore = store.destination
 		return personaDetails(with: destinationStore)
+			.fungibleDetails(with: destinationStore)
+			.nonFungibleDetails(with: destinationStore)
+			.confirmDisconnectAlert(with: destinationStore)
 	}
 
 	private func personaDetails(with destinationStore: PresentationStoreOf<DappDetails.Destination>) -> some View {


### PR DESCRIPTION
Jira ticket: ABW-2602

## Description
The navigation destinations from the dApp details screen got lost in a merge, making it impossible to forget a dApp or open details on NFTs/fungibles. This PR brings them back.

## How to test
- Connect a dApp
- Open details on an NFT and a fungible
- Press the Forget dApp button

## Video
https://share.icloud.com/photos/0a8k_VgaK8OLHlrGoRMxmL8AA

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
