### PR TITLE
[ABW-2875] Transaction Review Asset Buttons

### DIFF
--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -401,8 +401,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
-        "version" : "1.0.2"
+        "revision" : "b58e6627149808b40634c4552fcf2f44d0b3ca87",
+        "version" : "1.1.0"
       }
     }
   ],

--- a/RadixWallet/Core/DesignSystem/Components/PoolUnitView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/PoolUnitView.swift
@@ -9,7 +9,7 @@ public struct PoolUnitView: View {
 	}
 
 	public let viewState: ViewState
-	public let backgroundColor: Color
+	public let background: Color
 	public let onTap: () -> Void
 
 	public var body: some View {
@@ -55,7 +55,7 @@ public struct PoolUnitView: View {
 				}
 				.padding(.bottom, .small2)
 
-				Text(L10n.TransactionReview.worth)
+				Text(L10n.TransactionReview.worth.uppercased())
 					.textStyle(.body2HighImportance)
 					.foregroundColor(.app.gray2)
 					.padding(.bottom, .small3)
@@ -64,8 +64,8 @@ public struct PoolUnitView: View {
 					PoolUnitResourcesView(resources: resources)
 				}
 			}
-			.padding(.medium1)
-			.background(backgroundColor)
+			.padding(.medium3)
+			.background(background)
 		}
 		.buttonStyle(.borderless)
 	}

--- a/RadixWallet/Core/DesignSystem/Components/PoolUnitView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/PoolUnitView.swift
@@ -46,6 +46,10 @@ public struct PoolUnitView: View {
 
 					Spacer(minLength: 0)
 
+					if let isSelected = viewState.isSelected {
+						CheckmarkView(appearance: .dark, isChecked: isSelected)
+					}
+
 					//					AssetIcon(.asset(AssetResource.info), size: .smallest)
 					//						.tint(.app.gray3)
 				}
@@ -57,40 +61,34 @@ public struct PoolUnitView: View {
 					.padding(.bottom, .small3)
 
 				loadable(viewState.resources) { resources in
-					HStack(spacing: .zero) {
-						PoolUnitResourcesView(resources: resources, resourceBackgroundColor: backgroundColor)
-							.padding(.trailing, .small2)
-
-						if let isSelected = viewState.isSelected {
-							CheckmarkView(appearance: .dark, isChecked: isSelected)
-						}
-					}
+					PoolUnitResourcesView(resources: resources)
 				}
 			}
-			.background(backgroundColor)
 			.padding(.medium1)
+			.background(backgroundColor)
 		}
+		.buttonStyle(.borderless)
 	}
 }
 
 // MARK: - PoolUnitResourcesView
 public struct PoolUnitResourcesView: View {
 	public let resources: [PoolUnitResourceView.ViewState]
-	public let resourceBackgroundColor: Color
 
 	public var body: some View {
-		VStack(spacing: 1) {
+		VStack(spacing: 0) {
 			ForEach(resources) { resource in
 				PoolUnitResourceView(viewState: resource)
+					.padding(.small1)
+
+				if resource.id != resources.last?.id {
+					Rectangle()
+						.fill(.app.gray3)
+						.frame(height: 1)
+				}
 			}
-			.padding(.small1)
-			.background(resourceBackgroundColor)
 		}
-		.background(.app.gray3)
-		.overlay(
-			RoundedRectangle(cornerRadius: .small2)
-				.stroke(.app.gray3, lineWidth: 1)
-		)
+		.roundedCorners(strokeColor: .app.gray3)
 	}
 }
 
@@ -101,18 +99,6 @@ public struct PoolUnitResourceView: View {
 		public let symbol: String?
 		public let icon: TokenThumbnail.Content
 		public let amount: String
-
-		public init(
-			id: ResourceAddress,
-			symbol: String?,
-			icon: TokenThumbnail.Content,
-			amount: String
-		) {
-			self.id = id
-			self.symbol = symbol
-			self.icon = icon
-			self.amount = amount
-		}
 
 		public init(
 			id: ResourceAddress,

--- a/RadixWallet/Core/DesignSystem/Components/TokenBalanceView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/TokenBalanceView.swift
@@ -26,7 +26,7 @@ public struct TokenBalanceView: View {
 	}
 
 	public var body: some View {
-		HStack(alignment: .center) {
+		HStack(alignment: .center, spacing: .zero) {
 			TokenThumbnail(viewState.thumbnail, size: viewState.iconSize)
 				.padding(.trailing, .small1)
 

--- a/RadixWallet/Core/DesignSystem/Components/TokenBalanceView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/TokenBalanceView.swift
@@ -1,6 +1,6 @@
 // MARK: - TokenBalanceView
 public struct TokenBalanceView: View {
-	public struct ViewState {
+	public struct ViewState: Equatable {
 		public let thumbnail: TokenThumbnail.Content
 		public let name: String
 		public let balance: RETDecimal
@@ -41,16 +41,24 @@ public struct TokenBalanceView: View {
 				.textStyle(.secondaryHeader)
 		}
 	}
+
+	public struct Bordered: View {
+		let viewState: ViewState
+
+		public var body: some View {
+			TokenBalanceView(viewState: viewState)
+				.padding(.small1)
+				.roundedCorners(strokeColor: .app.gray3)
+		}
+	}
 }
 
-extension TokenBalanceView {
+extension TokenBalanceView.ViewState {
 	public static func xrd(balance: RETDecimal) -> Self {
-		TokenBalanceView(
-			viewState: .init(
-				thumbnail: .xrd,
-				name: "XRD",
-				balance: balance
-			)
+		.init(
+			thumbnail: .xrd,
+			name: Constants.xrdTokenName,
+			balance: balance
 		)
 	}
 }

--- a/RadixWallet/Core/DesignSystem/Components/TransferNFTView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/TransferNFTView.swift
@@ -1,23 +1,28 @@
 // MARK: - TransferNFTView
 public struct TransferNFTView: View {
 	let viewState: ViewState
+	let background: Color
 	let onTap: () -> Void
 	let disabled: Bool
 
-	public init(viewState: ViewState, onTap: (() -> Void)? = nil) {
+	public init(viewState: ViewState, background: Color, onTap: (() -> Void)? = nil) {
 		self.viewState = viewState
+		self.background = background
 		self.onTap = onTap ?? {}
 		self.disabled = onTap == nil
 	}
 
 	public var body: some View {
 		Button(action: onTap) {
-			HStack(spacing: .small1) {
+			HStack(spacing: .zero) {
 				NFTThumbnail(viewState.thumbnail, size: .small)
-					.padding(.vertical, .small1)
+					.padding([.vertical, .trailing], .small1)
+
+				Spacer(minLength: 0)
 
 				VStack(alignment: .leading, spacing: 0) {
 					Text(viewState.tokenID)
+						.multilineTextAlignment(.leading)
 						.textStyle(.body2Regular)
 						.foregroundColor(.app.gray2)
 						.lineLimit(1)
@@ -29,10 +34,12 @@ public struct TransferNFTView: View {
 					}
 				}
 			}
+			.padding(.horizontal, .medium3)
+			.background(background)
 		}
 		.disabled(disabled)
+		.buttonStyle(.borderless)
 		.frame(maxWidth: .infinity, alignment: .leading)
-		.padding(.horizontal, .medium3)
 	}
 }
 

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/NonFungibleResourceAsset+Reducer+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/NonFungibleResourceAsset+Reducer+View.swift
@@ -39,7 +39,7 @@ extension NonFungibleResourceAsset.State {
 extension NonFungibleResourceAsset.View {
 	public var body: some View {
 		WithViewStore(store, observe: \.viewState) { viewStore in
-			TransferNFTView(viewState: viewStore.state)
+			TransferNFTView(viewState: viewStore.state, background: .app.white)
 				.frame(height: .largeButtonHeight)
 		}
 	}

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit+View.swift
@@ -19,11 +19,10 @@ extension PoolUnit {
 				Section {
 					PoolUnitView(
 						viewState: viewStore.state,
-						backgroundColor: .app.white,
-						onTap: {
-							viewStore.send(.didTap)
-						}
-					)
+						backgroundColor: .app.white
+					) {
+						viewStore.send(.didTap)
+					}
 					.rowStyle()
 				}
 			}

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit+View.swift
@@ -17,10 +17,7 @@ extension PoolUnit {
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState, send: PoolUnit.Action.view) { viewStore in
 				Section {
-					PoolUnitView(
-						viewState: viewStore.state,
-						backgroundColor: .app.white
-					) {
+					PoolUnitView(viewState: viewStore.state, background: .app.white) {
 						viewStore.send(.didTap)
 					}
 					.rowStyle()

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnitDetails+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnitDetails+View.swift
@@ -57,7 +57,7 @@ extension PoolUnitDetails {
 							.textStyle(.secondaryHeader)
 							.foregroundColor(.app.gray1)
 
-						PoolUnitResourcesView(resources: viewStore.resources, resourceBackgroundColor: .app.white)
+						PoolUnitResourcesView(resources: viewStore.resources)
 							.padding(.horizontal, .large2)
 
 						AssetResourceDetailsSection(viewState: viewStore.resourceDetails)

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LSUDetails+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LSUDetails+View.swift
@@ -11,10 +11,11 @@ extension LSUDetails.State {
 			),
 			thumbnailURL: stakeUnitResource.resource.metadata.iconURL,
 			validatorNameViewState: .init(with: validator),
-			redeemableTokenAmount: [.init(
-				id: stakeUnitResource.resource.resourceAddress,
-				xrdAmount: xrdRedemptionValue.formatted()
-			)],
+			redeemableTokenAmount: .init(
+				thumbnail: .xrd,
+				name: Constants.xrdTokenName,
+				balance: xrdRedemptionValue
+			),
 			resourceDetails: .init(
 				description: .success(stakeUnitResource.resource.metadata.description),
 				resourceAddress: stakeUnitResource.resource.resourceAddress,
@@ -35,7 +36,7 @@ extension LSUDetails {
 		let thumbnailURL: URL?
 
 		let validatorNameViewState: ValidatorHeaderView.ViewState
-		let redeemableTokenAmount: [PoolUnitResourceView.ViewState]
+		let redeemableTokenAmount: TokenBalanceView.ViewState
 		let resourceDetails: AssetResourceDetailsSection.ViewState
 	}
 
@@ -66,11 +67,9 @@ extension LSUDetails {
 
 						ValidatorHeaderView(viewState: viewStore.validatorNameViewState)
 							.padding(.horizontal, .large2)
-						PoolUnitResourcesView(
-							resources: viewStore.redeemableTokenAmount,
-							resourceBackgroundColor: .app.white
-						)
-						.padding(.horizontal, .large2)
+
+						TokenBalanceView.Bordered(viewState: viewStore.redeemableTokenAmount)
+							.padding(.horizontal, .large2)
 
 						AssetResourceDetailsSection(viewState: viewStore.resourceDetails)
 					}
@@ -89,21 +88,6 @@ extension ValidatorHeaderView.ViewState {
 			imageURL: validator.metadata.iconURL,
 			name: validator.metadata.name ?? L10n.Account.PoolUnits.unknownValidatorName,
 			stakedAmount: nil
-		)
-	}
-}
-
-extension PoolUnitResourceView.ViewState {
-	init(
-		id: ResourceAddress,
-		xrdAmount: String,
-		isSelected: Bool? = nil
-	) {
-		self.init(
-			id: id,
-			symbol: Constants.xrdTokenName,
-			icon: .xrd,
-			amount: xrdAmount
 		)
 	}
 }

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LiquidStakeUnitView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LiquidStakeUnitView.swift
@@ -37,10 +37,9 @@ public struct LiquidStakeUnitView: View {
 				}
 
 				VStack(alignment: .leading, spacing: .small3) {
-					Text(L10n.Account.Staking.worth)
+					Text(L10n.Account.Staking.worth.uppercased())
 						.textStyle(.body2HighImportance)
 						.foregroundColor(.app.gray2)
-						.textCase(nil)
 
 					TokenBalanceView.Bordered(viewState: .xrd(balance: viewState.worth))
 				}

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LiquidStakeUnitView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LiquidStakeUnitView.swift
@@ -42,7 +42,7 @@ public struct LiquidStakeUnitView: View {
 					.textCase(nil)
 					.padding(.bottom, .small3)
 
-				TokenBalanceView.xrd(balance: viewState.worth)
+				TokenBalanceView(viewState: .xrd(balance: viewState.worth))
 					.padding(.small1)
 					.roundedCorners(strokeColor: .app.gray3)
 			}

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LiquidStakeUnitView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LiquidStakeUnitView.swift
@@ -7,11 +7,12 @@ public struct LiquidStakeUnitView: View {
 	}
 
 	let viewState: ViewState
-	let action: () -> Void
+	let background: Color
+	let onTap: () -> Void
 
 	public var body: some View {
-		Button(action: action) {
-			VStack(alignment: .leading, spacing: .zero) {
+		Button(action: onTap) {
+			VStack(alignment: .leading, spacing: .medium3) {
 				HStack(spacing: .zero) {
 					TokenThumbnail(.known(viewState.resource.metadata.iconURL), size: .smaller)
 						.padding(.trailing, .small2)
@@ -34,18 +35,18 @@ public struct LiquidStakeUnitView: View {
 						CheckmarkView(appearance: .dark, isChecked: isSelected)
 					}
 				}
-				.padding(.bottom, .medium3)
 
-				Text(L10n.Account.Staking.worth)
-					.textStyle(.body2HighImportance)
-					.foregroundColor(.app.gray2)
-					.textCase(nil)
-					.padding(.bottom, .small3)
+				VStack(alignment: .leading, spacing: .small3) {
+					Text(L10n.Account.Staking.worth)
+						.textStyle(.body2HighImportance)
+						.foregroundColor(.app.gray2)
+						.textCase(nil)
 
-				TokenBalanceView(viewState: .xrd(balance: viewState.worth))
-					.padding(.small1)
-					.roundedCorners(strokeColor: .app.gray3)
+					TokenBalanceView.Bordered(viewState: .xrd(balance: viewState.worth))
+				}
 			}
+			.padding(.medium3)
+			.background(background)
 		}
 		.buttonStyle(.borderless)
 	}

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LiquidStakeUnitView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/LiquidStakeUnitView.swift
@@ -11,9 +11,10 @@ public struct LiquidStakeUnitView: View {
 
 	public var body: some View {
 		Button(action: action) {
-			VStack(alignment: .leading, spacing: .small2) {
-				HStack {
+			VStack(alignment: .leading, spacing: .zero) {
+				HStack(spacing: .zero) {
 					TokenThumbnail(.known(viewState.resource.metadata.iconURL), size: .smaller)
+						.padding(.trailing, .small2)
 
 					VStack(alignment: .leading, spacing: .zero) {
 						Text(viewState.resource.metadata.name ?? L10n.Account.PoolUnits.unknownPoolUnitName)
@@ -25,25 +26,27 @@ public struct LiquidStakeUnitView: View {
 								.textStyle(.body2Regular)
 						}
 					}
+					.padding(.trailing, .small2)
 
-					Spacer()
+					Spacer(minLength: 0)
+
+					if let isSelected = viewState.isSelected {
+						CheckmarkView(appearance: .dark, isChecked: isSelected)
+					}
 				}
+				.padding(.bottom, .medium3)
 
 				Text(L10n.Account.Staking.worth)
 					.textStyle(.body2HighImportance)
 					.foregroundColor(.app.gray2)
 					.textCase(nil)
+					.padding(.bottom, .small3)
 
-				HStack {
-					TokenBalanceView.xrd(balance: viewState.worth)
-					if let isSelected = viewState.isSelected {
-						CheckmarkView(appearance: .dark, isChecked: isSelected)
-					}
-				}
-				.padding(.small1)
-				.background(.white)
-				.roundedCorners(strokeColor: .app.gray3)
+				TokenBalanceView.xrd(balance: viewState.worth)
+					.padding(.small1)
+					.roundedCorners(strokeColor: .app.gray3)
 			}
 		}
+		.buttonStyle(.borderless)
 	}
 }

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/StakeClaimNFTsView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/StakeClaimNFTsView.swift
@@ -4,6 +4,7 @@ public struct StakeClaimNFTSView: View {
 		public let canClaimTokens: Bool
 		public let validatorName: String?
 		public let stakeClaimTokens: OnLedgerEntitiesClient.NonFunbileResourceWithTokens
+
 		var selectedStakeClaims: IdentifiedArrayOf<NonFungibleGlobalId>?
 
 		var unstaking: IdentifiedArrayOf<OnLedgerEntitiesClient.StakeClaim> {
@@ -42,11 +43,18 @@ public struct StakeClaimNFTSView: View {
 	}
 
 	public let viewState: ViewState
+	public let backgroundColor: Color
 	public let onTap: (OnLedgerEntitiesClient.StakeClaim) -> Void
 	public let onClaimAllTapped: (() -> Void)?
 
-	public init(viewState: ViewState, onTap: @escaping (OnLedgerEntitiesClient.StakeClaim) -> Void, onClaimAllTapped: (() -> Void)? = nil) {
+	public init(
+		viewState: ViewState,
+		backgroundColor: Color,
+		onTap: @escaping (OnLedgerEntitiesClient.StakeClaim) -> Void,
+		onClaimAllTapped: (() -> Void)? = nil
+	) {
 		self.viewState = viewState
+		self.backgroundColor = backgroundColor
 		self.onTap = onTap
 		self.onClaimAllTapped = onClaimAllTapped
 	}
@@ -111,19 +119,20 @@ public struct StakeClaimNFTSView: View {
 				}
 			}
 			ForEach(claims) { claim in
-				HStack {
-					Button {
-						onTap(claim)
-					} label: {
+				Button {
+					onTap(claim)
+				} label: {
+					HStack {
 						TokenBalanceView.xrd(balance: claim.claimAmount)
 							.contentShape(Rectangle())
-					}
-					if let isSelected = viewState.selectedStakeClaims?.contains(claim.id) {
-						CheckmarkView(appearance: .dark, isChecked: isSelected)
+						if let isSelected = viewState.selectedStakeClaims?.contains(claim.id) {
+							CheckmarkView(appearance: .dark, isChecked: isSelected)
+						}
 					}
 				}
+				.buttonStyle(.borderless)
 				.padding(.small1)
-				.background(.white)
+				.background(backgroundColor)
 				.roundedCorners(strokeColor: .app.gray3)
 			}
 		}

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/StakeClaimNFTsView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/StakeClaimNFTsView.swift
@@ -43,24 +43,24 @@ public struct StakeClaimNFTSView: View {
 	}
 
 	public let viewState: ViewState
-	public let backgroundColor: Color
+	public let background: Color
 	public let onTap: (OnLedgerEntitiesClient.StakeClaim) -> Void
 	public let onClaimAllTapped: (() -> Void)?
 
 	public init(
 		viewState: ViewState,
-		backgroundColor: Color,
+		background: Color,
 		onTap: @escaping (OnLedgerEntitiesClient.StakeClaim) -> Void,
 		onClaimAllTapped: (() -> Void)? = nil
 	) {
 		self.viewState = viewState
-		self.backgroundColor = backgroundColor
+		self.background = background
 		self.onTap = onTap
 		self.onClaimAllTapped = onClaimAllTapped
 	}
 
 	public var body: some View {
-		VStack(alignment: .leading, spacing: .small1) {
+		VStack(alignment: .leading, spacing: .medium3) {
 			HStack(spacing: .zero) {
 				TokenThumbnail(.known(viewState.resourceMetadata.iconURL), size: .smaller)
 					.padding(.trailing, .small1)
@@ -94,11 +94,13 @@ public struct StakeClaimNFTSView: View {
 				sectionView(viewState.toBeClaimed, kind: .toBeClaimed)
 			}
 		}
+		.padding(.medium3)
+		.background(background)
 	}
 
 	@ViewBuilder
 	func sectionView(_ claims: IdentifiedArrayOf<OnLedgerEntitiesClient.StakeClaim>, kind: SectionKind) -> some View {
-		VStack(alignment: .leading, spacing: .small2) {
+		VStack(alignment: .leading, spacing: .zero) {
 			HStack {
 				Text(kind.title)
 					.textStyle(.body2HighImportance)
@@ -118,22 +120,26 @@ public struct StakeClaimNFTSView: View {
 					}
 				}
 			}
-			ForEach(claims) { claim in
-				Button {
-					onTap(claim)
-				} label: {
-					HStack {
-						TokenBalanceView(viewState: .xrd(balance: claim.claimAmount))
+			.padding(.bottom, .small3)
 
-						if let isSelected = viewState.selectedStakeClaims?.contains(claim.id) {
-							CheckmarkView(appearance: .dark, isChecked: isSelected)
+			VStack(alignment: .leading, spacing: .small2) {
+				ForEach(claims) { claim in
+					Button {
+						onTap(claim)
+					} label: {
+						HStack {
+							TokenBalanceView(viewState: .xrd(balance: claim.claimAmount))
+
+							if let isSelected = viewState.selectedStakeClaims?.contains(claim.id) {
+								CheckmarkView(appearance: .dark, isChecked: isSelected)
+							}
 						}
+						.padding(.small1)
+						.background(background)
 					}
-					.padding(.small1)
-					.background(backgroundColor)
+					.buttonStyle(.borderless)
 					.roundedCorners(strokeColor: .app.gray3)
 				}
-				.buttonStyle(.borderless)
 			}
 		}
 	}

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/StakeClaimNFTsView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/StakeClaimNFTsView.swift
@@ -123,17 +123,17 @@ public struct StakeClaimNFTSView: View {
 					onTap(claim)
 				} label: {
 					HStack {
-						TokenBalanceView.xrd(balance: claim.claimAmount)
+						TokenBalanceView(viewState: .xrd(balance: claim.claimAmount))
 
 						if let isSelected = viewState.selectedStakeClaims?.contains(claim.id) {
 							CheckmarkView(appearance: .dark, isChecked: isSelected)
 						}
 					}
+					.padding(.small1)
+					.background(backgroundColor)
+					.roundedCorners(strokeColor: .app.gray3)
 				}
 				.buttonStyle(.borderless)
-				.padding(.small1)
-				.background(backgroundColor)
-				.roundedCorners(strokeColor: .app.gray3)
 			}
 		}
 	}

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/StakeClaimNFTsView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/StakeClaimNFTsView.swift
@@ -124,7 +124,7 @@ public struct StakeClaimNFTSView: View {
 				} label: {
 					HStack {
 						TokenBalanceView.xrd(balance: claim.claimAmount)
-							.contentShape(Rectangle())
+
 						if let isSelected = viewState.selectedStakeClaims?.contains(claim.id) {
 							CheckmarkView(appearance: .dark, isChecked: isSelected)
 						}

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/ValidatorStakeView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/ValidatorStakeView.swift
@@ -57,6 +57,7 @@ struct ValidatorStakeView: View {
 
 			LiquidStakeUnitView(viewState: viewState, action: action)
 				.padding(.medium1)
+				.background(.app.white)
 		}
 		.contentShape(Rectangle())
 	}
@@ -71,8 +72,13 @@ struct ValidatorStakeView: View {
 				.frame(height: .small3)
 				.overlay(.app.gray5)
 
-			StakeClaimNFTSView(viewState: viewState, onTap: handleTapGesture, onClaimAllTapped: onClaimAllTapped)
-				.padding(.medium1)
+			StakeClaimNFTSView(
+				viewState: viewState,
+				backgroundColor: .app.white,
+				onTap: handleTapGesture,
+				onClaimAllTapped: onClaimAllTapped
+			)
+			.padding(.medium1)
 		}
 	}
 }

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/ValidatorStakeView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/ValidatorStakeView.swift
@@ -27,9 +27,11 @@ struct ValidatorStakeView: View {
 		} label: {
 			ValidatorHeaderView(viewState: viewState.validatorNameViewState)
 				.contentShape(Rectangle())
+				.padding(.vertical, .medium3)
+				.padding(.horizontal, .small1)
 				.rowStyle()
-				.padding(.medium1)
 		}
+		.buttonStyle(.borderless)
 
 		if isExpanded {
 			if let liquidStakeUnitViewState = viewState.liquidStakeUnit {
@@ -40,7 +42,7 @@ struct ValidatorStakeView: View {
 			if let stakeClaimNFTsViewState = viewState.stakeClaimNFTs {
 				stakeClaimNFTsView(
 					viewState: stakeClaimNFTsViewState,
-					handleTapGesture: onStakeClaimTokenTapped,
+					onTap: onStakeClaimTokenTapped,
 					onClaimAllTapped: onClaimAllStakeClaimsTapped
 				)
 				.rowStyle()
@@ -55,16 +57,13 @@ struct ValidatorStakeView: View {
 				.frame(height: .small3)
 				.overlay(.app.gray5)
 
-			LiquidStakeUnitView(viewState: viewState, action: action)
-				.padding(.medium1)
-				.background(.app.white)
+			LiquidStakeUnitView(viewState: viewState, background: .app.white, onTap: action)
 		}
-		.contentShape(Rectangle())
 	}
 
 	private func stakeClaimNFTsView(
 		viewState: StakeClaimNFTSView.ViewState,
-		handleTapGesture: @escaping (OnLedgerEntitiesClient.StakeClaim) -> Void,
+		onTap: @escaping (OnLedgerEntitiesClient.StakeClaim) -> Void,
 		onClaimAllTapped: @escaping () -> Void
 	) -> some SwiftUI.View {
 		VStack(spacing: .zero) {
@@ -74,11 +73,10 @@ struct ValidatorStakeView: View {
 
 			StakeClaimNFTSView(
 				viewState: viewState,
-				backgroundColor: .app.white,
-				onTap: handleTapGesture,
+				background: .app.white,
+				onTap: onTap,
 				onClaimAllTapped: onClaimAllTapped
 			)
-			.padding(.medium1)
 		}
 	}
 }

--- a/RadixWallet/Features/TransactionReviewFeature/SelectFeePayer/SelectFeePayer+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SelectFeePayer/SelectFeePayer+View.swift
@@ -125,11 +125,9 @@ enum SelectAccountToPayForFeeRow {
 					VStack(spacing: 0) {
 						SmallAccountCard(account: viewState.account)
 						HStack {
-							TokenBalanceView(viewState: .init(thumbnail: .xrd, name: Constants.xrdTokenName, balance: viewState.xrdBalance))
-							RadioButton(
-								appearance: .dark,
-								state: isSelected ? .selected : .unselected
-							)
+							TokenBalanceView(viewState: .xrd(balance: viewState.xrdBalance))
+
+							RadioButton(appearance: .dark, state: isSelected ? .selected : .unselected)
 						}
 						.padding(.medium3)
 					}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -661,8 +661,8 @@ struct RawTransactionView: SwiftUI.View {
 	}
 }
 
-// MARK: - TransactionReviewTokenView
-struct TransactionReviewTokenView: View {
+// MARK: - TransactionReviewFungibleView
+struct TransactionReviewFungibleView: View {
 	struct ViewState: Equatable {
 		let name: String?
 		let thumbnail: TokenThumbnail.Content
@@ -673,18 +673,20 @@ struct TransactionReviewTokenView: View {
 	}
 
 	let viewState: ViewState
+	let background: Color
 	let onTap: () -> Void
 	let disabled: Bool
 
-	init(viewState: ViewState, onTap: (() -> Void)? = nil) {
+	init(viewState: ViewState, background: Color, onTap: (() -> Void)? = nil) {
 		self.viewState = viewState
+		self.background = background
 		self.onTap = onTap ?? {}
 		self.disabled = onTap == nil
 	}
 
 	var body: some View {
-		HStack(spacing: .small1) {
-			Button(action: onTap) {
+		Button(action: onTap) {
+			HStack(spacing: .small1) {
 				TokenThumbnail(viewState.thumbnail, size: .small)
 					.padding(.vertical, .small1)
 
@@ -694,39 +696,41 @@ struct TransactionReviewTokenView: View {
 						.textStyle(.body2HighImportance)
 						.foregroundColor(.app.gray1)
 				}
-			}
-			.disabled(disabled)
 
-			Spacer(minLength: 0)
+				Spacer(minLength: 0)
 
-			VStack(alignment: .trailing, spacing: 0) {
-				if viewState.guaranteedAmount != nil {
-					Text(L10n.TransactionReview.estimated)
-						.textStyle(.body2HighImportance)
+				VStack(alignment: .trailing, spacing: 0) {
+					if viewState.guaranteedAmount != nil {
+						Text(L10n.TransactionReview.estimated)
+							.textStyle(.body2HighImportance)
+							.foregroundColor(.app.gray1)
+					}
+					Text(viewState.amount.formatted())
+						.textStyle(.secondaryHeader)
 						.foregroundColor(.app.gray1)
-				}
-				Text(viewState.amount.formatted())
-					.textStyle(.secondaryHeader)
-					.foregroundColor(.app.gray1)
 
-				if let fiatAmount = viewState.fiatAmount {
-					// Text(fiatAmount.formatted(.currency(code: "USD")))
-					Text(fiatAmount.formatted())
-						.textStyle(.body2HighImportance)
-						.foregroundColor(.app.gray1)
-						.padding(.top, .small2)
-				}
+					if let fiatAmount = viewState.fiatAmount {
+						// Text(fiatAmount.formatted(.currency(code: "USD")))
+						Text(fiatAmount.formatted())
+							.textStyle(.body2HighImportance)
+							.foregroundColor(.app.gray1)
+							.padding(.top, .small2)
+					}
 
-				if let guaranteedAmount = viewState.guaranteedAmount {
-					Text("\(L10n.TransactionReview.guaranteed) **\(guaranteedAmount.formatted())**")
-						.textStyle(.body2HighImportance)
-						.foregroundColor(.app.gray2)
-						.padding(.top, .small1)
+					if let guaranteedAmount = viewState.guaranteedAmount {
+						Text("\(L10n.TransactionReview.guaranteed) **\(guaranteedAmount.formatted())**")
+							.textStyle(.body2HighImportance)
+							.foregroundColor(.app.gray2)
+							.padding(.top, .small1)
+					}
 				}
+				.padding(.vertical, .medium3)
 			}
-			.padding(.vertical, .medium3)
+			.padding(.horizontal, .medium3)
+			.background(background)
 		}
-		.padding(.horizontal, .medium3)
+		.buttonStyle(.borderless)
+		.disabled(disabled)
 	}
 }
 

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
@@ -75,15 +75,19 @@ extension TransactionReviewAccount {
 				InnerCard {
 					SmallAccountCard(account: viewStore.account)
 
-					VStack(spacing: 1) {
+					VStack(spacing: .zero) {
 						ForEach(viewStore.transfers) { transfer in
 							TransactionReviewResourceView(transfer: transfer) { token in
 								viewStore.send(.transferTapped(transfer, token))
 							}
+
+							if transfer.id != viewStore.transfers.last?.id {
+								Rectangle()
+									.fill(.app.gray4)
+									.frame(height: 1)
+							}
 						}
-						.background(.app.gray5)
 					}
-					.background(.app.gray4)
 				}
 			}
 		}
@@ -98,11 +102,11 @@ struct TransactionReviewResourceView: View {
 	var body: some View {
 		switch transfer.details {
 		case let .fungible(details):
-			TransactionReviewTokenView(viewState: .init(resource: transfer.resource, details: details)) {
+			TransactionReviewFungibleView(viewState: .init(resource: transfer.resource, details: details), background: .app.gray5) {
 				onTap(nil)
 			}
 		case let .nonFungible(details):
-			TransferNFTView(viewState: .init(resource: transfer.resource, details: details)) {
+			TransferNFTView(viewState: .init(resource: transfer.resource, details: details), background: .app.gray5) {
 				onTap(nil)
 			}
 		case let .liquidStakeUnit(details):
@@ -131,7 +135,7 @@ extension LiquidStakeUnitView.ViewState {
 	}
 }
 
-extension TransactionReviewTokenView.ViewState {
+extension TransactionReviewFungibleView.ViewState {
 	init(resource: OnLedgerEntity.Resource, details: TransactionReview.Transfer.Details.Fungible) {
 		self.init(
 			name: resource.metadata.symbol ?? resource.metadata.name ?? L10n.TransactionReview.unknown,

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
@@ -111,12 +111,13 @@ struct TransactionReviewResourceView: View {
 				onTap(nil)
 			}
 			.padding(.medium3)
+			.background(.app.gray5)
 		case let .poolUnit(details):
 			PoolUnitView(viewState: .init(details: details.details), backgroundColor: .app.gray5) {
 				onTap(nil)
 			}
 		case let .stakeClaimNFT(details):
-			StakeClaimNFTSView(viewState: details) { stakeClaim in
+			StakeClaimNFTSView(viewState: details, backgroundColor: .app.gray5) { stakeClaim in
 				onTap(stakeClaim.token)
 			}
 			.padding()

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
@@ -98,8 +98,7 @@ struct TransactionReviewResourceView: View {
 	var body: some View {
 		switch transfer.details {
 		case let .fungible(details):
-			let viewState = TransactionReviewTokenView.ViewState(resource: transfer.resource, details: details)
-			TransactionReviewTokenView(viewState: viewState) {
+			TransactionReviewTokenView(viewState: .init(resource: transfer.resource, details: details)) {
 				onTap(nil)
 			}
 		case let .nonFungible(details):
@@ -107,20 +106,17 @@ struct TransactionReviewResourceView: View {
 				onTap(nil)
 			}
 		case let .liquidStakeUnit(details):
-			LiquidStakeUnitView(viewState: .init(resource: transfer.resource, details: details)) {
+			LiquidStakeUnitView(viewState: .init(resource: transfer.resource, details: details), background: .app.gray5) {
 				onTap(nil)
 			}
-			.padding(.medium3)
-			.background(.app.gray5)
 		case let .poolUnit(details):
-			PoolUnitView(viewState: .init(details: details.details), backgroundColor: .app.gray5) {
+			PoolUnitView(viewState: .init(details: details.details), background: .app.gray5) {
 				onTap(nil)
 			}
 		case let .stakeClaimNFT(details):
-			StakeClaimNFTSView(viewState: details, backgroundColor: .app.gray5) { stakeClaim in
+			StakeClaimNFTSView(viewState: details, background: .app.gray5) { stakeClaim in
 				onTap(stakeClaim.token)
 			}
-			.padding()
 		}
 	}
 }

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees+View.swift
@@ -107,7 +107,7 @@ extension TransactionReviewGuarantee {
 	public struct ViewState: Identifiable, Equatable {
 		public let id: TransactionReview.Transfer.ID
 		let account: TransactionReview.Account
-		let token: TransactionReviewTokenView.ViewState
+		let token: TransactionReviewFungibleView.ViewState
 	}
 
 	public struct View: SwiftUI.View {
@@ -123,7 +123,7 @@ extension TransactionReviewGuarantee {
 					VStack(spacing: 0) {
 						SmallAccountCard(account: viewStore.account)
 
-						TransactionReviewTokenView(viewState: viewStore.token)
+						TransactionReviewFungibleView(viewState: viewStore.token, background: .clear)
 
 						Separator()
 


### PR DESCRIPTION
Jira ticket: ABW-2875

## Description
Fixes the appearance and behaviour of all the assets in Transaction Review, and most of the ones used in the account screens etc. Among other things, it turns all of these into actual buttons that highlight when pressed. The highlight is quite subtle though, it's the native one, which turns the view slightly transparent. For white views, this means that the background does not change at all.

We could easily change this behaviour by adding a new button style that slightly darkens the view when the button is pressed.

## How to test

### Happy path (or test variation 1)

1. Step 1
2. Step 2
3. Verify

### Unhappy path (or test variation 2)

1. Step 1
2. Step 2
3. Verify

## Screenshot

| Screen 1 Before | Screen 1 After |
| - | - |
| paste link here | paste link here |

## Video
paste link here

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
