### PR TITLE
[ABS-2662] Enter Seed Phrase Problems

### DIFF
--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
@@ -7,6 +7,7 @@ extension ImportMnemonic.State {
 		var viewState = ImportMnemonic.ViewState(
 			readonlyMode: mode.readonly?.context,
 			hideAdvancedMode: mode.write?.hideAdvancedMode ?? false,
+			showCloseButton: showCloseButton,
 			isProgressing: mode.write?.isProgressing ?? false,
 			isWordCountFixed: isWordCountFixed,
 			isAdvancedMode: isAdvancedMode,
@@ -24,6 +25,15 @@ extension ImportMnemonic.State {
 		return viewState
 	}
 
+	private var showCloseButton: Bool {
+		switch mode {
+		case let .readonly(readOnlyMode):
+			readOnlyMode.context == .fromBackupPrompt
+		case let .write(writeMode):
+			writeMode.showCloseButton
+		}
+	}
+
 	var rowCount: Int {
 		words.count / ImportMnemonic.wordsPerRow
 	}
@@ -38,6 +48,7 @@ extension ImportMnemonic {
 
 		let readonlyMode: ImportMnemonic.State.ReadonlyMode.Context?
 		let hideAdvancedMode: Bool
+		let showCloseButton: Bool
 		let isProgressing: Bool // irrelevant for read only mode
 		let isWordCountFixed: Bool
 		let isAdvancedMode: Bool
@@ -55,11 +66,6 @@ extension ImportMnemonic {
 
 		var showBackButton: Bool {
 			guard let readonlyMode, case .fromSettings = readonlyMode else { return false }
-			return true
-		}
-
-		var showCloseButton: Bool {
-			guard let readonlyMode, case .fromBackupPrompt = readonlyMode else { return false }
 			return true
 		}
 

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
@@ -339,58 +339,48 @@ extension ImportMnemonic.View {
 			Button("DEBUG ONLY Copy") {
 				viewStore.send(.debugCopyMnemonic)
 			}
-			.buttonStyle(
-				.secondaryRectangular(
-					shouldExpand: true,
-					isDestructive: true,
-					isInToolbar: true
-				)
-			)
+			.buttonStyle(.secondaryRectangular(shouldExpand: true, isDestructive: true, isInToolbar: true))
 			.padding(.horizontal, .medium2)
 			.padding(.bottom, .medium3)
 		} else {
 			if !(viewStore.isWordCountFixed && viewStore.wordCount == .twentyFour) {
 				Button("DEBUG AccRecScan Olympia 15") {
-					viewStore.send(.debugUseOlympiaTestingMnemonicWithActiveAccounts)
+					viewStore.send(.debugUseOlympiaTestingMnemonicWithActiveAccounts(continue: true))
 				}
-				.buttonStyle(
-					.secondaryRectangular(
-						shouldExpand: true,
-						isDestructive: true,
-						isInToolbar: true
-					)
-				)
+				.buttonStyle(.secondaryRectangular(shouldExpand: true, isDestructive: true, isInToolbar: true))
+				.overlay(alignment: .trailing) {
+					Button("M") {
+						viewStore.send(.debugUseOlympiaTestingMnemonicWithActiveAccounts(continue: false))
+					}
+					.frame(width: 40)
+				}
 				.padding(.horizontal, .medium2)
 				.padding(.bottom, .medium3)
 			}
 
 			Button("DEBUG AccRecScan Babylon 24") {
-				viewStore.send(.debugUseBabylonTestingMnemonicWithActiveAccounts)
+				viewStore.send(.debugUseBabylonTestingMnemonicWithActiveAccounts(continue: true))
 			}
-			.buttonStyle(
-				.secondaryRectangular(
-					shouldExpand: true,
-					isDestructive: true,
-					isInToolbar: true
-				)
-			)
+			.buttonStyle(.secondaryRectangular(shouldExpand: true, isDestructive: true, isInToolbar: true))
+			.overlay(alignment: .trailing) {
+				Button("M") {
+					viewStore.send(.debugUseBabylonTestingMnemonicWithActiveAccounts(continue: false))
+				}
+				.frame(width: 40)
+			}
 			.padding(.horizontal, .medium2)
 			.padding(.bottom, .medium3)
 
-			Button(
-				"DEBUG zoo..vote (24)"
-			) {
-				viewStore.send(
-					.debugUseTestingMnemonicZooVote
-				)
+			Button("DEBUG zoo..vote (24)") {
+				viewStore.send(.debugUseTestingMnemonicZooVote(continue: true))
 			}
-			.buttonStyle(
-				.secondaryRectangular(
-					shouldExpand: true,
-					isDestructive: true,
-					isInToolbar: true
-				)
-			)
+			.buttonStyle(.secondaryRectangular(shouldExpand: true, isDestructive: true, isInToolbar: true))
+			.overlay(alignment: .trailing) {
+				Button("M") {
+					viewStore.send(.debugUseTestingMnemonicZooVote(continue: false))
+				}
+				.frame(width: 40)
+			}
 			.padding(.horizontal, .medium2)
 			.padding(.bottom, .medium3)
 

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
@@ -270,10 +270,10 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 
 		#if DEBUG
 		case debugCopyMnemonic
-		case debugMnemonicChanged(String)
-		case debugUseBabylonTestingMnemonicWithActiveAccounts
-		case debugUseOlympiaTestingMnemonicWithActiveAccounts
-		case debugUseTestingMnemonicZooVote
+		case debugMnemonicChanged(String, continue: Bool = false)
+		case debugUseBabylonTestingMnemonicWithActiveAccounts(continue: Bool)
+		case debugUseOlympiaTestingMnemonicWithActiveAccounts(continue: Bool)
+		case debugUseTestingMnemonicZooVote(continue: Bool)
 		case debugPasteMnemonic
 		#endif
 	}
@@ -465,28 +465,30 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 			}
 			return .none
 
-		case let .debugMnemonicChanged(mnemonic):
+		case let .debugMnemonicChanged(mnemonic, continueAutomatically):
 			state.debugMnemonicPhraseSingleField = mnemonic
 			if let mnemonic = try? Mnemonic(phrase: mnemonic, language: state.language) {
 				state.words = State.words(from: mnemonic, isReadonlyMode: state.mode.readonly != nil)
-				state.mode.update(isProgressing: true)
-				return .send(.view(.continueButtonTapped(mnemonic)))
-			} else {
-				return .none
+				if continueAutomatically {
+					state.mode.update(isProgressing: true)
+					return .send(.view(.continueButtonTapped(mnemonic)))
+				}
 			}
+
+			return .none
 
 		case .debugPasteMnemonic:
 			let toPaste = pasteboardClient.getString() ?? ""
 			return .send(.view(.debugMnemonicChanged(toPaste)))
 
-		case .debugUseOlympiaTestingMnemonicWithActiveAccounts:
-			return .send(.view(.debugMnemonicChanged("section canoe half crystal crew balcony duty scout half robot avocado gas all effort piece")))
+		case let .debugUseOlympiaTestingMnemonicWithActiveAccounts(continueAutomatically):
+			return .send(.view(.debugMnemonicChanged("section canoe half crystal crew balcony duty scout half robot avocado gas all effort piece", continue: continueAutomatically)))
 
-		case .debugUseBabylonTestingMnemonicWithActiveAccounts:
-			return .send(.view(.debugMnemonicChanged("wine over village stage barrel strategy cushion decline echo fiber salad carry empower fun awful cereal galaxy laundry practice appear bean flat mansion license")))
+		case let .debugUseBabylonTestingMnemonicWithActiveAccounts(continueAutomatically):
+			return .send(.view(.debugMnemonicChanged("wine over village stage barrel strategy cushion decline echo fiber salad carry empower fun awful cereal galaxy laundry practice appear bean flat mansion license", continue: continueAutomatically)))
 
-		case .debugUseTestingMnemonicZooVote:
-			return .send(.view(.debugMnemonicChanged(Mnemonic.testValueZooVote.phrase.rawValue)))
+		case let .debugUseTestingMnemonicZooVote(continueAutomatically):
+			return .send(.view(.debugMnemonicChanged(Mnemonic.testValueZooVote.phrase.rawValue, continue: continueAutomatically)))
 		#endif
 		}
 	}

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
@@ -311,10 +311,8 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 
 		public enum Action: Sendable, Equatable {
 			case offDeviceMnemonicInfoPrompt(OffDeviceMnemonicInfo.Action)
-
 			case backupConfirmation(BackupConfirmation)
 			case verifyMnemonic(VerifyMnemonic.Action)
-
 			case onContinueWarning(OnContinueWarning)
 
 			public enum BackupConfirmation: Sendable, Hashable {
@@ -503,6 +501,7 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 			passphrase: state.bip39Passphrase
 		)
 		guard let persistStrategy = write.persistStrategy else {
+			state.mode.update(isProgressing: false)
 			return .send(.delegate(.notPersisted(mnemonicWithPassphrase)))
 		}
 		switch persistStrategy.location {
@@ -561,10 +560,10 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 			return .none
 
 		case let .saveFactorSourceResult(.success(saved)):
-
 			state.mode.update(isProgressing: false)
 			overlayWindowClient.scheduleHUD(.seedPhraseImported)
 			let factorSource = saved.factorSource
+
 			if saved.savedIntoProfile {
 				return .send(.delegate(.persistedNewFactorSourceInProfile(factorSource)))
 			} else {

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
@@ -119,6 +119,7 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 		case .inputMnemonicButtonTapped:
 			state.destination = .importMnemonic(.init(
 				warning: L10n.RevealSeedPhrase.warning,
+				showCloseButton: true,
 				isWordCountFixed: true,
 				persistStrategy: nil,
 				wordCount: state.entitiesControlledByFactorSource.mnemonicWordCount

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoverySeedPhrase+View.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoverySeedPhrase+View.swift
@@ -54,11 +54,10 @@ extension ManualAccountRecoverySeedPhrase.View {
 						store.send(.view(.addButtonTapped))
 					}
 					.buttonStyle(.secondaryRectangular)
-
-					Spacer(minLength: 0)
 				}
 			}
 			.foregroundStyle(.app.gray1)
+			.padding(.bottom, .medium3)
 		}
 		.footer {
 			WithViewStore(store, observe: \.selected) { viewStore in


### PR DESCRIPTION
Jira ticket: [ABS-2662](https://radixdlt.atlassian.net/browse/ABW-2662)

## Description
This fixes some issues with seed phrase entry. It also upgrades the debug buttons with a new power. If you press the small "M", it will only paste in the mnemonic, not press continue. That makes it possible to test "almost correct" mnemonics etc.

The second issue mentioned in the ticket is partly due to using the automatic debug entry, which is not a realistic scenario, it will not typically be possible to press Continue with an invalid mnemonic.

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/7f896e5c-1d50-40ea-9162-d6f7cd391cea


## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
