### PR TITLE
fix title in ImportMnemonicControllingAccounts

### DIFF
--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ConfirmSkippingBDFS/ConfirmSkippingBDFS+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ConfirmSkippingBDFS/ConfirmSkippingBDFS+View.swift
@@ -52,9 +52,9 @@ extension ConfirmSkippingBDFS {
 				.padding(.horizontal, .large3)
 				.padding(.bottom, .medium2)
 				.toolbar {
-					ToolbarItem(placement: .navigationBarLeading) {
-						BackButton {
-							store.send(.view(.backButtonTapped))
+					ToolbarItem(placement: .primaryAction) {
+						CloseButton {
+							store.send(.view(.closeButtonTapped))
 						}
 					}
 				}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ConfirmSkippingBDFS/ConfirmSkippingBDFS.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ConfirmSkippingBDFS/ConfirmSkippingBDFS.swift
@@ -8,7 +8,7 @@ public struct ConfirmSkippingBDFS: Sendable, FeatureReducer {
 	public enum ViewAction: Sendable, Equatable {
 		case task
 		case confirmTapped
-		case backButtonTapped
+		case closeButtonTapped
 	}
 
 	public enum InternalAction: Sendable, Equatable {
@@ -33,7 +33,7 @@ public struct ConfirmSkippingBDFS: Sendable, FeatureReducer {
 			}
 		case .confirmTapped:
 			.send(.delegate(.confirmed))
-		case .backButtonTapped:
+		case .closeButtonTapped:
 			.send(.delegate(.cancel))
 		}
 	}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
@@ -11,7 +11,13 @@ extension ImportMnemonicControllingAccounts {
 	public struct ViewState: Equatable {
 		let isMain: Bool
 
-		var title: LocalizedStringKey {
+		var navigationTitle: String {
+			isMain
+				? L10n.RecoverSeedPhrase.Header.titleMain
+				: L10n.RecoverSeedPhrase.Header.titleOther
+		}
+
+		var subtitle: LocalizedStringKey {
 			.init(
 				isMain
 					? L10n.RecoverSeedPhrase.Header.subtitleMainSeedPhrase
@@ -19,13 +25,8 @@ extension ImportMnemonicControllingAccounts {
 			)
 		}
 
-		var navigationTitle: String {
-			isMain
-				? L10n.RecoverSeedPhrase.Header.titleMain
-				: L10n.RecoverSeedPhrase.Header.titleOther
-		}
-
 		var skipButtonTitle: String {
+			// FIXME: Strings
 			isMain ? "I Don't Have the Main Seed Phrase" : L10n.RecoverSeedPhrase.skipButton
 		}
 	}
@@ -44,28 +45,25 @@ extension ImportMnemonicControllingAccounts {
 					Text(viewStore.navigationTitle)
 						.textStyle(.sheetTitle)
 						.foregroundColor(.app.gray1)
+						.multilineTextAlignment(.center)
+						.padding(.bottom, .small1)
 
-					Text(viewStore.title)
+					Text(viewStore.subtitle)
 						.textStyle(.body1Regular)
 						.foregroundColor(.app.gray1)
-						.padding()
 
-					if !viewStore.isMain {
-						skipButton(with: viewStore)
-					}
 					ScrollView {
 						DisplayEntitiesControlledByMnemonic.View(
 							store: store.scope(state: \.entities, action: { .child(.entities($0)) })
 						)
 					}
 
-					if viewStore.isMain {
-						skipButton(with: viewStore)
-					}
 					Spacer(minLength: 0)
 				}
 				.padding(.horizontal, .medium3)
 				.footer {
+					skipButton(title: viewStore.skipButtonTitle)
+
 					Button(L10n.RecoverSeedPhrase.enterButton) {
 						viewStore.send(.inputMnemonic)
 					}
@@ -76,12 +74,12 @@ extension ImportMnemonicControllingAccounts {
 			}
 		}
 
-		private func skipButton(with viewStore: ViewStoreOf<ImportMnemonicControllingAccounts>) -> some SwiftUI.View {
-			Button(viewStore.skipButtonTitle) {
-				viewStore.send(.skip)
+		private func skipButton(title: String) -> some SwiftUI.View {
+			Button(title) {
+				store.send(.view(.skip))
 			}
 			.foregroundColor(.app.blue2)
-			.font(.app.body1Regular)
+			.font(.app.body1Header)
 			.frame(height: .standardButtonHeight)
 			.frame(maxWidth: .infinity)
 			.padding(.medium1)

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
@@ -41,16 +41,17 @@ extension ImportMnemonicControllingAccounts {
 
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
-				VStack(alignment: .center) {
+				VStack(spacing: 0) {
 					Text(viewStore.navigationTitle)
 						.textStyle(.sheetTitle)
 						.foregroundColor(.app.gray1)
 						.multilineTextAlignment(.center)
-						.padding(.bottom, .small1)
+						.padding(.bottom, .medium2)
 
 					Text(viewStore.subtitle)
 						.textStyle(.body1Regular)
 						.foregroundColor(.app.gray1)
+						.padding(.bottom, .medium3)
 
 					ScrollView {
 						DisplayEntitiesControlledByMnemonic.View(
@@ -65,7 +66,7 @@ extension ImportMnemonicControllingAccounts {
 					skipButton(title: viewStore.skipButtonTitle)
 
 					Button(L10n.RecoverSeedPhrase.enterButton) {
-						viewStore.send(.inputMnemonic)
+						viewStore.send(.inputMnemonicButtonTapped)
 					}
 					.buttonStyle(.primaryRectangular)
 				}
@@ -76,13 +77,12 @@ extension ImportMnemonicControllingAccounts {
 
 		private func skipButton(title: String) -> some SwiftUI.View {
 			Button(title) {
-				store.send(.view(.skip))
+				store.send(.view(.skipButtonTapped))
 			}
 			.foregroundColor(.app.blue2)
 			.font(.app.body1Header)
 			.frame(height: .standardButtonHeight)
 			.frame(maxWidth: .infinity)
-			.padding(.medium1)
 			.background(.app.white)
 			.cornerRadius(.small2)
 		}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts+View.swift
@@ -40,7 +40,11 @@ extension ImportMnemonicControllingAccounts {
 
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
-				VStack {
+				VStack(alignment: .center) {
+					Text(viewStore.navigationTitle)
+						.textStyle(.sheetTitle)
+						.foregroundColor(.app.gray1)
+
 					Text(viewStore.title)
 						.textStyle(.body1Regular)
 						.foregroundColor(.app.gray1)
@@ -58,7 +62,6 @@ extension ImportMnemonicControllingAccounts {
 					if viewStore.isMain {
 						skipButton(with: viewStore)
 					}
-
 					Spacer(minLength: 0)
 				}
 				.padding(.horizontal, .medium3)
@@ -68,7 +71,6 @@ extension ImportMnemonicControllingAccounts {
 					}
 					.buttonStyle(.primaryRectangular)
 				}
-				.navigationTitle(viewStore.navigationTitle)
 				.onAppear { viewStore.send(.appeared) }
 				.destinations(with: store)
 			}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
@@ -35,7 +35,9 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 	}
 
 	public enum ViewAction: Sendable, Equatable {
-		case appeared, inputMnemonic, skip
+		case appeared
+		case inputMnemonicButtonTapped
+		case skipButtonTapped
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
@@ -94,7 +96,7 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 		switch viewAction {
 		case .appeared:
 			return .none
-		case .inputMnemonic:
+		case .inputMnemonicButtonTapped:
 			state.destination = .importMnemonic(.init(
 				warning: L10n.RevealSeedPhrase.warning,
 				isWordCountFixed: true,
@@ -103,7 +105,7 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 			))
 			return .none
 
-		case .skip:
+		case .skipButtonTapped:
 			if state.isMainBDFS {
 				state.destination = .confirmSkippingBDFS(.init())
 				return .none

--- a/RadixWallet/Features/SplashFeature/Splash.swift
+++ b/RadixWallet/Features/SplashFeature/Splash.swift
@@ -17,13 +17,7 @@ public struct Splash: Sendable, FeatureReducer {
 	}
 
 	public enum ViewAction: Sendable, Equatable {
-		public enum PasscodeCheckFailedAlertAction: Sendable, Equatable {
-			case retryButtonTapped
-			case openSettingsButtonTapped
-		}
-
 		case appeared
-		case passcodeCheckFailedAlert(PresentationAction<PasscodeCheckFailedAlertAction>)
 		case didTapToUnlock
 	}
 
@@ -83,18 +77,6 @@ public struct Splash: Sendable, FeatureReducer {
 		case .didTapToUnlock:
 			state.biometricsCheckFailed = false
 			return verifyPasscode()
-
-		case let .passcodeCheckFailedAlert(.presented(action)):
-			switch action {
-			case .retryButtonTapped:
-				return verifyPasscode()
-			case .openSettingsButtonTapped:
-				return .run { _ in
-					await openURL(URL(string: UIApplication.openSettingsURLString)!)
-				}
-			}
-		case .passcodeCheckFailedAlert:
-			return .none
 		}
 	}
 
@@ -147,6 +129,17 @@ public struct Splash: Sendable, FeatureReducer {
 				loggerGlobal.notice("Account recovery needed")
 			}
 			return delegateCompleted()
+		}
+	}
+
+	public func reduce(into state: inout State, presentedAction: Destination.Action) -> Effect<Action> {
+		switch presentedAction {
+		case .passcodeCheckFailed(.retryButtonTapped):
+			verifyPasscode()
+		case .passcodeCheckFailed(.openSettingsButtonTapped):
+			.run { _ in
+				await openURL(URL(string: UIApplication.openSettingsURLString)!)
+			}
 		}
 	}
 


### PR DESCRIPTION
Change from real navigation title to a fake one in `ImportMnemonicControllingAccounts` so that `Main Seed Phrase Required` does not get truncated.

Fix appearance of skip button.

Use close button on bottom sheet shown when pressing skip.

![image](https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/d5beb032-d67b-466c-b19d-33e9ec1828db)
