### PR TITLE
Show Factor Source in Seed Phrases even if it controls 0 accounts

### DIFF
--- a/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
+++ b/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
@@ -33,12 +33,12 @@ extension EntitiesControlledByFactorSource {
 		}
 
 		public let id: ID
-		public let accounts: NonEmptyAccounts
-		public let hiddenAccounts: NonEmptyAccounts?
+		public let accounts: IdentifiedArrayOf<Profile.Network.Account>
+		public let hiddenAccounts: IdentifiedArrayOf<Profile.Network.Account>
 	}
 
 	public var olympia: AccountsControlledByKeysOnSameCurve? {
-		guard let olympiaAccounts else { return nil }
+		guard deviceFactorSource.supportsOlympia else { return nil }
 		return AccountsControlledByKeysOnSameCurve(
 			id: .init(factorSourceID: deviceFactorSource.id, isOlympia: true),
 			accounts: olympiaAccounts,
@@ -47,7 +47,7 @@ extension EntitiesControlledByFactorSource {
 	}
 
 	public var babylon: AccountsControlledByKeysOnSameCurve? {
-		guard let babylonAccounts else { return nil }
+		guard deviceFactorSource.isBDFS else { return nil }
 		return AccountsControlledByKeysOnSameCurve(
 			id: .init(factorSourceID: deviceFactorSource.id, isOlympia: false),
 			accounts: babylonAccounts,
@@ -56,23 +56,23 @@ extension EntitiesControlledByFactorSource {
 	}
 
 	/// Non hidden
-	public var babylonAccounts: NonEmptyAccounts? {
-		NonEmpty(rawValue: accounts.filter(not(\.isOlympiaAccount)).asIdentifiable())
+	public var babylonAccounts: IdentifiedArrayOf<Profile.Network.Account> {
+		accounts.filter(not(\.isOlympiaAccount)).asIdentifiable()
 	}
 
 	/// hidden
-	public var babylonAccountsHidden: NonEmptyAccounts? {
-		NonEmpty(rawValue: hiddenAccounts.filter(not(\.isOlympiaAccount)).asIdentifiable())
+	public var babylonAccountsHidden: IdentifiedArrayOf<Profile.Network.Account> {
+		hiddenAccounts.filter(not(\.isOlympiaAccount)).asIdentifiable()
 	}
 
 	/// Non hidden
-	public var olympiaAccounts: NonEmptyAccounts? {
-		NonEmpty(rawValue: accounts.filter(\.isOlympiaAccount).asIdentifiable())
+	public var olympiaAccounts: IdentifiedArrayOf<Profile.Network.Account> {
+		accounts.filter(\.isOlympiaAccount).asIdentifiable()
 	}
 
 	/// hidden
-	public var olympiaAccountsHidden: NonEmptyAccounts? {
-		NonEmpty(rawValue: hiddenAccounts.filter(\.isOlympiaAccount).asIdentifiable())
+	public var olympiaAccountsHidden: IdentifiedArrayOf<Profile.Network.Account> {
+		hiddenAccounts.filter(\.isOlympiaAccount).asIdentifiable()
 	}
 
 	public var accounts: [Profile.Network.Account] { entities.compactMap { try? $0.asAccount() } }

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -66,8 +66,8 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 				id: .singleCurve(accountSet.id.factorSourceID, isOlympia: accountSet.id.isOlympia),
 				isMnemonicMarkedAsBackedUp: isMnemonicMarkedAsBackedUp,
 				isMnemonicPresentInKeychain: isMnemonicPresentInKeychain,
-				accounts: accountSet.accounts.rawValue,
-				hasHiddenAccounts: accountSet.hiddenAccounts != nil,
+				accounts: accountSet.accounts,
+				hasHiddenAccounts: !accountSet.hiddenAccounts.isEmpty,
 				mode: mode
 			)
 		}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
@@ -24,13 +24,13 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 			self.isMainBDFS = isMainBDFS
 			self.entitiesControlledByFactorSource = ents
 
-			let accounts: IdentifiedArrayOf<Profile.Network.Account> = switch (ents.babylonAccounts, ents.olympiaAccounts) {
-			case let (.some(babylonAccounts), _):
+			let accounts: IdentifiedArrayOf<Profile.Network.Account> = switch (ents.babylonAccounts.isEmpty, ents.olympiaAccounts.isEmpty) {
+			case (false, _):
 				// We prefer Babylon, always.
-				babylonAccounts.rawValue
-			case let (.none, .some(olympiaAccounts)):
-				olympiaAccounts.rawValue
-			case (.none, nil):
+				ents.babylonAccounts
+			case (true, false):
+				ents.olympiaAccounts
+			case (true, true):
 				// no accounts... still possible! i.e. Profile -> Create HARDWARE Account ->
 				// delete passcode -> import missing Mnemonic, which... does not control any
 				// accounts


### PR DESCRIPTION
(Android already does this) List a Factor Source in `App Settings -> Account Sec & Settings -> Seed Phrases` even if it does not control any account, i.e. for DFS call it `X` we with `CP_BAO` we show it as an ODFS and a BDFS, even it `X` controls 0 Babylon accounts and/or 0 Olympia accounts.

# Demo 1 - See Slack
(Video too large for GH)
[Slack](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1702378108609239)

# Demo 2 - Import Mnemonics Flow
However, when prompted to Import Mnemonics we show ONLY Babylon accounts if any, if no Babylon accounts and if Olympia accounts, we show them.

Where we left off from Demo 1, the state of the Profile, is that contains 3 factor sources, all with both set of crypto parameters (support both Olympia and Babylon) see screenshot, and then watch demo video.

![simulator_screenshot_C39BD87B-5F43-449A-92DA-EE8C376AEE38](https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/9552750d-aa6a-4db6-b163-4ccc21ea97bc)

We should only be asked for three mnemonics, and for the first DFS, the main one, we only see the 4 babylon accounts, not the 2 olympia accounts. But for the two remaining mnemonics we see two olympia accounts each of them controls.

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/b8b7bef3-3e74-411e-a7ad-b28e31422b5e

