### PR TITLE
Assertion failed message for Guarantees

### DIFF
--- a/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Live.swift
+++ b/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Live.swift
@@ -177,7 +177,6 @@ extension TXFailureStatus {
 	}
 }
 
-/// Rudimentary parser combinator algo
 extension TXFailureStatus.Reason {
 	public init(_ rawError: String?) {
 		guard let rawError else {
@@ -185,52 +184,10 @@ extension TXFailureStatus.Reason {
 			return
 		}
 
-		let components = rawError.components(separatedBy: CharacterSet(charactersIn: "()"))
-			.flatMap { $0.split(separator: " ") }
-			.map(String.init)
-
-		switch components.first {
-		case "ApplicationError":
-			guard let wrappedCase = ApplicationError(components.dropFirst()) else {
-				self = .unknown
-				return
-			}
-			self = .applicationError(wrappedCase)
-		default:
+		if rawError.contains("AssertionFailed") {
+			self = .applicationError(.worktopError(.assertionFailed))
+		} else {
 			self = .unknown
-		}
-	}
-}
-
-extension TXFailureStatus.Reason.ApplicationError {
-	init?(_ rawErrorComponents: ArraySlice<String>) {
-		guard let firstComponent = rawErrorComponents.first else {
-			return nil
-		}
-
-		switch firstComponent {
-		case "WorktopError":
-			guard let wrappedCase = WorktopError(rawErrorComponents.dropFirst()) else {
-				return nil
-			}
-			self = .worktopError(wrappedCase)
-		default:
-			return nil
-		}
-	}
-}
-
-extension TXFailureStatus.Reason.ApplicationError.WorktopError {
-	init?(_ rawErrorComponents: ArraySlice<String>) {
-		guard let firstComponent = rawErrorComponents.first else {
-			return nil
-		}
-
-		switch firstComponent {
-		case "AssertionFailed":
-			self = .assertionFailed
-		default:
-			return nil
 		}
 	}
 }

--- a/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Live.swift
+++ b/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Live.swift
@@ -165,8 +165,8 @@ public enum TXFailureStatus: LocalizedError, Sendable, Hashable {
 extension TXFailureStatus {
 	public enum Reason: Sendable, Hashable, Equatable {
 		public enum ApplicationError: Equatable, Sendable, Hashable {
-			public enum WorktopError: String, Sendable, Hashable, Equatable {
-				case assertionFailed = "AssertionFailed"
+			public enum WorktopError: Sendable, Hashable, Equatable {
+				case assertionFailed
 			}
 
 			case worktopError(WorktopError)

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
@@ -14,6 +14,9 @@ extension SubmitTransaction.State {
 extension SubmitTransaction.State.TXStatus {
 	var display: String {
 		switch self {
+		case .failed(.applicationError(.worktopError(.assertionFailed))),
+		     .permanentlyRejected(.applicationError(.worktopError(.assertionFailed))):
+			L10n.TransactionStatus.AssertionFailure.text
 		case .failed:
 			L10n.TransactionStatus.Failed.text
 		case .permanentlyRejected:

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
@@ -16,8 +16,8 @@ public struct SubmitTransaction: Sendable, FeatureReducer {
 			case submitted
 			case committedSuccessfully
 			case temporarilyRejected(remainingProcessingTime: Int)
-			case permanentlyRejected
-			case failed
+			case permanentlyRejected(TXFailureStatus.Reason)
+			case failed(TXFailureStatus.Reason)
 		}
 
 		public let notarizedTX: NotarizeTransactionResponse
@@ -131,16 +131,16 @@ public struct SubmitTransaction: Sendable, FeatureReducer {
 				} catch let error as TXFailureStatus {
 					// Error is always TXFailureStatus, just that it is erased to generic Error
 					switch error {
-					case .permanentlyRejected:
-						await send(.internal(.statusUpdate(.permanentlyRejected)))
+					case let .permanentlyRejected(reason):
+						await send(.internal(.statusUpdate(.permanentlyRejected(reason))))
 					case let .temporarilyRejected(epoch):
 						await send(.internal(.statusUpdate(
 							.temporarilyRejected(
 								remainingProcessingTime: Int(endEpoch - epoch.rawValue) * epochDurationInMinutes
 							)
 						)))
-					case .failed:
-						await send(.internal(.statusUpdate(.failed)))
+					case let .failed(reason):
+						await send(.internal(.statusUpdate(.failed(reason))))
 					}
 				}
 			}


### PR DESCRIPTION
## Description
Identify and display the proper error message for assertion failed errors.

## How to test

### Happy path (or test variation 1)

1. Execute tx with guarantees > 100%
2. Observe failure message

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/15e1b0e7-547b-469e-8b96-f9e43df70705


