### PR TITLE
[ABW-2913] Customize Fees Crash

### DIFF
--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
@@ -151,13 +151,15 @@ public struct CustomizeFees: FeatureReducer, Sendable {
 			) -> Effect<Action> {
 				.run { send in
 					var reviewedTransaction = reviewedTransaction
-					var newSigners = OrderedSet(reviewedTransaction.transactionSigners.intentSignerEntitiesOrEmpty() + [.account(feePayer.account)])
+					var newSigners = OrderedSet(reviewedTransaction.transactionSigners.intentSignerEntitiesOrEmpty())
 
 					/// Remove the previous Fee Payer Signature if it is not required
-					if let previousFeePayer, feePayer.account != previousFeePayer.account, !manifestSummary.accountsRequiringAuth.contains(where: { $0.addressString() == previousFeePayer.account.address.address }) {
+					if let previousFeePayer, !manifestSummary.accountsRequiringAuth.contains(where: { $0.addressString() == previousFeePayer.account.address.address }) {
 						// removed, need to recalculate signing factors
 						newSigners.remove(.account(previousFeePayer.account))
 					}
+
+					newSigners.append(.account(feePayer.account))
 
 					// Update transaction signers
 					reviewedTransaction.transactionSigners = .init(
@@ -173,9 +175,15 @@ public struct CustomizeFees: FeatureReducer, Sendable {
 					@Dependency(\.factorSourcesClient) var factorSourcesClient
 
 					do {
+						guard let signers = NonEmpty(rawValue: Set(newSigners)) else {
+							assertionFailure("NewSigners can not be empty here, barring programmer errors")
+							struct InternalError: Error {}
+							throw InternalError()
+						}
+
 						let factors = try await factorSourcesClient.getSigningFactors(.init(
 							networkID: reviewedTransaction.networkID,
-							signers: .init(rawValue: Set(newSigners))!,
+							signers: signers,
 							signingPurpose: signingPurpose
 						))
 
@@ -194,7 +202,11 @@ public struct CustomizeFees: FeatureReducer, Sendable {
 				}
 			}
 
-			return replaceFeePayer(selection, state.reviewedTransaction, manifestSummary: state.manifestSummary)
+			if selection != previousFeePayer {
+				return replaceFeePayer(selection, state.reviewedTransaction, manifestSummary: state.manifestSummary)
+			} else {
+				return .none
+			}
 
 		default:
 			return .none

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
@@ -154,7 +154,7 @@ public struct CustomizeFees: FeatureReducer, Sendable {
 					var newSigners = OrderedSet(reviewedTransaction.transactionSigners.intentSignerEntitiesOrEmpty() + [.account(feePayer.account)])
 
 					/// Remove the previous Fee Payer Signature if it is not required
-					if let previousFeePayer, !manifestSummary.accountsRequiringAuth.contains(where: { $0.addressString() == previousFeePayer.account.address.address }) {
+					if let previousFeePayer, feePayer.account != previousFeePayer.account, !manifestSummary.accountsRequiringAuth.contains(where: { $0.addressString() == previousFeePayer.account.address.address }) {
 						// removed, need to recalculate signing factors
 						newSigners.remove(.account(previousFeePayer.account))
 					}


### PR DESCRIPTION
Jira ticket: [ABW-2913](https://radixdlt.atlassian.net/browse/ABW-2913)

## Description
Previously we used this logic, when changing fee payers:

1. Create a list of signers, based on the manifest + the new feePayer
2. Remove the previous feePayer unless it's also in the manifest
3. Force create a non-empty set of signers

The problem was that this was done even if the old feePayer that happened to be the same as the new.

I made the following changes:

1. I only replace the fee payer at all if it has changed, so the logic above would not get called in vain
2. The order inside the function was changed to first remove the old one, then add the new
3. We no longer force create the non empty set, instead we throw an error it (impossibly) is empty

## How to test
As in the ticket

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2913]: https://radixdlt.atlassian.net/browse/ABW-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ