### PR TITLE
[ABW-2651] Enable MARS for non-Mainnet (current network)

### DIFF
--- a/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
+++ b/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
@@ -61,9 +61,9 @@ extension FactorSourcesClient: DependencyKey {
 						throw FactorSourceAlreadyPresent()
 					case .appendWithCryptoParamaters:
 						var updated = existingInProfile
-						loggerGlobal.critical("🔮 Appending crypto parameters to DeviceFactorSource, BEFORE: \(updated.common.cryptoParameters)....")
-						updated.common.cryptoParameters.append(request.privateHDFactorSource.factorSource.common.cryptoParameters)
-						loggerGlobal.critical("🔮 Appended crypto parameters to DeviceFactorSource, AFTER: \(updated.common.cryptoParameters) ✅")
+						let cryptoParamsToAdd = request.privateHDFactorSource.factorSource.common.cryptoParameters
+						updated.common.cryptoParameters.append(cryptoParamsToAdd)
+						loggerGlobal.notice("Appended crypto parameters \(cryptoParamsToAdd) to DeviceFactorSource.")
 						try await updateFactorSource(updated.embed())
 					}
 				} else {

--- a/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
+++ b/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
@@ -124,7 +124,7 @@ public struct AccountRecoveryScanCoordinator: Sendable, FeatureReducer {
 				return .none
 			}
 
-		case .accountRecoveryScanInProgress(.delegate(.failedToDerivePublicKey)):
+		case .accountRecoveryScanInProgress(.delegate(.failed)):
 			return .send(.delegate(.dismissed))
 
 		case .selectInactiveAccountsToAdd(.delegate(.goBack)):


### PR DESCRIPTION
[Jira Ticket](https://radixdlt.atlassian.net/browse/ABW-2651)

We accidentally did not read the current network... now MARS works on non mainnet (current network). 

Another important fix: if GW responds with error, we dismiss the flow (as intended)

https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/a1668248-324b-4748-b893-d34f6a8eaee3