### PR TITLE
[ABW-2683] Make Backup Seedphrase Button Work in Auth dApps

### DIFF
--- a/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
@@ -72,7 +72,7 @@ private extension StoreOf<DappDetails> {
 	}
 
 	var personas: StoreOf<PersonaList> {
-		scope(state: \.personaList) { .child(.personas($0)) }
+		scope(state: \.personaList) { .child(.personaList($0)) }
 	}
 }
 
@@ -83,6 +83,7 @@ private extension View {
 		return personaDetails(with: destinationStore)
 			.fungibleDetails(with: destinationStore)
 			.nonFungibleDetails(with: destinationStore)
+			.exportMnemonic(with: destinationStore)
 			.confirmDisconnectAlert(with: destinationStore)
 	}
 
@@ -110,6 +111,15 @@ private extension View {
 			state: /DappDetails.Destination.State.nonFungibleDetails,
 			action: DappDetails.Destination.Action.nonFungibleDetails,
 			content: { NonFungibleTokenDetails.View(store: $0) }
+		)
+	}
+
+	private func exportMnemonic(with destinationStore: PresentationStoreOf<DappDetails.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /DappDetails.Destination.State.exportMnemonic,
+			action: DappDetails.Destination.Action.exportMnemonic,
+			content: { ExportMnemonic.View(store: $0).inNavigationStack }
 		)
 	}
 

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+View.swift
@@ -59,17 +59,12 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	private func exportMnemonic(with destinationStore: PresentationStoreOf<PersonasCoordinator.Destination>) -> some SwiftUI.View {
+	private func exportMnemonic(with destinationStore: PresentationStoreOf<PersonasCoordinator.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
 			state: /PersonasCoordinator.Destination.State.exportMnemonic,
 			action: PersonasCoordinator.Destination.Action.exportMnemonic,
-			content: { childStore in
-				NavigationStack {
-					ExportMnemonic.View(store: childStore)
-				}
-			}
+			content: { ExportMnemonic.View(store: $0).inNavigationStack }
 		)
 	}
 }


### PR DESCRIPTION
Jira ticket: [ABW-2683](https://radixdlt.atlassian.net/browse/ABW-2683)

## Description
The seed phrase backup prompt on personas did not work in Authorised dApps.

### Notes
The string is fixed in a separate PR

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/af2b3066-0ddc-49a9-8ddb-d9ac847369c0


## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2683]: https://radixdlt.atlassian.net/browse/ABW-2683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ