### PR TITLE
Fix Account&Persona unhide

### DIFF
--- a/RadixWalletTests/Features/AccountAndPersonaHidingTests/AccountAndPersonaHidingTests.swift
+++ b/RadixWalletTests/Features/AccountAndPersonaHidingTests/AccountAndPersonaHidingTests.swift
@@ -45,7 +45,7 @@ final class AccountAndPersonaHidingTests: TestCase {
 			))
 		}
 
-		await store.send(.view(.confirmUnhideAllAlert(.presented(.confirmTapped)))) {
+		await store.send(.destination(.presented(.confirmUnhideAllAlert(.confirmTapped)))) {
 			$0.destination = nil
 		}
 
@@ -97,7 +97,7 @@ final class AccountAndPersonaHidingTests: TestCase {
 			))
 		}
 
-		await store.send(.view(.confirmUnhideAllAlert(.presented(.confirmTapped)))) {
+		await store.send(.destination(.presented(.confirmUnhideAllAlert(.confirmTapped)))) {
 			$0.destination = nil
 		}
 


### PR DESCRIPTION
Jira ticket: https://radixdlt.atlassian.net/browse/ABW-3006

## Description
Now user is able to unhide the Accounts and Personas again.

## Video


https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/afab2e76-779c-4306-a480-bace42d849a2

