### PR TITLE
Prevent PoolUnits crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       checks: write
     name: "Unit test"
     runs-on: macos-13-xlarge
-    timeout-minutes: 15
+    timeout-minutes: 18
 
     needs:
       - linting

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit/PoolUnit+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit/PoolUnit+View.swift
@@ -70,8 +70,12 @@ extension PoolUnitResourceViewState {
 	) -> NonEmpty<IdentifiedArrayOf<PoolUnitResourceViewState>> {
 		func redemptionValue(for resourceDetails: OnLedgerEntitiesClient.ResourceWithVaultAmount) -> String {
 			guard let poolUnitTotalSupply = resourcesDetails.poolUnitResource.resource.totalSupply else {
-				loggerGlobal.error("Missing total supply for \(resourcesDetails.poolUnitResource.resource.totalSupply)")
+				loggerGlobal.error("Missing total supply for \(resourcesDetails.poolUnitResource.resource.resourceAddress.address)")
 				return L10n.Account.PoolUnits.noTotalSupply
+			}
+			guard poolUnitTotalSupply > 0 else {
+				loggerGlobal.error("Total supply is 0 for \(resourcesDetails.poolUnitResource.resource.resourceAddress.address)")
+				return "Total supply is 0 - could not calculate redemption value" // FIXME: strings
 			}
 			let redemptionValue = poolUnit.resource.amount * (resourceDetails.amount / poolUnitTotalSupply)
 			let decimalPlaces = resourceDetails.resource.divisibility.map(UInt.init) ?? RETDecimal.maxDivisibility

--- a/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
@@ -33,9 +33,6 @@ extension Completion {
 	struct View: SwiftUI.View {
 		let store: StoreOf<Completion>
 
-		// FIXME: use dismiss dependency, when TCA 1.1.0
-		@Environment(\.dismiss) var dismiss
-
 		var body: some SwiftUI.View {
 			WithViewStore(store, observe: ViewState.init) { viewStore in
 				WithNavigationBar {


### PR DESCRIPTION
## Description
[Slack thread](https://rdxworks.slack.com/archives/C05V4202J90/p1700474625827809)

The user with account [account_rdx128ldshjmrge7j98ydag7qgsdk2t79qqlxpw5j2warzqnju7mg6x605](https://dashboard.radixdlt.com/account/account_rdx128ldshjmrge7j98ydag7qgsdk2t79qqlxpw5j2warzqnju7mg6x605/pool-units) experienced a crash when opening the pool unit view. This turned out to be because the total supply of Ociswap LP XRD/BCN was `0`, which caused a division-by-zero crash. This PR displays the text "Total supply is 0 - could not calculate redemption value", similar to how we already handle the case when the total supply property is missing.

## Screenshot
<img width="200" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/c492fac3-bdbf-4df0-a5cd-9b7f3166728f">

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
