### PR TITLE
Abw 2412 restore wallet from mnemonic only mark bdfs as main

### DIFF
--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/RecoverWalletWithoutProfile/Coordinator/RecoverWalletWithoutProfileCoordinator.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/RecoverWalletWithoutProfile/Coordinator/RecoverWalletWithoutProfileCoordinator.swift
@@ -145,24 +145,14 @@ public struct RecoverWalletWithoutProfileCoordinator: Sendable, FeatureReducer {
 			switch delegateAction {
 			case let .notPersisted(mnemonicWithPassphrase):
 				do {
-					let fromHash = try FactorSource.id(
-						fromMnemonicWithPassphrase: mnemonicWithPassphrase,
-						factorSourceKind: .device
-					)
-
-					let deviceFactorSource = DeviceFactorSource(
-						id: fromHash,
-						common: .init(),
-						hint: .init(
-							name: "iPhone",
-							model: "iPhone",
-							mnemonicWordCount: .twentyFour
-						)
+					let mainBDFS = try DeviceFactorSource.babylon(
+						mnemonicWithPassphrase: mnemonicWithPassphrase,
+						isOlympiaCompatible: false // FIXME: is this what we want?
 					)
 
 					let privateHD = try PrivateHDFactorSource(
 						mnemonicWithPassphrase: mnemonicWithPassphrase,
-						factorSource: deviceFactorSource
+						factorSource: mainBDFS
 					)
 
 					state.factorSourceOfImportedMnemonic = privateHD

--- a/RadixWallet/Profile/Factor/FactorSource+Kinds/DeviceFactorSource.swift
+++ b/RadixWallet/Profile/Factor/FactorSource+Kinds/DeviceFactorSource.swift
@@ -76,6 +76,7 @@ extension DeviceFactorSource {
 
 	public static func babylon(
 		mnemonicWithPassphrase: MnemonicWithPassphrase,
+		isOlympiaCompatible: Bool = false,
 		model: Hint.Model = "",
 		name: String = "",
 		addedOn: Date? = nil,
@@ -87,7 +88,7 @@ extension DeviceFactorSource {
 			model: model,
 			name: name,
 			isMain: true,
-			isOlympiaCompatible: false,
+			isOlympiaCompatible: isOlympiaCompatible,
 			addedOn: addedOn ?? date(),
 			lastUsedOn: lastUsedOn ?? date()
 		)


### PR DESCRIPTION
Tiny but important bug fix: ensure we mark the BDFS as `main` when added through `AccountRecoveryScan`

![Screenshot 2023-12-05 at 15 42 43](https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/a7d5dbd6-3b6d-48a4-bc95-d5aa582b2303)
