### PR TITLE
Display rate limit error on 429 GW response.

### DIFF
--- a/RadixWallet/Core/Resources/Generated/L10n.generated.swift
+++ b/RadixWallet/Core/Resources/Generated/L10n.generated.swift
@@ -264,8 +264,8 @@ public enum L10n {
       public static let addAnAssetAllow = L10n.tr("Localizable", "accountSettings_specificAssetsDeposits_addAnAssetAllow", fallback: "Allow Deposits")
       /// Add Asset
       public static let addAnAssetButton = L10n.tr("Localizable", "accountSettings_specificAssetsDeposits_addAnAssetButton", fallback: "Add Asset")
-      /// Deny Deposit
-      public static let addAnAssetDeny = L10n.tr("Localizable", "accountSettings_specificAssetsDeposits_addAnAssetDeny", fallback: "Deny Deposit")
+      /// Deny Deposits
+      public static let addAnAssetDeny = L10n.tr("Localizable", "accountSettings_specificAssetsDeposits_addAnAssetDeny", fallback: "Deny Deposits")
       /// Resource Address
       public static let addAnAssetInputHint = L10n.tr("Localizable", "accountSettings_specificAssetsDeposits_addAnAssetInputHint", fallback: "Resource Address")
       /// Enter the asset’s resource address (starting with “reso”)
@@ -857,6 +857,10 @@ public enum L10n {
   public enum Common {
     /// Account
     public static let account = L10n.tr("Localizable", "common_account", fallback: "Account")
+    /// Bad HTTP response status code %d
+    public static func badHttpStatusResponseCode(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "common_badHttpStatusResponseCode", p1, fallback: "Bad HTTP response status code %d")
+    }
     /// Cancel
     public static let cancel = L10n.tr("Localizable", "common_cancel", fallback: "Cancel")
     /// Choose

--- a/RadixWallet/Core/Resources/Generated/L10n.generated.swift
+++ b/RadixWallet/Core/Resources/Generated/L10n.generated.swift
@@ -858,8 +858,8 @@ public enum L10n {
     /// Account
     public static let account = L10n.tr("Localizable", "common_account", fallback: "Account")
     /// Bad HTTP response status code %d
-    public static func badHttpStatusResponseCode(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "common_badHttpStatusResponseCode", p1, fallback: "Bad HTTP response status code %d")
+    public static func badHttpResponseStatusCode(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "common_badHttpResponseStatusCode", p1, fallback: "Bad HTTP response status code %d")
     }
     /// Cancel
     public static let cancel = L10n.tr("Localizable", "common_cancel", fallback: "Cancel")

--- a/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
+++ b/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
@@ -996,3 +996,4 @@ You will be asked to enter your main seed phrase. This is a set of **24 words** 
 
 If you have any “Legacy” Accounts (created on the Olympia network) to import - or any Accounts using a Ledger hardware wallet device - please continue and then use the **Account Recovery Scan** option in your Radix Wallet settings under **Account Security**.";
 "recoverWalletWithoutProfile_complete_continueButton" = "Continue";
+

--- a/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
+++ b/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
@@ -996,4 +996,3 @@ You will be asked to enter your main seed phrase. This is a set of **24 words** 
 
 If you have any “Legacy” Accounts (created on the Olympia network) to import - or any Accounts using a Ledger hardware wallet device - please continue and then use the **Account Recovery Scan** option in your Radix Wallet settings under **Account Security**.";
 "recoverWalletWithoutProfile_complete_continueButton" = "Continue";
-

--- a/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
+++ b/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
@@ -994,3 +994,5 @@ You will be asked to enter your main seed phrase. This is a set of **24 words** 
 
 If you have any “Legacy” Accounts (created on the Olympia network) to import - or any Accounts using a Ledger hardware wallet device - please continue and then use the **Account Recovery Scan** option in your Radix Wallet settings under **Account Security**.";
 "recoverWalletWithoutProfile_complete_continueButton" = "Continue";
+
+"common_badHttpStatusResponseCode" = "Bad HTTP response status code %d";

--- a/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
+++ b/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
@@ -995,4 +995,4 @@ You will be asked to enter your main seed phrase. This is a set of **24 words** 
 If you have any “Legacy” Accounts (created on the Olympia network) to import - or any Accounts using a Ledger hardware wallet device - please continue and then use the **Account Recovery Scan** option in your Radix Wallet settings under **Account Security**.";
 "recoverWalletWithoutProfile_complete_continueButton" = "Continue";
 
-"common_badHttpStatusResponseCode" = "Bad HTTP response status code %d";
+"common_badHttpResponseStatusCode" = "Bad HTTP response status code %d";

--- a/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
+++ b/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
@@ -995,5 +995,3 @@ You will be asked to enter your main seed phrase. This is a set of **24 words** 
 
 If you have any “Legacy” Accounts (created on the Olympia network) to import - or any Accounts using a Ledger hardware wallet device - please continue and then use the **Account Recovery Scan** option in your Radix Wallet settings under **Account Security**.";
 "recoverWalletWithoutProfile_complete_continueButton" = "Continue";
-
-"common_badHttpResponseStatusCode" = "Bad HTTP response status code %d";

--- a/RadixWallet/Core/SharedModels/HTTPURLSessionResponse/HTTPURLSessionResponse.swift
+++ b/RadixWallet/Core/SharedModels/HTTPURLSessionResponse/HTTPURLSessionResponse.swift
@@ -18,7 +18,7 @@ public struct BadHTTPResponseCode: LocalizedError {
 		case 429:
 			L10n.Common.rateLimitReached
 		default:
-			"Bad HTTP response code \(got)" // FIXME: Strings
+			L10n.Common.badHttpStatusResponseCode(got)
 		}
 	}
 }

--- a/RadixWallet/Core/SharedModels/HTTPURLSessionResponse/HTTPURLSessionResponse.swift
+++ b/RadixWallet/Core/SharedModels/HTTPURLSessionResponse/HTTPURLSessionResponse.swift
@@ -4,13 +4,22 @@ public struct ExpectedHTTPURLResponse: Swift.Error {
 }
 
 // MARK: - BadHTTPResponseCode
-public struct BadHTTPResponseCode: Swift.Error {
+public struct BadHTTPResponseCode: LocalizedError {
 	public let got: Int
 	public let butExpected = Self.expected
 	public static let expected = 200
 
 	public init(got: Int) {
 		self.got = got
+	}
+
+	public var errorDescription: String? {
+		switch got {
+		case 429:
+			L10n.Common.rateLimitReached
+		default:
+			"Bad HTTP response code \(got)" // FIXME: Strings
+		}
 	}
 }
 

--- a/RadixWallet/Core/SharedModels/HTTPURLSessionResponse/HTTPURLSessionResponse.swift
+++ b/RadixWallet/Core/SharedModels/HTTPURLSessionResponse/HTTPURLSessionResponse.swift
@@ -18,7 +18,7 @@ public struct BadHTTPResponseCode: LocalizedError {
 		case 429:
 			L10n.Common.rateLimitReached
 		default:
-			L10n.Common.badHttpStatusResponseCode(got)
+			L10n.Common.badHttpResponseStatusCode(got)
 		}
 	}
 }


### PR DESCRIPTION
Identify and display the 429 bad HTTP response code.



https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/13101e3e-2137-44e6-bb61-188856297702

