### PR TITLE
Show the information about the dApp proposing the transaction

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -3211,8 +3211,9 @@
 		48CFBCD02ADC10D800E77A5C /* TransactionReviewFeature */ = {
 			isa = PBXGroup;
 			children = (
-				48CFBCD12ADC10D800E77A5C /* SelectFeePayer */,
 				48CFBCD42ADC10D800E77A5C /* TransactionReview.swift */,
+				48CFBCF52ADC10D800E77A5C /* TransactionReview+View.swift */,
+				48CFBCD12ADC10D800E77A5C /* SelectFeePayer */,
 				48CFBCD52ADC10D800E77A5C /* SubmitTransaction */,
 				48CFBCD82ADC10D800E77A5C /* TransactionReviewGuarantees */,
 				48CFBCDE2ADC10D800E77A5C /* TransactionReviewProofs */,
@@ -3221,7 +3222,6 @@
 				48CFBCE72ADC10D800E77A5C /* TransactionReviewNetworkFee */,
 				48CFBCEA2ADC10D800E77A5C /* CustomizeFees */,
 				48CFBCF22ADC10D800E77A5C /* TransactionReviewDappsUsed */,
-				48CFBCF52ADC10D800E77A5C /* TransactionReview+View.swift */,
 				48CFBCF62ADC10D800E77A5C /* AccountDepositSettings */,
 			);
 			path = TransactionReviewFeature;

--- a/RadixWallet/Core/Resources/Generated/L10n.generated.swift
+++ b/RadixWallet/Core/Resources/Generated/L10n.generated.swift
@@ -2361,6 +2361,10 @@ public enum L10n {
     public static let messageHeading = L10n.tr("Localizable", "transactionReview_messageHeading", fallback: "Message")
     /// Presenting
     public static let presentingHeading = L10n.tr("Localizable", "transactionReview_presentingHeading", fallback: "Presenting")
+    /// Proposed by %s
+    public static func proposingDappSubtitle(_ p1: UnsafePointer<CChar>) -> String {
+      return L10n.tr("Localizable", "transactionReview_proposingDappSubtitle", p1, fallback: "Proposed by %s")
+    }
     /// Raw Transaction
     public static let rawTransactionTitle = L10n.tr("Localizable", "transactionReview_rawTransactionTitle", fallback: "Raw Transaction")
     /// Sending to

--- a/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
+++ b/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
@@ -964,3 +964,5 @@ You will be asked to enter your main seed phrase. This is a set of **24 words** 
 
 If you have any “Legacy” Accounts (created on the Olympia network) to import - or any Accounts using a Ledger hardware wallet device - please continue and then use the **Account Recovery Scan** option in your Radix Wallet settings under **Account Security**.";
 "recoverWalletWithoutProfile_complete_continueButton" = "Continue";
+
+"transactionReview_proposingDappSubtitle" = "Proposed by %s";

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
@@ -240,7 +240,8 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 				nonce: .secureRandom(),
 				signTransactionPurpose: .internalManifest(.debugModifyAccount),
 				message: .none,
-				isWalletTransaction: true
+				isWalletTransaction: true,
+				proposingDappMetadata: nil
 			))
 			return .none
 

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -1031,7 +1031,7 @@ extension DappInteractionFlow.Path.State {
 				} ?? .none,
 				waitsForTransactionToBeComitted: interaction.id.isWalletAccountDepositSettingsInteraction,
 				isWalletTransaction: interaction.id.isWalletInteraction,
-				proposingDappMetadata: dappMetadata.ledger
+				proposingDappMetadata: dappMetadata.onLedger
 			)))
 		}
 	}

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -1030,7 +1030,8 @@ extension DappInteractionFlow.Path.State {
 					Message.plainText(value: .init(mimeType: "text", message: .str(value: $0)))
 				} ?? .none,
 				waitsForTransactionToBeComitted: interaction.id.isWalletAccountDepositSettingsInteraction,
-				isWalletTransaction: interaction.id.isWalletInteraction
+				isWalletTransaction: interaction.id.isWalletInteraction,
+				proposingDappMetadata: dappMetadata.ledger
 			)))
 		}
 	}

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionModels.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionModels.swift
@@ -79,7 +79,7 @@ extension DappMetadata {
 		return fromLedgerDappMetadata.thumbnail
 	}
 
-	public var ledger: Ledger? {
+	public var onLedger: Ledger? {
 		guard case let .ledger(fromLedgerDappMetadata) = self else {
 			return nil
 		}

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionModels.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionModels.swift
@@ -13,7 +13,7 @@ extension DappInteraction {
 /// Metadata for a dapp, either from a request or fetched from ledger.
 /// not to be confused with `P2P.Dapp.Request.Metadata` which is the
 /// associated value of one of the cases of this enum.
-enum DappMetadata: Sendable, Hashable {
+public enum DappMetadata: Sendable, Hashable {
 	/// The metadata sent with the request from the Dapp.
 	/// We only allow this case `request` to be passed around if `isDeveloperModeEnabled` is `true`.
 	case request(P2P.Dapp.Request.Metadata)
@@ -26,7 +26,7 @@ enum DappMetadata: Sendable, Hashable {
 
 extension DappMetadata {
 	static let wallet: Wallet = .init()
-	struct Wallet: Sendable, Hashable {
+	public struct Wallet: Sendable, Hashable {
 		let origin: DappOrigin = .wallet
 		let name: NonEmptyString = "Radix Wallet"
 		let description: String? = nil
@@ -37,7 +37,7 @@ extension DappMetadata {
 // MARK: DappMetadata.Ledger
 extension DappMetadata {
 	/// A detailed DappMetaData fetched from Ledger.
-	struct Ledger: Sendable, Hashable, Codable {
+	public struct Ledger: Sendable, Hashable, Codable {
 		static let defaultName = NonEmptyString(rawValue: L10n.DAppRequest.Metadata.unknownName)!
 
 		let origin: P2P.Dapp.Request.Metadata.Origin
@@ -77,6 +77,13 @@ extension DappMetadata {
 			return nil
 		}
 		return fromLedgerDappMetadata.thumbnail
+	}
+
+	public var ledger: Ledger? {
+		guard case let .ledger(fromLedgerDappMetadata) = self else {
+			return nil
+		}
+		return fromLedgerDappMetadata
 	}
 }
 

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -166,8 +166,8 @@ extension TransactionReview {
 
 		@ViewBuilder
 		private func header(_ proposingDappMetadata: DappMetadata.Ledger?) -> some SwiftUI.View {
-			VStack(alignment: .leading) {
-				HStack {
+			VStack(alignment: .leading, spacing: .small3) {
+				HStack(spacing: .small2) {
 					Text(L10n.TransactionReview.title)
 						.textStyle(.sheetTitle)
 						.lineLimit(2)

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -33,7 +33,8 @@ extension TransactionReview.State {
 			canApproveTX: canApproveTX && reviewedTransaction?.feePayingValidation.wrappedValue == .valid,
 			sliderResetDate: sliderResetDate,
 			canToggleViewMode: reviewedTransaction != nil && reviewedTransaction?.transaction != .nonConforming,
-			viewRawTransactionButtonState: reviewedTransaction?.feePayer.isSuccess == true ? .enabled : .disabled
+			viewRawTransactionButtonState: reviewedTransaction?.feePayer.isSuccess == true ? .enabled : .disabled,
+			proposingDappMetadata: proposingDappMetadata
 		)
 	}
 
@@ -60,6 +61,7 @@ extension TransactionReview {
 		let sliderResetDate: Date
 		let canToggleViewMode: Bool
 		let viewRawTransactionButtonState: ControlState
+		let proposingDappMetadata: DappMetadata.Ledger?
 
 		var approvalSliderControlState: ControlState {
 			// TODO: Is this the logic we want?
@@ -104,12 +106,7 @@ extension TransactionReview {
 		private func coreView(with viewStore: ViewStoreOf<TransactionReview>) -> some SwiftUI.View {
 			ScrollView(showsIndicators: false) {
 				VStack(spacing: 0) {
-					Text(L10n.TransactionReview.title)
-						.textStyle(.sheetTitle)
-						.lineLimit(2)
-						.multilineTextAlignment(.leading)
-						.foregroundColor(.app.gray1)
-						.flushedLeft
+					header(viewStore.proposingDappMetadata)
 						.padding(.horizontal, .medium3)
 						.padding(.bottom, .medium3)
 						.background {
@@ -166,6 +163,30 @@ extension TransactionReview {
 		}
 
 		private let shadowColor: Color = .app.gray2.opacity(0.4)
+
+		@ViewBuilder
+		private func header(_ proposingDappMetadata: DappMetadata.Ledger?) -> some SwiftUI.View {
+			VStack(alignment: .leading) {
+				HStack {
+					Text(L10n.TransactionReview.title)
+						.textStyle(.sheetTitle)
+						.lineLimit(2)
+						.multilineTextAlignment(.leading)
+						.foregroundColor(.app.gray1)
+
+					Spacer(minLength: 0)
+					if let thumbnail = proposingDappMetadata?.thumbnail {
+						DappThumbnail(.known(thumbnail), size: .medium)
+					}
+				}
+
+				if let name = proposingDappMetadata?.name {
+					Text("Proposed by \(name.rawValue)")
+						.textStyle(.body2HighImportance)
+						.foregroundColor(.app.gray1)
+				}
+			}
+		}
 
 		@ViewBuilder
 		private func messageSection(with message: String?) -> some SwiftUI.View {
@@ -515,7 +536,8 @@ extension TransactionReview.State {
 		nonce: .zero,
 		signTransactionPurpose: .manifestFromDapp,
 		message: .none,
-		isWalletTransaction: false
+		isWalletTransaction: false,
+		proposingDappMetadata: nil
 	)
 }
 #endif

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -181,7 +181,7 @@ extension TransactionReview {
 				}
 
 				if let name = proposingDappMetadata?.name {
-					Text("Proposed by \(name.rawValue)")
+					Text("Proposed by \(name.rawValue)") // FIXME: Strings
 						.textStyle(.body2HighImportance)
 						.foregroundColor(.app.gray1)
 				}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -167,7 +167,7 @@ extension TransactionReview {
 		@ViewBuilder
 		private func header(_ proposingDappMetadata: DappMetadata.Ledger?) -> some SwiftUI.View {
 			VStack(alignment: .leading, spacing: .small3) {
-				HStack(spacing: .small2) {
+				HStack(spacing: .zero) {
 					Text(L10n.TransactionReview.title)
 						.textStyle(.sheetTitle)
 						.lineLimit(2)
@@ -175,13 +175,15 @@ extension TransactionReview {
 						.foregroundColor(.app.gray1)
 
 					Spacer(minLength: 0)
+
 					if let thumbnail = proposingDappMetadata?.thumbnail {
 						DappThumbnail(.known(thumbnail), size: .medium)
+							.padding(.leading, .small2)
 					}
 				}
 
 				if let name = proposingDappMetadata?.name {
-					Text("Proposed by \(name.rawValue)") // FIXME: Strings
+					Text(L10n.TransactionReview.proposingDappSubtitle(name.rawValue))
 						.textStyle(.body2HighImportance)
 						.foregroundColor(.app.gray1)
 				}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -12,6 +12,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		public let signTransactionPurpose: SigningPurpose.SignTransactionPurpose
 		public let waitsForTransactionToBeComitted: Bool
 		public let isWalletTransaction: Bool
+		public let proposingDappMetadata: DappMetadata.Ledger?
 
 		public var networkID: NetworkID? { reviewedTransaction?.networkId }
 
@@ -67,7 +68,8 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			message: Message,
 			ephemeralNotaryPrivateKey: Curve25519.Signing.PrivateKey = .init(),
 			waitsForTransactionToBeComitted: Bool = false,
-			isWalletTransaction: Bool
+			isWalletTransaction: Bool,
+			proposingDappMetadata: DappMetadata.Ledger?
 		) {
 			self.nonce = nonce
 			self.transactionManifest = transactionManifest
@@ -76,6 +78,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			self.ephemeralNotaryPrivateKey = ephemeralNotaryPrivateKey
 			self.waitsForTransactionToBeComitted = waitsForTransactionToBeComitted
 			self.isWalletTransaction = isWalletTransaction
+			self.proposingDappMetadata = proposingDappMetadata
 		}
 
 		public enum DisplayMode: Sendable, Hashable {


### PR DESCRIPTION
Show in the Transaction Review header the name and thumbnail of the dApp that is proposing the transaction.

## Gumbal
![IMG_0143](https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/29d1d950-ff07-42db-b7ed-03f367522104){width=30 height=30}
## Dashboard
![IMG_0144](https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/4387460a-e6fb-4bab-8387-a4887f453da2)
## Console
![IMG_0145](https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/04c76433-c485-4696-a330-c0c2d04d2ebc)
