### PR TITLE
[ABW-2683] Remove Shield in Auth dApps Context

### DIFF
--- a/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
@@ -72,7 +72,7 @@ private extension StoreOf<DappDetails> {
 	}
 
 	var personas: StoreOf<PersonaList> {
-		scope(state: \.personaList) { .child(.personas($0)) }
+		scope(state: \.personaList) { .child(.personaList($0)) }
 	}
 }
 
@@ -83,6 +83,7 @@ private extension View {
 		return personaDetails(with: destinationStore)
 			.fungibleDetails(with: destinationStore)
 			.nonFungibleDetails(with: destinationStore)
+			.exportMnemonic(with: destinationStore)
 			.confirmDisconnectAlert(with: destinationStore)
 	}
 
@@ -110,6 +111,15 @@ private extension View {
 			state: /DappDetails.Destination.State.nonFungibleDetails,
 			action: DappDetails.Destination.Action.nonFungibleDetails,
 			content: { NonFungibleTokenDetails.View(store: $0) }
+		)
+	}
+
+	private func exportMnemonic(with destinationStore: PresentationStoreOf<DappDetails.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /DappDetails.Destination.State.exportMnemonic,
+			action: DappDetails.Destination.Action.exportMnemonic,
+			content: { ExportMnemonic.View(store: $0).inNavigationStack }
 		)
 	}
 

--- a/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
@@ -286,7 +286,7 @@ extension DappDetails.View {
 					Separator()
 						.padding(.bottom, .small2)
 
-					PersonaListCoreView(store: store, tappable: tappablePersonas)
+					PersonaListCoreView(store: store, tappable: tappablePersonas, showShield: false)
 				} else {
 					Text(L10n.AuthorizedDapps.DAppDetails.noPersonasHeading)
 						.sectionHeading

--- a/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
@@ -83,7 +83,6 @@ private extension View {
 		return personaDetails(with: destinationStore)
 			.fungibleDetails(with: destinationStore)
 			.nonFungibleDetails(with: destinationStore)
-			.exportMnemonic(with: destinationStore)
 			.confirmDisconnectAlert(with: destinationStore)
 	}
 
@@ -111,15 +110,6 @@ private extension View {
 			state: /DappDetails.Destination.State.nonFungibleDetails,
 			action: DappDetails.Destination.Action.nonFungibleDetails,
 			content: { NonFungibleTokenDetails.View(store: $0) }
-		)
-	}
-
-	private func exportMnemonic(with destinationStore: PresentationStoreOf<DappDetails.Destination>) -> some View {
-		sheet(
-			store: destinationStore,
-			state: /DappDetails.Destination.State.exportMnemonic,
-			action: DappDetails.Destination.Action.exportMnemonic,
-			content: { ExportMnemonic.View(store: $0).inNavigationStack }
 		)
 	}
 

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Child/List/PersonaList+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Child/List/PersonaList+View.swift
@@ -24,7 +24,7 @@ extension PersonaList {
 						Separator()
 							.padding(.bottom, .small2)
 
-						PersonaListCoreView(store: store, tappable: true)
+						PersonaListCoreView(store: store, tappable: true, showShield: true)
 					}
 
 					Button(L10n.Personas.createNewPersona) {
@@ -44,10 +44,12 @@ extension PersonaList {
 public struct PersonaListCoreView: View {
 	private let store: StoreOf<PersonaList>
 	private let tappable: Bool
+	private let showShield: Bool
 
-	public init(store: StoreOf<PersonaList>, tappable: Bool) {
+	public init(store: StoreOf<PersonaList>, tappable: Bool, showShield: Bool) {
 		self.store = store
 		self.tappable = tappable
+		self.showShield = showShield
 	}
 
 	public var body: some View {
@@ -58,7 +60,7 @@ public struct PersonaListCoreView: View {
 					action: { .child(.persona(id: $0, action: $1)) }
 				)
 			) {
-				Persona.View(store: $0, tappable: tappable)
+				Persona.View(store: $0, tappable: tappable, showShield: showShield)
 					.padding(.horizontal, .medium3)
 			}
 		}

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Child/Row/Persona+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Child/Row/Persona+View.swift
@@ -7,10 +7,12 @@ extension Persona {
 	public struct View: SwiftUI.View {
 		private let store: StoreOf<Persona>
 		private let tappable: Bool
+		private let showShield: Bool
 
-		public init(store: StoreOf<Persona>, tappable: Bool) {
+		public init(store: StoreOf<Persona>, tappable: Bool, showShield: Bool) {
 			self.store = store
 			self.tappable = tappable
+			self.showShield = showShield
 		}
 
 		public var body: some SwiftUI.View {
@@ -23,7 +25,7 @@ extension Persona {
 							PlainListRow(title: viewStore.displayName) {
 								PersonaThumbnail(viewStore.thumbnail)
 							}
-							if viewStore.shouldWriteDownMnemonic {
+							if showShield, viewStore.shouldWriteDownMnemonic {
 								shieldPromptView(
 									// FIXME: Strings
 									text: "Write down this Persona's seed phrase",
@@ -64,7 +66,8 @@ struct Persona_Preview: PreviewProvider {
 				initialState: .previewValue,
 				reducer: Persona.init
 			),
-			tappable: true
+			tappable: true,
+			showShield: true
 		)
 	}
 }

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+View.swift
@@ -59,17 +59,12 @@ private extension View {
 		)
 	}
 
-	@MainActor
-	private func exportMnemonic(with destinationStore: PresentationStoreOf<PersonasCoordinator.Destination>) -> some SwiftUI.View {
+	private func exportMnemonic(with destinationStore: PresentationStoreOf<PersonasCoordinator.Destination>) -> some View {
 		sheet(
 			store: destinationStore,
 			state: /PersonasCoordinator.Destination.State.exportMnemonic,
 			action: PersonasCoordinator.Destination.Action.exportMnemonic,
-			content: { childStore in
-				NavigationStack {
-					ExportMnemonic.View(store: childStore)
-				}
-			}
+			content: { ExportMnemonic.View(store: $0).inNavigationStack }
 		)
 	}
 }


### PR DESCRIPTION
Jira ticket: [ABW-2683](https://radixdlt.atlassian.net/browse/ABW-2683)

## Description
The seed phrase backup prompt on personas should not be shown in Authorised dApps.

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/3a4d1ed6-d7b5-415d-9fd5-01c90df160aa


## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
