### PR TITLE
Only show Olympia recovery on Mainnet

### DIFF
--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+Reducer.swift
@@ -7,6 +7,11 @@ public struct ManualAccountRecoveryCoordinator: Sendable, FeatureReducer {
 
 	public struct State: Sendable, Hashable {
 		public var path: StackState<Path.State> = .init()
+		public var isMainnet: Bool
+
+		public init() {
+			self.isMainnet = false
+		}
 	}
 
 	// MARK: - Path
@@ -47,6 +52,7 @@ public struct ManualAccountRecoveryCoordinator: Sendable, FeatureReducer {
 	}
 
 	public enum ViewAction: Sendable, Equatable {
+		case appeared
 		case closeButtonTapped
 		case useSeedPhraseTapped(isOlympia: Bool)
 		case useLedgerTapped(isOlympia: Bool)
@@ -56,11 +62,16 @@ public struct ManualAccountRecoveryCoordinator: Sendable, FeatureReducer {
 		case path(StackActionOf<Path>)
 	}
 
+	public enum InternalAction: Sendable, Equatable {
+		case isMainnet(Bool)
+	}
+
 	public enum DelegateAction: Sendable, Equatable {
 		case gotoAccountList
 	}
 
 	@Dependency(\.dismiss) var dismiss
+	@Dependency(\.gatewaysClient) var gatewaysClient
 
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
@@ -71,6 +82,12 @@ public struct ManualAccountRecoveryCoordinator: Sendable, FeatureReducer {
 
 	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
+		case .appeared:
+			return .run { send in
+				let isMainnet = await gatewaysClient.getCurrentGateway().network == .mainnet
+				await send(.internal(.isMainnet(isMainnet)))
+			}
+
 		case .closeButtonTapped:
 			return .run { _ in await dismiss() }
 
@@ -90,6 +107,14 @@ public struct ManualAccountRecoveryCoordinator: Sendable, FeatureReducer {
 			reduce(into: &state, id: id, pathAction: pathAction)
 		default:
 			.none
+		}
+	}
+
+	public func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
+		switch internalAction {
+		case let .isMainnet(isMainnet):
+			state.isMainnet = isMainnet
+			return .none
 		}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+Reducer.swift
@@ -7,11 +7,9 @@ public struct ManualAccountRecoveryCoordinator: Sendable, FeatureReducer {
 
 	public struct State: Sendable, Hashable {
 		public var path: StackState<Path.State> = .init()
-		public var isMainnet: Bool
+		public var isMainnet: Bool = false
 
-		public init() {
-			self.isMainnet = false
-		}
+		public init() {}
 	}
 
 	// MARK: - Path

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+View.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+View.swift
@@ -3,14 +3,14 @@ import SwiftUI
 
 extension ManualAccountRecoveryCoordinator.State {
 	var viewState: ManualAccountRecoveryCoordinator.ViewState {
-		.init(showOlympiaSection: isMainnet)
+		.init(olympiaControlState: isMainnet ? .enabled : .disabled)
 	}
 }
 
 // MARK: - ManualAccountRecoveryCoordinator.View
 extension ManualAccountRecoveryCoordinator {
 	public struct ViewState: Equatable {
-		let showOlympiaSection: Bool
+		let olympiaControlState: ControlState
 	}
 
 	@MainActor
@@ -36,19 +36,18 @@ extension ManualAccountRecoveryCoordinator.View {
 
 	private func root() -> some View {
 		ScrollView {
-			WithViewStore(store, observe: \.viewState) { viewStore in
-				VStack(spacing: .large3) {
-					header()
-					separator()
-					babylonSection()
-					if viewStore.showOlympiaSection {
-						separator()
-						olympiaSection()
-					}
+			VStack(spacing: .large3) {
+				header()
+				separator()
+				babylonSection()
+				separator()
+				WithViewStore(store, observe: \.viewState) { viewStore in
+					olympiaSection()
+						.controlState(viewStore.olympiaControlState)
 				}
-				.foregroundStyle(.app.gray1)
-				.padding(.bottom, .small1)
 			}
+			.foregroundStyle(.app.gray1)
+			.padding(.bottom, .small1)
 		}
 		.background(.app.white)
 		.toolbar {

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+View.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+View.swift
@@ -1,8 +1,18 @@
 import ComposableArchitecture
 import SwiftUI
 
+extension ManualAccountRecoveryCoordinator.State {
+	var viewState: ManualAccountRecoveryCoordinator.ViewState {
+		.init(showOlympiaSection: isMainnet)
+	}
+}
+
 // MARK: - ManualAccountRecoveryCoordinator.View
 extension ManualAccountRecoveryCoordinator {
+	public struct ViewState: Equatable {
+		let showOlympiaSection: Bool
+	}
+
 	@MainActor
 	public struct View: SwiftUI.View {
 		private let store: Store
@@ -26,15 +36,19 @@ extension ManualAccountRecoveryCoordinator.View {
 
 	private func root() -> some View {
 		ScrollView {
-			VStack(spacing: .large3) {
-				header()
-				separator()
-				babylonSection()
-				separator()
-				olympiaSection()
+			WithViewStore(store, observe: \.viewState) { viewStore in
+				VStack(spacing: .large3) {
+					header()
+					separator()
+					babylonSection()
+					if viewStore.showOlympiaSection {
+						separator()
+						olympiaSection()
+					}
+				}
+				.foregroundStyle(.app.gray1)
+				.padding(.bottom, .small1)
 			}
-			.foregroundStyle(.app.gray1)
-			.padding(.bottom, .small1)
 		}
 		.background(.app.white)
 		.toolbar {
@@ -43,6 +57,9 @@ extension ManualAccountRecoveryCoordinator.View {
 					store.send(.view(.closeButtonTapped))
 				}
 			}
+		}
+		.onAppear {
+			store.send(.view(.appeared))
 		}
 	}
 


### PR DESCRIPTION
## Description
Hide the Olympia section of manual account recovery in settings, when not on mainnet.
https://rdxworks.slack.com/archives/C031A0V1A1W/p1702031619345969

## Screenshot
<img width="200" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/ec9a9a0a-21bf-4af9-9022-37daf8cd4fcd">

