### PR TITLE
Proper default icon for validators without any icon

### DIFF
--- a/RadixWallet/Core/DesignSystem/Components/Thumbnails.swift
+++ b/RadixWallet/Core/DesignSystem/Components/Thumbnails.swift
@@ -127,6 +127,26 @@ public struct PersonaThumbnail: View {
 	}
 }
 
+// MARK: - ValidatorThumbnail
+public struct ValidatorThumbnail: View {
+	private let url: URL?
+	private let size: HitTargetSize
+
+	public init(_ url: URL?, size hitTargetSize: HitTargetSize = .small) {
+		self.url = url
+		self.size = hitTargetSize
+	}
+
+	public var body: some View {
+		LoadableImage(url: url, size: .fixedSize(size)) {
+			Image(asset: AssetResource.iconValidator)
+				.resizable()
+		}
+		.cornerRadius(size.cornerRadius)
+		.frame(size)
+	}
+}
+
 // MARK: - LoadableImage
 /// A helper view that handles the loading state, and potentially the error state
 public struct LoadableImage<Placeholder: View>: View {

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/ValidatorHeaderView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/ValidatorHeaderView.swift
@@ -13,13 +13,15 @@ struct ValidatorHeaderView: View {
 
 	var body: some View {
 		HStack(spacing: .zero) {
-			NFTThumbnail(viewState.imageURL, size: .small)
+			ValidatorThumbnail(viewState.imageURL, size: .small)
 				.padding(.trailing, .small1)
 
 			VStack(alignment: .leading) {
 				Text(viewState.name)
 					.textStyle(.secondaryHeader)
 					.foregroundColor(.app.gray1)
+					.multilineTextAlignment(.leading)
+
 				if let stakedAmount = viewState.stakedAmount {
 					// This localization does not look right, should be only one string.
 					Text(L10n.Account.Staking.staked + " \(stakedAmount.formatted()) XRD")

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -803,7 +803,7 @@ extension TransactionReview {
 		public var body: some SwiftUI.View {
 			Card {
 				HStack(spacing: .zero) {
-					DappThumbnail(.known(viewState.thumbnail))
+					ValidatorThumbnail(viewState.thumbnail)
 						.padding(.trailing, .medium3)
 
 					VStack(alignment: .leading, spacing: .zero) {


### PR DESCRIPTION
Proper default icon for validators without any icon

# Demo



https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/dd9ff549-e2d3-4c48-9fe8-c2db03f29a1b


