### PR TITLE
[ABW-2905] Show Guarantees for Pool Units

### DIFF
--- a/RadixWallet/Core/DesignSystem/Components/PoolUnitView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/PoolUnitView.swift
@@ -2,7 +2,7 @@
 public struct PoolUnitView: View {
 	public struct ViewState: Equatable {
 		public let poolName: String?
-		public let amount: RETDecimal
+		public let amount: RETDecimal?
 		public let guaranteedAmount: RETDecimal?
 		public let dAppName: Loadable<String?>
 		public let poolIcon: URL?
@@ -37,11 +37,13 @@ public struct PoolUnitView: View {
 
 					Spacer(minLength: 0)
 
-					TransactionReviewAmountView(amount: viewState.amount, guaranteedAmount: viewState.guaranteedAmount)
+					if let amount = viewState.amount {
+						TransactionReviewAmountView(amount: amount, guaranteedAmount: viewState.guaranteedAmount)
+							.padding(.leading, viewState.isSelected != nil ? .small2 : 0)
+					}
 
 					if let isSelected = viewState.isSelected {
 						CheckmarkView(appearance: .dark, isChecked: isSelected)
-							.padding(.leading, .small2)
 					}
 
 					//					AssetIcon(.asset(AssetResource.info), size: .smallest)

--- a/RadixWallet/Core/DesignSystem/Components/PoolUnitView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/PoolUnitView.swift
@@ -2,6 +2,8 @@
 public struct PoolUnitView: View {
 	public struct ViewState: Equatable {
 		public let poolName: String?
+		public let amount: RETDecimal
+		public let guaranteedAmount: RETDecimal?
 		public let dAppName: Loadable<String?>
 		public let poolIcon: URL?
 		public let resources: Loadable<[PoolUnitResourceView.ViewState]>
@@ -17,7 +19,7 @@ public struct PoolUnitView: View {
 			VStack(alignment: .leading, spacing: .zero) {
 				HStack(spacing: .zero) {
 					Thumbnail(.poolUnit, url: viewState.poolIcon, size: .extraSmall)
-						.padding(.trailing, .medium3)
+						.padding(.trailing, .small1)
 
 					VStack(alignment: .leading, spacing: 0) {
 						Text(viewState.poolName ?? L10n.TransactionReview.poolUnits)
@@ -35,8 +37,11 @@ public struct PoolUnitView: View {
 
 					Spacer(minLength: 0)
 
+					TransactionReviewAmountView(amount: viewState.amount, guaranteedAmount: viewState.guaranteedAmount)
+
 					if let isSelected = viewState.isSelected {
 						CheckmarkView(appearance: .dark, isChecked: isSelected)
+							.padding(.leading, .small2)
 					}
 
 					//					AssetIcon(.asset(AssetResource.info), size: .smallest)

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit+View.swift
@@ -32,7 +32,7 @@ extension PoolUnit.State {
 	var viewState: PoolUnit.ViewState {
 		.init(
 			poolName: poolUnit.resource.metadata.fungibleResourceName,
-			amount: poolUnit.resource.amount,
+			amount: nil, // In this contextwe don't want to show any amount
 			guaranteedAmount: nil,
 			dAppName: resourceDetails.dAppName,
 			poolIcon: poolUnit.resource.metadata.iconURL,

--- a/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/PoolUnitsList/Components/PoolUnit+View.swift
@@ -32,24 +32,13 @@ extension PoolUnit.State {
 	var viewState: PoolUnit.ViewState {
 		.init(
 			poolName: poolUnit.resource.metadata.fungibleResourceName,
+			amount: poolUnit.resource.amount,
+			guaranteedAmount: nil,
 			dAppName: resourceDetails.dAppName,
 			poolIcon: poolUnit.resource.metadata.iconURL,
 			resources: resourceDetails.map { .init(resources: $0) },
 			isSelected: isSelected
 		)
-	}
-}
-
-extension [PoolUnitResourceView.ViewState] {
-	init(resources: OnLedgerEntitiesClient.OwnedResourcePoolDetails) {
-		let xrdResource = resources.xrdResource.map {
-			PoolUnitResourceView.ViewState(resourceWithRedemptionValue: $0, isXRD: true)
-		}
-		let nonXrdResources = resources.nonXrdResources.map {
-			PoolUnitResourceView.ViewState(resourceWithRedemptionValue: $0, isXRD: false)
-		}
-
-		self = (xrdResource.map { [$0] } ?? []) + nonXrdResources
 	}
 }
 

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -484,7 +484,7 @@ private extension View {
 			store: destinationStore,
 			state: /TransactionReview.Destination.State.customizeFees,
 			action: TransactionReview.Destination.Action.customizeFees,
-			content: { store in NavigationView { CustomizeFees.View(store: store) } }
+			content: { CustomizeFees.View(store: $0).inNavigationView }
 		)
 	}
 
@@ -687,7 +687,7 @@ struct TransactionReviewFungibleView: View {
 	var body: some View {
 		Button(action: onTap) {
 			HStack(spacing: .small1) {
-				Thumbnail(fungible: viewState.thumbnail, size: .small)
+				Thumbnail(fungible: viewState.thumbnail, size: .extraSmall)
 					.padding(.vertical, .small1)
 
 				if let name = viewState.name {
@@ -699,32 +699,8 @@ struct TransactionReviewFungibleView: View {
 
 				Spacer(minLength: 0)
 
-				VStack(alignment: .trailing, spacing: 0) {
-					if viewState.guaranteedAmount != nil {
-						Text(L10n.TransactionReview.estimated)
-							.textStyle(.body2HighImportance)
-							.foregroundColor(.app.gray1)
-					}
-					Text(viewState.amount.formatted())
-						.textStyle(.secondaryHeader)
-						.foregroundColor(.app.gray1)
-
-					if let fiatAmount = viewState.fiatAmount {
-						// Text(fiatAmount.formatted(.currency(code: "USD")))
-						Text(fiatAmount.formatted())
-							.textStyle(.body2HighImportance)
-							.foregroundColor(.app.gray1)
-							.padding(.top, .small2)
-					}
-
-					if let guaranteedAmount = viewState.guaranteedAmount {
-						Text("\(L10n.TransactionReview.guaranteed) **\(guaranteedAmount.formatted())**")
-							.textStyle(.body2HighImportance)
-							.foregroundColor(.app.gray2)
-							.padding(.top, .small1)
-					}
-				}
-				.padding(.vertical, .medium3)
+				TransactionReviewAmountView(amount: viewState.amount, guaranteedAmount: viewState.guaranteedAmount)
+					.padding(.vertical, .medium3)
 			}
 			.padding(.horizontal, .medium3)
 			.background(background)

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
@@ -114,7 +114,7 @@ struct TransactionReviewResourceView: View {
 				onTap(nil)
 			}
 		case let .poolUnit(details):
-			PoolUnitView(viewState: .init(details: details.details), background: .app.gray5) {
+			PoolUnitView(viewState: .init(resource: transfer.resource, details: details), background: .app.gray5) {
 				onTap(nil)
 			}
 		case let .stakeClaimNFT(details):
@@ -122,6 +122,37 @@ struct TransactionReviewResourceView: View {
 				onTap(stakeClaim.token)
 			}
 		}
+	}
+}
+
+// MARK: - TransactionReviewAmountView
+struct TransactionReviewAmountView: View {
+	let amount: RETDecimal
+	let guaranteedAmount: RETDecimal?
+
+	var body: some View {
+		VStack(alignment: .trailing, spacing: 0) {
+			if guaranteedAmount != nil {
+				Text(L10n.TransactionReview.estimated)
+					.textStyle(.body2HighImportance)
+					.foregroundColor(.app.gray1)
+			}
+			Text(amount.formatted())
+				.textStyle(.body1Header)
+				.foregroundColor(.app.gray1)
+
+			if let guaranteedAmount {
+				Text(L10n.TransactionReview.guaranteed)
+					.textStyle(.body2HighImportance)
+					.foregroundColor(.app.gray2)
+					.padding(.top, .small3)
+
+				Text(guaranteedAmount.formatted())
+					.textStyle(.body1Header)
+					.foregroundColor(.app.gray2)
+			}
+		}
+		.minimumScaleFactor(0.8)
 	}
 }
 
@@ -158,25 +189,29 @@ extension TransferNFTView.ViewState {
 }
 
 extension PoolUnitView.ViewState {
-	init(details: OnLedgerEntitiesClient.OwnedResourcePoolDetails) {
+	init(resource: OnLedgerEntity.Resource, details: TransactionReview.Transfer.Details.PoolUnit) {
 		self.init(
-			poolName: details.poolUnitResource.resource.fungibleResourceName,
-			dAppName: .success(details.dAppName),
-			poolIcon: details.poolUnitResource.resource.metadata.iconURL,
-			resources: {
-				let xrdResource = details.xrdResource.map {
-					PoolUnitResourceView.ViewState(resourceWithRedemptionValue: $0, isXRD: true)
-				}
-				.asArray(\.self)
-
-				let nonXrdResources = details.nonXrdResources.map {
-					PoolUnitResourceView.ViewState(resourceWithRedemptionValue: $0, isXRD: false)
-				}
-
-				return .success(xrdResource + nonXrdResources)
-			}(),
+			poolName: resource.fungibleResourceName,
+			amount: details.details.poolUnitResource.amount,
+			guaranteedAmount: details.guarantee?.amount,
+			dAppName: .success(details.details.dAppName),
+			poolIcon: resource.metadata.iconURL,
+			resources: .success(.init(resources: details.details)),
 			isSelected: nil
 		)
+	}
+}
+
+extension [PoolUnitResourceView.ViewState] {
+	init(resources: OnLedgerEntitiesClient.OwnedResourcePoolDetails) {
+		let xrdResource = resources.xrdResource.map {
+			PoolUnitResourceView.ViewState(resourceWithRedemptionValue: $0, isXRD: true)
+		}
+		let nonXrdResources = resources.nonXrdResources.map {
+			PoolUnitResourceView.ViewState(resourceWithRedemptionValue: $0, isXRD: false)
+		}
+
+		self = (xrdResource.map { [$0] } ?? []) + nonXrdResources
 	}
 }
 


### PR DESCRIPTION
Jira ticket: [ABW-2905](https://radixdlt.atlassian.net/browse/ABW-2905)

## Description
This PR makes it so that guaranteed amounts for pool units are shown.

It also updates the guarantee amount view for fungible tokens to use the new design.

## Discussion
With this PR we will also start showing the amount of pool units that are owned, both in the portfolio and when selecting an asset for transfer. Do we want to suppress this?

Also, do we want to add the amount (including estimated/guaranteed amount) for LSUs?

Both of these changes are quite trivial.

## Screenshot
![image](https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/5c8ee92c-42ac-41bf-b09f-edebb48a9567)

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works

[ABW-2905]: https://radixdlt.atlassian.net/browse/ABW-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ