### PR TITLE
Lower PRESET default deposit guarantee to 99% (from 100%), for NEW Pr…

### DIFF
--- a/RadixWallet/Profile/AppPreferences/Transaction/AppPreferences+Transaction.swift
+++ b/RadixWallet/Profile/AppPreferences/Transaction/AppPreferences+Transaction.swift
@@ -10,10 +10,11 @@ extension AppPreferences {
 		CustomStringConvertible,
 		CustomDumpReflectable
 	{
+		public static let defaultDepositGuaranteePreset = RETDecimal(floatLiteral: 0.99)
 		public var defaultDepositGuarantee: RETDecimal
 
 		public init(
-			defaultDepositGuarantee: RETDecimal = 1
+			defaultDepositGuarantee: RETDecimal = Self.defaultDepositGuaranteePreset
 		) {
 			self.defaultDepositGuarantee = defaultDepositGuarantee
 		}

--- a/RadixWalletTests/ProfileTests/TestCases/ProfileBuilderTest.swift
+++ b/RadixWalletTests/ProfileTests/TestCases/ProfileBuilderTest.swift
@@ -3,6 +3,11 @@ import Foundation
 import XCTest
 
 final class ProfileBuilderTest: TestCase {
+	// MOVE ME to some appropriate file.
+	func test_tx_guarantee_default_preset_is_99() throws {
+		try XCTAssertEqual(AppPreferences.Transaction().defaultDepositGuarantee, RETDecimal(value: "0.99"))
+	}
+
 	func test_profile_builder() throws {
 		let profile = ProfileBuilder()
 			.bdfs()

--- a/RadixWalletTests/ProfileTests/TestCases/ProfileBuilderTest.swift
+++ b/RadixWalletTests/ProfileTests/TestCases/ProfileBuilderTest.swift
@@ -5,7 +5,13 @@ import XCTest
 final class ProfileBuilderTest: TestCase {
 	// MOVE ME to some appropriate file.
 	func test_tx_guarantee_default_preset_is_99() throws {
-		try XCTAssertEqual(AppPreferences.Transaction().defaultDepositGuarantee, RETDecimal(value: "0.99"))
+		let expectedPreset = try RETDecimal(value: "0.99")
+		XCTAssertEqual(AppPreferences.Transaction.defaultDepositGuaranteePreset, expectedPreset)
+		XCTAssertEqual(AppPreferences.Transaction().defaultDepositGuarantee, expectedPreset)
+		XCTAssertEqual(AppPreferences().transaction.defaultDepositGuarantee, expectedPreset)
+
+		// assert the initializer of Transaction still uses the passed in value...
+		XCTAssertEqual(AppPreferences.Transaction(defaultDepositGuarantee: 2).defaultDepositGuarantee, 2)
 	}
 
 	func test_profile_builder() throws {


### PR DESCRIPTION
For new Profiles, the TX Guarantee of 99% will be used by default for all Guarantees, instead of 100%.

Rationale: Will decrease risk of transactions failing where 100% guarantee could not be met, but 99% could.