### PR TITLE
Linked connector not restoring after iCloud restore

### DIFF
--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Interface.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Interface.swift
@@ -24,7 +24,7 @@ public struct RadixConnectClient: DependencyKey, Sendable {
 	public var loadFromProfileAndConnectAll: LoadFromProfileAndConnectAll
 	public var disconnectAll: DisconnectAll
 
-	/// Connects to a given list of p2p links
+	/// Connects to a given list of p2p links, those will not be stored in profile.
 	public var connectToP2PLinks: ConnectToP2PLinks
 
 	public var getLocalNetworkAccess: GetLocalNetworkAccess

--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Interface.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Interface.swift
@@ -20,8 +20,12 @@ extension P2P {
 
 // MARK: - RadixConnectClient
 public struct RadixConnectClient: DependencyKey, Sendable {
+	/// Connects to the p2p links stored in the current profile
 	public var loadFromProfileAndConnectAll: LoadFromProfileAndConnectAll
 	public var disconnectAll: DisconnectAll
+
+	/// Connects to a given list of p2p links
+	public var connectToP2PLinks: ConnectToP2PLinks
 
 	public var getLocalNetworkAccess: GetLocalNetworkAccess
 
@@ -60,4 +64,6 @@ extension RadixConnectClient {
 	public typealias SendRequest = @Sendable (_ request: P2P.RTCOutgoingMessage.Request, _ sendStrategy: P2P.RTCOutgoingMessage.Request.SendStrategy) async throws -> Int
 
 	public typealias SendResponse = @Sendable (_ response: P2P.RTCOutgoingMessage.Response, _ origin: P2P.RTCRoute) async throws -> Void
+
+	public typealias ConnectToP2PLinks = @Sendable (P2PLinks) async throws -> Void
 }

--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Interface.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Interface.swift
@@ -21,7 +21,6 @@ extension P2P {
 // MARK: - RadixConnectClient
 public struct RadixConnectClient: DependencyKey, Sendable {
 	public var loadFromProfileAndConnectAll: LoadFromProfileAndConnectAll
-	public var disconnectAndRemoveAll: DisconnectAndRemoveAll
 	public var disconnectAll: DisconnectAll
 
 	public var getLocalNetworkAccess: GetLocalNetworkAccess
@@ -43,7 +42,6 @@ extension RadixConnectClient {
 	// Returns an async sequence of connection events
 	public typealias LoadFromProfileAndConnectAll = @Sendable () async -> AnyAsyncSequence<[P2P.LinkConnectionUpdate]>
 
-	public typealias DisconnectAndRemoveAll = @Sendable () async -> Void
 	public typealias DisconnectAll = @Sendable () async -> Void
 
 	public typealias GetLocalNetworkAccess = @Sendable () async -> Bool

--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Live.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Live.swift
@@ -37,15 +37,6 @@ extension RadixConnectClient {
 				}
 				return await getP2PLinksWithConnectionStatusUpdates()
 			},
-			disconnectAndRemoveAll: {
-				loggerGlobal.info("🔌 Disconnecting and removing all P2P connections")
-				await rtcClients.disconnectAndRemoveAll()
-				do {
-					try await p2pLinksClient.deleteAllP2PLinks()
-				} catch {
-					loggerGlobal.error("Failed to delete P2PLinks -> \(error)")
-				}
-			},
 			disconnectAll: {
 				loggerGlobal.info("🔌 Disconnecting all P2P connections")
 				await rtcClients.disconnectAndRemoveAll()

--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Live.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Live.swift
@@ -25,15 +25,19 @@ extension RadixConnectClient {
 			.eraseToAnyAsyncSequence()
 		}
 
+		let connectToP2PLinks: ConnectToP2PLinks = { _ in
+			for client in await p2pLinksClient.getP2PLinks() {
+				try await rtcClients.connect(
+					client.connectionPassword
+				)
+			}
+		}
+
 		return Self(
 			loadFromProfileAndConnectAll: {
 				Task {
 					loggerGlobal.info("🔌 Loading and connecting all P2P connections")
-					for client in await p2pLinksClient.getP2PLinks() {
-						try await rtcClients.connect(
-							client.connectionPassword
-						)
-					}
+					try await connectToP2PLinks(p2pLinksClient.getP2PLinks())
 				}
 				return await getP2PLinksWithConnectionStatusUpdates()
 			},
@@ -41,6 +45,7 @@ extension RadixConnectClient {
 				loggerGlobal.info("🔌 Disconnecting all P2P connections")
 				await rtcClients.disconnectAndRemoveAll()
 			},
+			connectToP2PLinks: connectToP2PLinks,
 			getLocalNetworkAccess: {
 				await localNetworkAuthorization.requestAuthorization()
 			},

--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Live.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Live.swift
@@ -25,8 +25,8 @@ extension RadixConnectClient {
 			.eraseToAnyAsyncSequence()
 		}
 
-		let connectToP2PLinks: ConnectToP2PLinks = { _ in
-			for client in await p2pLinksClient.getP2PLinks() {
+		let connectToP2PLinks: ConnectToP2PLinks = { links in
+			for client in links {
 				try await rtcClients.connect(
 					client.connectionPassword
 				)

--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Test.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Test.swift
@@ -7,6 +7,7 @@ extension RadixConnectClient: TestDependencyKey {
 	public static let testValue = Self(
 		loadFromProfileAndConnectAll: unimplemented("\(Self.self).loadFromProfileAndConnectAll"),
 		disconnectAll: unimplemented("\(Self.self).disconnectAll"),
+		connectToP2PLinks: unimplemented("\(Self.self).connectToP2PLinks"),
 		getLocalNetworkAccess: unimplemented("\(Self.self).getLocalNetworkAccess"),
 		getP2PLinks: unimplemented("\(Self.self).getP2PLinks"),
 		getP2PLinksWithConnectionStatusUpdates: unimplemented("\(Self.self).getP2PLinksWithConnectionStatusUpdates"),
@@ -24,6 +25,7 @@ extension RadixConnectClient {
 	static let noop = Self(
 		loadFromProfileAndConnectAll: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
 		disconnectAll: {},
+		connectToP2PLinks: { _ in },
 		getLocalNetworkAccess: { false },
 		getP2PLinks: { [] },
 		getP2PLinksWithConnectionStatusUpdates: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },

--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Test.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Test.swift
@@ -6,7 +6,6 @@ extension RadixConnectClient: TestDependencyKey {
 
 	public static let testValue = Self(
 		loadFromProfileAndConnectAll: unimplemented("\(Self.self).loadFromProfileAndConnectAll"),
-		disconnectAndRemoveAll: unimplemented("\(Self.self).disconnectAndRemoveAll"),
 		disconnectAll: unimplemented("\(Self.self).disconnectAll"),
 		getLocalNetworkAccess: unimplemented("\(Self.self).getLocalNetworkAccess"),
 		getP2PLinks: unimplemented("\(Self.self).getP2PLinks"),
@@ -24,7 +23,6 @@ extension RadixConnectClient: TestDependencyKey {
 extension RadixConnectClient {
 	static let noop = Self(
 		loadFromProfileAndConnectAll: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
-		disconnectAndRemoveAll: {},
 		disconnectAll: {},
 		getLocalNetworkAccess: { false },
 		getP2PLinks: { [] },

--- a/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+Reducer.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/ProfileBackupSettings/ProfileBackupSettings+Reducer.swift
@@ -281,7 +281,7 @@ public struct ProfileBackupSettings: Sendable, FeatureReducer {
 	private func deleteProfile(keepInICloudIfPresent: Bool) -> Effect<Action> {
 		.run { send in
 			cacheClient.removeAll()
-			await radixConnectClient.disconnectAndRemoveAll()
+			await radixConnectClient.disconnectAll()
 			userDefaults.removeAll()
 			await send(.delegate(.deleteProfileAndFactorSources(keepInICloudIfPresent: keepInICloudIfPresent)))
 		}


### PR DESCRIPTION
Connect to the P2PLinks during the profile Restore from Backup flow.

# Changes
- Don't remove the P2PLinks from the Profile when deleting the Wallet, so those are not lost when trying to Restore from Backup.
- When user starts the Restore from Backup flow, the Wallet pro-actively connects to the P2PLinks from the selected Profile. 
- While it was possible to connect to P2PLinks only when landing on home screen, connecting pro-actively in Restore from Backup flow, would make the experience of needing to use a Ledger device during the flow a lot better.
- If user leaves the Restore from Backup flow, RadixConnect will remove the established connections.

# Demo

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/a4d52339-1fce-4195-b6a5-b9fee83f123f

