### PR TITLE
Preselect Single Value

### DIFF
--- a/RadixWallet/Core/DesignSystem/Components/Selection.swift
+++ b/RadixWallet/Core/DesignSystem/Components/Selection.swift
@@ -123,6 +123,9 @@ public struct Selection<Value: Hashable, Content: View>: View {
 			.disabled(isDisabled)
 		}
 		.onAppear {
+			if selectedValues.isEmpty, values.count == 1, let value = values.first {
+				selectedValues = [value]
+			}
 			updateResult(with: selectedValues, in: values, requiring: requirement)
 		}
 		.onChange(of: selectedValues) { selectedValues in

--- a/RadixWallet/Core/DesignSystem/Components/Selection.swift
+++ b/RadixWallet/Core/DesignSystem/Components/Selection.swift
@@ -123,7 +123,7 @@ public struct Selection<Value: Hashable, Content: View>: View {
 			.disabled(isDisabled)
 		}
 		.onAppear {
-			if selectedValues.isEmpty, values.count == 1, let value = values.first {
+			if requirement.count == 1, selectedValues.isEmpty, values.count == 1, let value = values.first {
 				selectedValues = [value]
 			}
 			updateResult(with: selectedValues, in: values, requiring: requirement)

--- a/RadixWallet/Core/DesignSystem/Components/Selection.swift
+++ b/RadixWallet/Core/DesignSystem/Components/Selection.swift
@@ -10,27 +10,21 @@ public struct SelectionItem<Value> {
 extension SelectionItem: Sendable where Value: Sendable {}
 
 // MARK: - SelectionRequirement
-public enum SelectionRequirement: Sendable, Hashable {
-	case exactly(Int)
-	case atLeast(Int)
+public struct SelectionRequirement: Sendable, Hashable {
+	public let quantifier: Quantifier
+	public let count: Int
+
+	static func exactly(_ count: Int) -> Self {
+		SelectionRequirement(quantifier: .exactly, count: count)
+	}
+
+	static func atLeast(_ count: Int) -> Self {
+		SelectionRequirement(quantifier: .atLeast, count: count)
+	}
 
 	public enum Quantifier: Sendable, Hashable {
 		case exactly
 		case atLeast
-	}
-
-	public var quantifier: Quantifier {
-		switch self {
-		case .exactly: .exactly
-		case .atLeast: .atLeast
-		}
-	}
-
-	public var count: Int {
-		switch self {
-		case let .exactly(count), let .atLeast(count):
-			count
-		}
 	}
 }
 
@@ -88,15 +82,15 @@ public struct Selection<Value: Hashable, Content: View>: View {
 				guard !selectedValues.contains(value) else {
 					return false
 				}
-				switch requirement {
-				case let .exactly(count):
-					if count == 1 {
+				switch requirement.quantifier {
+				case .exactly:
+					if requirement.count == 1 {
 						return false
 					} else {
-						return selectedValues.count >= count
+						return selectedValues.count >= requirement.count
 					}
 				case .atLeast:
-					return false
+					return true
 				}
 			}()
 			content(


### PR DESCRIPTION
## Description
In any selection list where there is a single element, and the user is asked to select one, or at least one element, then it should be preselected.

The last commit is entirely optional. It simplifies SelectionRequirement. I am not 100% I prefer the new version, but it _is_ more standard.

## Screenshot
<img width="250" alt="image" src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/d46d22f0-d70a-414b-8dab-34693de1f6c3">

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
