### PR TITLE
[ABW-2656] Deriving Accounts Issues

### DIFF
--- a/RadixWallet/Features/AccountRecoveryScan/Children/AccountRecoveryScanInProgress/AccountRecoveryScanInProgress.swift
+++ b/RadixWallet/Features/AccountRecoveryScan/Children/AccountRecoveryScanInProgress/AccountRecoveryScanInProgress.swift
@@ -101,6 +101,7 @@ public struct AccountRecoveryScanInProgress: Sendable, FeatureReducer {
 
 	private let destinationPath: WritableKeyPath<State, PresentationState<Destination.State>> = \.$destination
 
+	@Dependency(\.dismiss) var dismiss
 	@Dependency(\.accountsClient) var accountsClient
 	@Dependency(\.factorSourcesClient) var factorSourcesClient
 	@Dependency(\.onLedgerEntitiesClient) var onLedgerEntitiesClient
@@ -233,6 +234,10 @@ public struct AccountRecoveryScanInProgress: Sendable, FeatureReducer {
 
 		default: return .none
 		}
+	}
+
+	public func reduceDismissedDestination(into state: inout State) -> Effect<Action> {
+		.run { _ in await dismiss() }
 	}
 }
 


### PR DESCRIPTION
Jira ticket: [ABW-2656](https://radixdlt.atlassian.net/browse/ABW-2656)

## Description
When dismissing the Deriving Accounts scan panel during MARS the user will be stuck on an empty screen.

## Video

Dismiss in MARS:

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/46d93bf8-91b9-48ab-b33b-0a3bee2f89e2


Dismiss in OARS:

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/9a8b1cce-d892-4c93-be64-630bb662c2e4


This also seems to fix [ABW-2658](https://radixdlt.atlassian.net/browse/ABW-2658), I have not been able to reproduce it.

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/f79d91cb-d949-4300-8729-9731ae17029e


## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2656]: https://radixdlt.atlassian.net/browse/ABW-2656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-2658]: https://radixdlt.atlassian.net/browse/ABW-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ