### PR TITLE
Treat only "general" with transfers as "transfer"

### DIFF
--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
@@ -57,6 +57,10 @@ extension TransactionReview {
 		case nil:
 			return nil
 		case .general, .transfer:
+			if summary.detailedManifestClass == .general {
+				guard !summary.accountDeposits.isEmpty || !summary.accountWithdraws.isEmpty else { return nil }
+			}
+
 			let resourcesInfo = try await resourcesInfo(allAddresses.elements)
 			let withdrawals = try await extractWithdrawals(
 				accountWithdraws: summary.accountWithdraws,


### PR DESCRIPTION
## Description
Manifests classified as `.general` should be considered:
- as `.transfer` if it has withdrawals or deposits
- non-conforming if it doesn't

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
