### PR TITLE
Show name of the network instead of its id

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -429,8 +429,12 @@ extension DappInteractionClient.ValidatedDappRequest.InvalidRequestReason {
 		case .dAppValidationError:
 			L10n.DAppRequest.ValidationOutcome.invalidRequestMessage
 		case let .wrongNetworkID(ce, wallet):
-			L10n.DAppRequest.RequestWrongNetworkAlert.message(ce, wallet)
+			L10n.DAppRequest.RequestWrongNetworkAlert.message(networkName(for: ce), networkName(for: wallet))
 		}
+	}
+
+	private func networkName(for networkID: NetworkID) -> String {
+		(try? Radix.Network.lookupBy(id: networkID).name.rawValue) ?? String(describing: networkID)
 	}
 }
 

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -434,7 +434,7 @@ extension DappInteractionClient.ValidatedDappRequest.InvalidRequestReason {
 	}
 
 	private func networkName(for networkID: NetworkID) -> String {
-		(try? Radix.Network.lookupBy(id: networkID).name.rawValue) ?? String(describing: networkID)
+		(try? Radix.Network.lookupBy(id: networkID).displayDescription) ?? String(describing: networkID)
 	}
 }
 


### PR DESCRIPTION
Simply show the network name, if available, instead of its id.