### PR TITLE
Stake claime transaction aggregate amounts

### DIFF
--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
@@ -232,7 +232,7 @@ extension TransactionReview {
 				unstakingFromValidators: unstakingFromValidators
 			)
 
-		case let .validatorClaim(validatorAddresses, claims):
+		case let .validatorClaim(validatorAddresses, _):
 			let resourcesInfo = try await resourcesInfo(allAddresses.elements)
 			let withdrawals = try? await extractWithdrawals(
 				accountWithdraws: summary.accountWithdraws.aggregated,


### PR DESCRIPTION
Aggregate the transfer amounts for the same resource for the same account.

The RET analysis might return multiple withdrawls/deposits for the same resource, instead of showing separate entries for each withdral/deposit, we aggregate the fungible amounts or the non fungible ids.

This aggregates only the guranteed amounts,  predicted amounts cannot be aggregated since each amount will have a specific instruction index attached.

This is only used curently for stake claim transactions, when the Dapp might sent a manifest which is interpreted by RET as having multiple distinct withdrawls/deposits for the same resource.

This should eventually be moved to RET, so it should return the aggregated amounts

## Before

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/9ff86e0a-53e9-4067-acec-75dd513dce33

## After

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/d8eeeded-2f6c-4f02-b6e1-8c4c3cdd4648

