### PR TITLE
Guarantees for LSUs

### DIFF
--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -874,7 +874,9 @@ extension TransactionReview {
 					fungible.guarantee
 				case let .liquidStakeUnit(liquidStakeUnit):
 					liquidStakeUnit.guarantee
-				case .nonFungible, .poolUnit, .stakeClaimNFT:
+				case let .poolUnit(poolUnit):
+					poolUnit.guarantee
+				case .nonFungible, .stakeClaimNFT:
 					nil
 				}
 			}
@@ -886,7 +888,10 @@ extension TransactionReview {
 				case var .liquidStakeUnit(liquidStakeUnit):
 					liquidStakeUnit.guarantee = newValue
 					details = .liquidStakeUnit(liquidStakeUnit)
-				case .nonFungible, .poolUnit, .stakeClaimNFT:
+				case var .poolUnit(poolUnit):
+					poolUnit.guarantee = newValue
+					details = .poolUnit(poolUnit)
+				case .nonFungible, .stakeClaimNFT:
 					return
 				}
 			}
@@ -899,7 +904,9 @@ extension TransactionReview {
 				fungible.amount
 			case let .liquidStakeUnit(liquidStakeUnit):
 				liquidStakeUnit.amount
-			case .nonFungible, .poolUnit, .stakeClaimNFT:
+			case let .poolUnit(poolUnit):
+				poolUnit.details.poolUnitResource.amount
+			case .nonFungible, .stakeClaimNFT:
 				nil
 			}
 		}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/MinimumPercentageStepper/MinimumPercentageStepper.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/MinimumPercentageStepper/MinimumPercentageStepper.swift
@@ -16,7 +16,8 @@ public struct MinimumPercentageStepper: FeatureReducer {
 		public init(value: RETDecimal) {
 			let clamped = value.clamped
 			self.value = clamped
-			self.string = clamped.formattedPlain()
+			// When first showing this view, we round the _displayed_ number, in case you don't touch it and return
+			self.string = clamped.rounded(decimalPlaces: 2).formattedPlain()
 		}
 	}
 

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees+View.swift
@@ -92,7 +92,13 @@ extension TransactionReviewGuarantee.State {
 		.init(
 			id: id,
 			account: account,
-			token: .init(resource: resource, details: details)
+			token: .init(
+				name: resource.title,
+				thumbnail: isXRD ? .xrd : .known(resource.metadata.iconURL),
+				amount: amount,
+				guaranteedAmount: guarantee.amount,
+				fiatAmount: nil
+			)
 		)
 	}
 }


### PR DESCRIPTION
## Description
- Make transaction review support LSUs
- Make the guarantee view show the divisibility rounded number right away

## How to test
- Stake
- Make sure that the "Customize guarantees" button is present and that it works

## Video
This also shows rounding (we pretend that the resource has a divisibility of 3):

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/d72d6f53-35e4-4034-8a62-7a17b048a97e


## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
