### PR TITLE
Handle malformed manifest request

### DIFF
--- a/RadixWallet/Clients/TransactionClient/Models/TransactionModels.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionModels.swift
@@ -190,7 +190,7 @@ extension TransactionClient {
 
 // MARK: - ManifestReviewRequest
 public struct ManifestReviewRequest: Sendable {
-	public let manifestToSign: RawTransactionManifest
+	public let unvalidatedManifest: UnvalidatedTransactionManifest
 	public let message: Message
 	public let nonce: Nonce
 	public let makeTransactionHeaderInput: MakeTransactionHeaderInput
@@ -199,7 +199,7 @@ public struct ManifestReviewRequest: Sendable {
 	public let isWalletTransaction: Bool
 
 	public init(
-		manifestToSign: RawTransactionManifest,
+		unvalidatedManifest: UnvalidatedTransactionManifest,
 		message: Message,
 		nonce: Nonce,
 		makeTransactionHeaderInput: MakeTransactionHeaderInput = .default,
@@ -207,7 +207,7 @@ public struct ManifestReviewRequest: Sendable {
 		signingPurpose: SigningPurpose,
 		isWalletTransaction: Bool
 	) {
-		self.manifestToSign = manifestToSign
+		self.unvalidatedManifest = unvalidatedManifest
 		self.message = message
 		self.nonce = nonce
 		self.makeTransactionHeaderInput = makeTransactionHeaderInput

--- a/RadixWallet/Clients/TransactionClient/Models/TransactionModels.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionModels.swift
@@ -190,7 +190,7 @@ extension TransactionClient {
 
 // MARK: - ManifestReviewRequest
 public struct ManifestReviewRequest: Sendable {
-	public let manifestToSign: TransactionManifest
+	public let manifestToSign: RawTransactionManifest
 	public let message: Message
 	public let nonce: Nonce
 	public let makeTransactionHeaderInput: MakeTransactionHeaderInput
@@ -199,7 +199,7 @@ public struct ManifestReviewRequest: Sendable {
 	public let isWalletTransaction: Bool
 
 	public init(
-		manifestToSign: TransactionManifest,
+		manifestToSign: RawTransactionManifest,
 		message: Message,
 		nonce: Nonce,
 		makeTransactionHeaderInput: MakeTransactionHeaderInput = .default,
@@ -233,6 +233,7 @@ public struct FeePayerCandidate: Sendable, Hashable, Identifiable {
 
 // MARK: - TransactionToReview
 public struct TransactionToReview: Sendable, Hashable {
+	public let transactionManifest: TransactionManifest
 	public let analyzedManifestToReview: ExecutionSummary
 	public let networkID: NetworkID
 

--- a/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
@@ -160,7 +160,7 @@ extension TransactionClient {
 		let getTransactionReview: GetTransactionReview = { request in
 			let networkID = await gatewaysClient.getCurrentNetworkID()
 
-			let manifestToSign = try request.manifestToSign.transactionManifest(onNetwork: networkID)
+			let manifestToSign = try request.unvalidatedManifest.transactionManifest(onNetwork: networkID)
 
 			/// Get all transaction signers.
 			let transactionSigners = try await getTransactionSigners(.init(

--- a/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
@@ -160,15 +160,22 @@ extension TransactionClient {
 		let getTransactionReview: GetTransactionReview = { request in
 			let networkID = await gatewaysClient.getCurrentNetworkID()
 
+			let manifestToSign = try request.manifestToSign.transactionManifest(onNetwork: networkID)
+
 			/// Get all transaction signers.
 			let transactionSigners = try await getTransactionSigners(.init(
 				networkID: networkID,
-				manifest: request.manifestToSign,
+				manifest: manifestToSign,
 				ephemeralNotaryPublicKey: request.ephemeralNotaryPublicKey
 			))
 
 			/// Get the transaction preview
-			let transactionPreviewRequest = try await createTransactionPreviewRequest(for: request, networkID: networkID, transactionSigners: transactionSigners)
+			let transactionPreviewRequest = try await createTransactionPreviewRequest(
+				for: request,
+				networkID: networkID,
+				transactionManifest: manifestToSign,
+				transactionSigners: transactionSigners
+			)
 			let transactionPreviewResponse = try await gatewayAPIClient.transactionPreview(transactionPreviewRequest)
 			guard transactionPreviewResponse.receipt.status == .succeeded else {
 				throw TransactionFailure.fromFailedTXReviewResponse(transactionPreviewResponse)
@@ -176,7 +183,7 @@ extension TransactionClient {
 			let receiptBytes = try Data(hex: transactionPreviewResponse.encodedReceipt)
 
 			/// Analyze the manifest
-			let analyzedManifestToReview = try request.manifestToSign.executionSummary(networkId: networkID.rawValue, encodedReceipt: receiptBytes)
+			let analyzedManifestToReview = try manifestToSign.executionSummary(networkId: networkID.rawValue, encodedReceipt: receiptBytes)
 
 			/// Transactions created outside of the Wallet are not allowed to use reserved instructions
 			if !request.isWalletTransaction, !analyzedManifestToReview.reservedInstructions.isEmpty {
@@ -213,6 +220,7 @@ extension TransactionClient {
 			}
 
 			return TransactionToReview(
+				transactionManifest: manifestToSign,
 				analyzedManifestToReview: analyzedManifestToReview,
 				networkID: networkID,
 				transactionFee: transactionFee,
@@ -225,11 +233,12 @@ extension TransactionClient {
 		func createTransactionPreviewRequest(
 			for request: ManifestReviewRequest,
 			networkID: NetworkID,
+			transactionManifest: TransactionManifest,
 			transactionSigners: TransactionSigners
 		) async throws -> GatewayAPI.TransactionPreviewRequest {
 			let intent = try await buildTransactionIntent(.init(
-				networkID: gatewaysClient.getCurrentNetworkID(),
-				manifest: request.manifestToSign,
+				networkID: networkID,
+				manifest: transactionManifest,
 				message: request.message,
 				nonce: request.nonce,
 				makeTransactionHeaderInput: request.makeTransactionHeaderInput,
@@ -237,7 +246,7 @@ extension TransactionClient {
 			))
 
 			return try .init(
-				rawManifest: request.manifestToSign,
+				rawManifest: transactionManifest,
 				header: intent.header(),
 				transactionSigners: transactionSigners
 			)

--- a/RadixWallet/Core/SharedModels/P2P/Dapp/Models/Interaction/Transactions/SendTransactionRequest.swift
+++ b/RadixWallet/Core/SharedModels/P2P/Dapp/Models/Interaction/Transactions/SendTransactionRequest.swift
@@ -67,17 +67,7 @@ extension P2P.Dapp.Request {
 
 			let manifestString = try container.decode(String.self, forKey: .transactionManifestString)
 			let blobsHex = try container.decodeIfPresent([String].self, forKey: .blobsHex) ?? []
-			let blobsBytes = try blobsHex.map {
-				try Data(hex: $0)
-			}
-
-//			let networkID = decoder.userInfo[.networkIdKey] as! UInt8
-//
-//			let instructions = try Instructions.fromString(
-//				string: manifestString,
-//				networkId: networkID
-//			)
-//			let manifest = TransactionManifest(instructions: instructions, blobs: blobsBytes)
+			let blobsBytes = try blobsHex.map { try Data(hex: $0) }
 
 			try self.init(
 				version: container.decode(TXVersion.self, forKey: .version),

--- a/RadixWallet/Core/SharedModels/P2P/Dapp/Models/Interaction/Transactions/SendTransactionRequest.swift
+++ b/RadixWallet/Core/SharedModels/P2P/Dapp/Models/Interaction/Transactions/SendTransactionRequest.swift
@@ -1,5 +1,5 @@
-// MARK: - RawTransactionManifest
-public struct RawTransactionManifest: Sendable, Hashable {
+// MARK: - UnvalidatedTransactionManifest
+public struct UnvalidatedTransactionManifest: Sendable, Hashable {
 	public let transactionManifestString: String
 	public let blobsBytes: [Data]
 
@@ -26,17 +26,17 @@ public struct RawTransactionManifest: Sendable, Hashable {
 // MARK: - P2P.Dapp.Request.SendTransactionItem
 extension P2P.Dapp.Request {
 	public struct SendTransactionItem: Sendable, Hashable, Decodable {
-		public let rawTransactionManifest: RawTransactionManifest
+		public let unvalidatedManifest: UnvalidatedTransactionManifest
 		public let version: TXVersion
 		public let message: String?
 
 		public init(
 			version: TXVersion,
-			rawTransactionManifest: RawTransactionManifest,
+			unvalidatedManifest: UnvalidatedTransactionManifest,
 			message: String?
 		) {
 			self.version = version
-			self.rawTransactionManifest = rawTransactionManifest
+			self.unvalidatedManifest = unvalidatedManifest
 			self.message = message
 		}
 
@@ -47,7 +47,7 @@ extension P2P.Dapp.Request {
 		) throws {
 			try self.init(
 				version: version,
-				rawTransactionManifest: .init(
+				unvalidatedManifest: .init(
 					transactionManifestString: transactionManifest.instructions().asStr(),
 					blobsBytes: transactionManifest.blobs()
 				),
@@ -71,7 +71,7 @@ extension P2P.Dapp.Request {
 
 			try self.init(
 				version: container.decode(TXVersion.self, forKey: .version),
-				rawTransactionManifest: .init(transactionManifestString: manifestString, blobsBytes: blobsBytes),
+				unvalidatedManifest: .init(transactionManifestString: manifestString, blobsBytes: blobsBytes),
 				message: container.decodeIfPresent(String.self, forKey: .message)
 			)
 		}

--- a/RadixWallet/Core/SharedModels/P2P/Dapp/Models/Interaction/WalletInteraction+PreviewValue.swift
+++ b/RadixWallet/Core/SharedModels/P2P/Dapp/Models/Interaction/WalletInteraction+PreviewValue.swift
@@ -25,7 +25,7 @@ extension P2P.Dapp.Request.PersonaDataRequestItem {
 }
 
 extension P2P.Dapp.Request.SendTransactionItem {
-	public static let previewValue = Self(version: .default, transactionManifest: .previewValue, message: nil)
+	public static let previewValue = try! Self(transactionManifest: .previewValue)
 }
 
 extension P2P.Dapp.Request.ID {

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
@@ -236,7 +236,7 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 		#if DEBUG
 		case let .reviewTransaction(manifest):
 			state.destination = .reviewTransaction(.init(
-				rawTransactionManifest: try! .init(manifest: manifest),
+				unvalidatedManifest: try! .init(manifest: manifest),
 				nonce: .secureRandom(),
 				signTransactionPurpose: .internalManifest(.debugModifyAccount),
 				message: .none,

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
@@ -236,7 +236,10 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 		#if DEBUG
 		case let .reviewTransaction(manifest):
 			state.destination = .reviewTransaction(.init(
-				transactionManifest: manifest,
+				rawTransactionManifest: try! .init(
+					transactionManifestString: manifest.instructions().asStr(),
+					blobsBytes: manifest.blobs()
+				),
 				nonce: .secureRandom(),
 				signTransactionPurpose: .internalManifest(.debugModifyAccount),
 				message: .none,

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
@@ -236,10 +236,7 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 		#if DEBUG
 		case let .reviewTransaction(manifest):
 			state.destination = .reviewTransaction(.init(
-				rawTransactionManifest: try! .init(
-					transactionManifestString: manifest.instructions().asStr(),
-					blobsBytes: manifest.blobs()
-				),
+				rawTransactionManifest: try! .init(manifest: manifest),
 				nonce: .secureRandom(),
 				signTransactionPurpose: .internalManifest(.debugModifyAccount),
 				message: .none,

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ThirdPartyDeposits+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ThirdPartyDeposits+Reducer.swift
@@ -131,15 +131,8 @@ public struct ManageThirdPartyDeposits: FeatureReducer, Sendable {
 		.run { send in
 			do {
 				/// Wait for user to complete the interaction with Transaction Review
-				let result = await dappInteractionClient.addWalletInteraction(
-					.transaction(
-						.init(
-							send: .init(
-								version: .default,
-								transactionManifest: manifest,
-								message: nil
-							))
-					),
+				let result = try await dappInteractionClient.addWalletInteraction(
+					.transaction(.init(send: .init(transactionManifest: manifest))),
 					.accountDepositSettings
 				)
 

--- a/RadixWallet/Features/AssetTransferFeature/AssetTransfer+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/AssetTransfer+Reducer.swift
@@ -75,14 +75,8 @@ public struct AssetTransfer: Sendable, FeatureReducer {
 			return .run { [accounts = state.accounts, message = state.message?.message] send in
 				let manifest = try await createManifest(accounts)
 				Task {
-					_ = await dappInteractionClient.addWalletInteraction(
-						.transaction(.init(
-							send: .init(
-								version: .default,
-								transactionManifest: manifest,
-								message: message
-							)
-						)),
+					_ = try await dappInteractionClient.addWalletInteraction(
+						.transaction(.init(send: .init(transactionManifest: manifest))),
 						.accountTransfer
 					)
 				}

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/StakeUnitList.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/StakeUnitList.swift
@@ -265,14 +265,8 @@ public struct StakeUnitList: Sendable, FeatureReducer {
 				accountAddress: acccountAddress,
 				stakeClaims: stakeClaims
 			)
-			_ = await dappInteractionClient.addWalletInteraction(
-				.transaction(.init(
-					send: .init(
-						version: .default,
-						transactionManifest: manifest,
-						message: nil
-					)
-				)),
+			_ = try await dappInteractionClient.addWalletInteraction(
+				.transaction(.init(send: .init(transactionManifest: manifest))),
 				.accountTransfer
 			)
 		}

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -1022,7 +1022,7 @@ extension DappInteractionFlow.Path.State {
 
 		case let .remote(.send(item)):
 			self = .relayed(anyItem, with: .reviewTransaction(.init(
-				transactionManifest: item.transactionManifest,
+				rawTransactionManifest: item.rawTransactionManifest,
 				nonce: .secureRandom(),
 				signTransactionPurpose: .manifestFromDapp,
 				message: item.message.map {

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -1022,7 +1022,7 @@ extension DappInteractionFlow.Path.State {
 
 		case let .remote(.send(item)):
 			self = .relayed(anyItem, with: .reviewTransaction(.init(
-				rawTransactionManifest: item.rawTransactionManifest,
+				unvalidatedManifest: item.unvalidatedManifest,
 				nonce: .secureRandom(),
 				signTransactionPurpose: .manifestFromDapp,
 				message: item.message.map {

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -664,7 +664,7 @@ struct TransactionReview_Previews: PreviewProvider {
 
 extension TransactionReview.State {
 	public static let previewValue: Self = .init(
-		rawTransactionManifest: try! .init(manifest: .previewValue),
+		unvalidatedManifest: try! .init(manifest: .previewValue),
 		nonce: .zero,
 		signTransactionPurpose: .manifestFromDapp,
 		message: .none,

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -664,7 +664,7 @@ struct TransactionReview_Previews: PreviewProvider {
 
 extension TransactionReview.State {
 	public static let previewValue: Self = .init(
-		transactionManifest: .previewValue,
+		rawTransactionManifest: try! .init(manifest: .previewValue),
 		nonce: .zero,
 		signTransactionPurpose: .manifestFromDapp,
 		message: .none,

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -7,7 +7,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		public var displayMode: DisplayMode = .review
 
 		public let nonce: Nonce
-		public let transactionManifest: TransactionManifest
+		public let rawTransactionManifest: RawTransactionManifest
 		public let message: Message
 		public let signTransactionPurpose: SigningPurpose.SignTransactionPurpose
 		public let waitsForTransactionToBeComitted: Bool
@@ -67,7 +67,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		}
 
 		public init(
-			transactionManifest: TransactionManifest,
+			rawTransactionManifest: RawTransactionManifest,
 			nonce: Nonce,
 			signTransactionPurpose: SigningPurpose.SignTransactionPurpose,
 			message: Message,
@@ -77,7 +77,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			proposingDappMetadata: DappMetadata.Ledger?
 		) {
 			self.nonce = nonce
-			self.transactionManifest = transactionManifest
+			self.rawTransactionManifest = rawTransactionManifest
 			self.signTransactionPurpose = signTransactionPurpose
 			self.message = message
 			self.ephemeralNotaryPrivateKey = ephemeralNotaryPrivateKey
@@ -85,6 +85,26 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			self.isWalletTransaction = isWalletTransaction
 			self.proposingDappMetadata = proposingDappMetadata
 		}
+
+//		public init(
+//			transactionManifest: TransactionManifest,
+//			nonce: Nonce,
+//			signTransactionPurpose: SigningPurpose.SignTransactionPurpose,
+//			message: Message,
+//			ephemeralNotaryPrivateKey: Curve25519.Signing.PrivateKey = .init(),
+//			waitsForTransactionToBeComitted: Bool = false,
+//			isWalletTransaction: Bool,
+//			proposingDappMetadata: DappMetadata.Ledger?
+//		) {
+//			self.nonce = nonce
+//			self.transactionManifest = transactionManifest
+//			self.signTransactionPurpose = signTransactionPurpose
+//			self.message = message
+//			self.ephemeralNotaryPrivateKey = ephemeralNotaryPrivateKey
+//			self.waitsForTransactionToBeComitted = waitsForTransactionToBeComitted
+//			self.isWalletTransaction = isWalletTransaction
+//			self.proposingDappMetadata = proposingDappMetadata
+//		}
 
 		public enum DisplayMode: Sendable, Hashable {
 			case review
@@ -234,7 +254,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			return .run { [state = state] send in
 				let preview = await TaskResult {
 					try await transactionClient.getTransactionReview(.init(
-						manifestToSign: state.transactionManifest,
+						manifestToSign: state.rawTransactionManifest,
 						message: state.message,
 						nonce: state.nonce,
 						ephemeralNotaryPublicKey: state.ephemeralNotaryPrivateKey.publicKey,
@@ -375,7 +395,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			}
 			state.destination = .customizeFees(.init(
 				reviewedTransaction: reviewedTransaction,
-				manifestSummary: state.transactionManifest.summary(networkId: reviewedTransaction.networkID.rawValue),
+				manifestSummary: reviewedTransaction.transactionManifest.summary(networkId: reviewedTransaction.networkID.rawValue),
 				signingPurpose: .signTransaction(state.signTransactionPurpose)
 			))
 			return .none
@@ -394,6 +414,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 
 		case let .previewLoaded(.success(preview)):
 			let reviewedTransaction = ReviewedTransaction(
+				transactionManifest: preview.transactionManifest,
 				networkID: preview.networkID,
 				feePayer: .loading,
 				transactionFee: preview.transactionFee,
@@ -638,10 +659,14 @@ extension TransactionReview {
 	}
 
 	func transactionManifestWithWalletInstructionsAdded(_ state: State) throws -> TransactionManifest {
-		var manifest = state.transactionManifest
-		if let reviewedTransaction = state.reviewedTransaction, case let .success(feePayerAccount) = reviewedTransaction.feePayer.unwrap()?.account {
+		guard let reviewedTransaction = state.reviewedTransaction else {
+			fatalError()
+		}
+
+		var manifest = reviewedTransaction.transactionManifest
+		if case let .success(feePayerAccount) = reviewedTransaction.feePayer.unwrap()?.account {
 			do {
-				manifest = try manifest.withLockFeeCallMethodAdded(
+				manifest = try reviewedTransaction.transactionManifest.withLockFeeCallMethodAdded(
 					address: feePayerAccount.address.asGeneral,
 					fee: reviewedTransaction.transactionFee.totalFee.lockFee
 				)
@@ -670,7 +695,7 @@ extension TransactionReview {
 						transactionSigners: reviewedTransaction.transactionSigners,
 						signingFactors: reviewedTransaction.signingFactors,
 						signingPurpose: .signTransaction(state.signTransactionPurpose),
-						manifest: state.transactionManifest
+						manifest: reviewedTransaction.transactionManifest
 					))
 				}
 
@@ -910,6 +935,7 @@ public struct TransactionReviewFailure: LocalizedError {
 
 // MARK: - ReviewedTransaction
 public struct ReviewedTransaction: Hashable, Sendable {
+	let transactionManifest: TransactionManifest
 	let networkID: NetworkID
 	var feePayer: Loadable<FeePayerCandidate?> = .idle
 

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -86,26 +86,6 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			self.proposingDappMetadata = proposingDappMetadata
 		}
 
-//		public init(
-//			transactionManifest: TransactionManifest,
-//			nonce: Nonce,
-//			signTransactionPurpose: SigningPurpose.SignTransactionPurpose,
-//			message: Message,
-//			ephemeralNotaryPrivateKey: Curve25519.Signing.PrivateKey = .init(),
-//			waitsForTransactionToBeComitted: Bool = false,
-//			isWalletTransaction: Bool,
-//			proposingDappMetadata: DappMetadata.Ledger?
-//		) {
-//			self.nonce = nonce
-//			self.transactionManifest = transactionManifest
-//			self.signTransactionPurpose = signTransactionPurpose
-//			self.message = message
-//			self.ephemeralNotaryPrivateKey = ephemeralNotaryPrivateKey
-//			self.waitsForTransactionToBeComitted = waitsForTransactionToBeComitted
-//			self.isWalletTransaction = isWalletTransaction
-//			self.proposingDappMetadata = proposingDappMetadata
-//		}
-
 		public enum DisplayMode: Sendable, Hashable {
 			case review
 			case raw(String)
@@ -660,7 +640,8 @@ extension TransactionReview {
 
 	func transactionManifestWithWalletInstructionsAdded(_ state: State) throws -> TransactionManifest {
 		guard let reviewedTransaction = state.reviewedTransaction else {
-			fatalError()
+			struct MissingReviewedTransaction: Error {}
+			throw MissingReviewedTransaction()
 		}
 
 		var manifest = reviewedTransaction.transactionManifest

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -7,7 +7,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		public var displayMode: DisplayMode = .review
 
 		public let nonce: Nonce
-		public let rawTransactionManifest: RawTransactionManifest
+		public let unvalidatedManifest: UnvalidatedTransactionManifest
 		public let message: Message
 		public let signTransactionPurpose: SigningPurpose.SignTransactionPurpose
 		public let waitsForTransactionToBeComitted: Bool
@@ -67,7 +67,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 		}
 
 		public init(
-			rawTransactionManifest: RawTransactionManifest,
+			unvalidatedManifest: UnvalidatedTransactionManifest,
 			nonce: Nonce,
 			signTransactionPurpose: SigningPurpose.SignTransactionPurpose,
 			message: Message,
@@ -77,7 +77,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			proposingDappMetadata: DappMetadata.Ledger?
 		) {
 			self.nonce = nonce
-			self.rawTransactionManifest = rawTransactionManifest
+			self.unvalidatedManifest = unvalidatedManifest
 			self.signTransactionPurpose = signTransactionPurpose
 			self.message = message
 			self.ephemeralNotaryPrivateKey = ephemeralNotaryPrivateKey
@@ -234,7 +234,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 			return .run { [state = state] send in
 				let preview = await TaskResult {
 					try await transactionClient.getTransactionReview(.init(
-						manifestToSign: state.rawTransactionManifest,
+						unvalidatedManifest: state.unvalidatedManifest,
 						message: state.message,
 						nonce: state.nonce,
 						ephemeralNotaryPublicKey: state.ephemeralNotaryPrivateKey.publicKey,

--- a/RadixWallet/RadixConnect/RadixConnect/RTC/RTCClients.swift
+++ b/RadixWallet/RadixConnect/RadixConnect/RTC/RTCClients.swift
@@ -410,7 +410,9 @@ extension RTCClient {
 func decode(
 	_ messageResult: Result<DataChannelClient.AssembledMessage, Error>
 ) -> Result<P2P.RTCMessageFromPeer, Error> {
-	let jsonDecoder = JSONDecoder()
+	@Dependency(\.jsonDecoder) var jsonDecoderDep
+	let jsonDecoder = jsonDecoderDep()
+
 	return messageResult.flatMap { (message: DataChannelClient.AssembledMessage) in
 		let jsonData = message.messageContent
 		do {

--- a/RadixWallet/RadixConnect/RadixConnect/RTC/RTCClients.swift
+++ b/RadixWallet/RadixConnect/RadixConnect/RTC/RTCClients.swift
@@ -379,7 +379,7 @@ extension RTCClient {
 			.receivedMessagesStream()
 			.map { (messageResult: Result<DataChannelClient.AssembledMessage, Error>) in
 				let route = P2P.RTCRoute(connectionId: self.id, peerConnectionId: connection.id)
-				return await P2P.RTCIncomingMessage(
+				return P2P.RTCIncomingMessage(
 					result: decode(messageResult),
 					route: .rtc(route)
 				)
@@ -409,14 +409,9 @@ extension RTCClient {
 // FIXME: once we have merge together the separated message formats `Dapp` and `Ledger` in CAP21, clean up!
 func decode(
 	_ messageResult: Result<DataChannelClient.AssembledMessage, Error>
-) async -> Result<P2P.RTCMessageFromPeer, Error> {
-	@Dependency(\.gatewaysClient) var gatewaysClient
-	let currentNetwork = await gatewaysClient.getCurrentNetworkID()
+) -> Result<P2P.RTCMessageFromPeer, Error> {
 	let jsonDecoder = JSONDecoder()
-	jsonDecoder.userInfo[.networkIdKey] = currentNetwork.rawValue
-
 	return messageResult.flatMap { (message: DataChannelClient.AssembledMessage) in
-
 		let jsonData = message.messageContent
 		do {
 			let request = try jsonDecoder.decode(

--- a/RadixWalletTests/Core/SharedModelsTests/DappModelsTests/DappModelsTests.swift
+++ b/RadixWalletTests/Core/SharedModelsTests/DappModelsTests/DappModelsTests.swift
@@ -5,11 +5,7 @@ import XCTest
 
 // MARK: - ToDappResponseTests
 final class ToDappResponseTests: TestCase {
-	let decoder: JSONDecoder = {
-		let decoder = JSONDecoder()
-		decoder.userInfo[.networkIdKey] = Radix.Gateway.default.network.id.rawValue
-		return decoder
-	}()
+	let decoder = JSONDecoder()
 
 	func test_encode_response() throws {
 		let sut = P2P.Dapp.Response.success(.init(

--- a/RadixWalletTests/Features/TransactionReviewFeatureTests/CustomizeFeePayerTests.swift
+++ b/RadixWalletTests/Features/TransactionReviewFeatureTests/CustomizeFeePayerTests.swift
@@ -14,6 +14,7 @@ final class CustomizeFeePayerTests: TestCase {
 		)
 		let notaryKey = Curve25519.Signing.PrivateKey()
 		var transactionStub = ReviewedTransaction(
+			transactionManifest: manifestStub,
 			networkID: NetworkID.enkinet,
 			feePayer: .success(nil),
 			transactionFee: .nonContingentLockPaying,


### PR DESCRIPTION
Main problem was that we were eagerly creating the TransactionManifest as part of the dApp request decoding, therefore if the manifest was invalid, the whole dApp request was invalid and we were not able to respond bacl.

This PR, moves up the TransactionManifest creation into TransactionClient. This allows identifying the invalid transaction manifest and respond back to dApp with proper error message.

# Demo

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/dff5f657-4e76-4098-9cf4-68eb503e4e81
