### PR TITLE
Home Screen load laggines

### DIFF
--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Interface.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Interface.swift
@@ -10,6 +10,8 @@ public struct AccountPortfoliosClient: Sendable {
 	/// Will return the portfolio after fetch, as well will notify any subscribes through `portfolioForAccount`
 	public var fetchAccountPortfolio: FetchAccountPortfolio
 
+	public var portfolioUpdates: PortfolioUpdates
+
 	/// Subscribe to portfolio changes for a given account address
 	public var portfolioForAccount: PortfolioForAccount
 
@@ -21,6 +23,8 @@ extension AccountPortfoliosClient {
 	public typealias FetchAccountPortfolio = @Sendable (_ address: AccountAddress, _ forceResfresh: Bool) async throws -> AccountPortfolio
 	public typealias FetchAccountPortfolios = @Sendable (_ addresses: [AccountAddress], _ forceResfresh: Bool) async throws -> [AccountPortfolio]
 	public typealias PortfolioForAccount = @Sendable (_ address: AccountAddress) async -> AnyAsyncSequence<AccountPortfolio>
+
+	public typealias PortfolioUpdates = @Sendable () -> AnyAsyncSequence<Loadable<[AccountPortfolio]>>
 	public typealias Portfolios = @Sendable () -> [AccountPortfolio]
 }
 

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
@@ -137,6 +137,11 @@ extension AccountPortfoliosClient: DependencyKey {
 
 				return portfolio
 			},
+			portfolioUpdates: {
+				state.portfoliosSubject
+					.map { $0.map { Array($0.values) } }
+					.eraseToAnyAsyncSequence()
+			},
 			portfolioForAccount: { address in
 				await state.portfolioForAccount(address)
 			},

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
@@ -66,6 +66,9 @@ extension AccountPortfoliosClient: DependencyKey {
 
 				let accounts = try await onLedgerEntitiesClient.getAccounts(accountAddresses).map(\.nonEmptyVaults)
 
+				let portfolios = accounts.map { AccountPortfolio(account: $0) }
+				await state.handlePortfoliosUpdate(portfolios)
+
 				/// Put together all resources from already fetched and new accounts
 				let currentAccounts = state.portfoliosSubject.value.wrappedValue.map { $0.values.map(\.account) } ?? []
 				let allResources: [ResourceAddress] = {
@@ -115,9 +118,6 @@ extension AccountPortfoliosClient: DependencyKey {
 						await state.setTokenPrices(prices)
 					}
 				}
-
-				let portfolios = accounts.map { AccountPortfolio(account: $0) }
-				await state.handlePortfoliosUpdate(portfolios)
 
 				// Load additional details
 				_ = await accounts.parallelMap(fetchPoolAndStakeUnitsDetails)

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Mock.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Mock.swift
@@ -4,7 +4,7 @@ extension AccountPortfoliosClient: TestDependencyKey {
 
 	public static let testValue = AccountPortfoliosClient(
 		fetchAccountPortfolios: unimplemented("\(AccountPortfoliosClient.self).fetchAccountPortfolios"),
-		fetchAccountPortfolio: unimplemented("\(AccountPortfoliosClient.self).fetchAccountPortfolio"),
+		fetchAccountPortfolio: unimplemented("\(AccountPortfoliosClient.self).fetchAccountPortfolio"), portfolioUpdates: unimplemented("\(AccountPortfoliosClient.self).fetchAccountPortfolio"),
 		portfolioForAccount: unimplemented("\(AccountPortfoliosClient.self).portfolioForAccount"),
 		portfolios: unimplemented("\(AccountPortfoliosClient.self).portfolios")
 	)
@@ -12,6 +12,7 @@ extension AccountPortfoliosClient: TestDependencyKey {
 	public static let noop = AccountPortfoliosClient(
 		fetchAccountPortfolios: { _, _ in throw NoopError() },
 		fetchAccountPortfolio: { _, _ in throw NoopError() },
+		portfolioUpdates: { fatalError() },
 		portfolioForAccount: { _ in fatalError() },
 		portfolios: { fatalError() }
 	)

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Mock.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Mock.swift
@@ -4,7 +4,8 @@ extension AccountPortfoliosClient: TestDependencyKey {
 
 	public static let testValue = AccountPortfoliosClient(
 		fetchAccountPortfolios: unimplemented("\(AccountPortfoliosClient.self).fetchAccountPortfolios"),
-		fetchAccountPortfolio: unimplemented("\(AccountPortfoliosClient.self).fetchAccountPortfolio"), portfolioUpdates: unimplemented("\(AccountPortfoliosClient.self).fetchAccountPortfolio"),
+		fetchAccountPortfolio: unimplemented("\(AccountPortfoliosClient.self).fetchAccountPortfolio"),
+		portfolioUpdates: unimplemented("\(AccountPortfoliosClient.self).fetchAccountPortfolio"),
 		portfolioForAccount: unimplemented("\(AccountPortfoliosClient.self).portfolioForAccount"),
 		portfolios: unimplemented("\(AccountPortfoliosClient.self).portfolios")
 	)
@@ -12,7 +13,7 @@ extension AccountPortfoliosClient: TestDependencyKey {
 	public static let noop = AccountPortfoliosClient(
 		fetchAccountPortfolios: { _, _ in throw NoopError() },
 		fetchAccountPortfolio: { _, _ in throw NoopError() },
-		portfolioUpdates: { fatalError() },
+		portfolioUpdates: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
 		portfolioForAccount: { _ in fatalError() },
 		portfolios: { fatalError() }
 	)

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
@@ -45,7 +45,7 @@ extension AccountPortfoliosClient.State {
 	}
 
 	func portfolioForAccount(_ address: AccountAddress) -> AnyAsyncSequence<AccountPortfoliosClient.AccountPortfolio> {
-		portfoliosSubject.compactMap { $0[address].unwrap()?.wrappedValue }.eraseToAnyAsyncSequence()
+		portfoliosSubject.compactMap { $0[address].unwrap()?.wrappedValue }.removeDuplicates().eraseToAnyAsyncSequence()
 	}
 
 	private func setOrUpdateAccountPortfolio(_ portfolio: AccountPortfoliosClient.AccountPortfolio) {

--- a/RadixWallet/Clients/TokenPriceClient/TokenPriceClient+Live.swift
+++ b/RadixWallet/Clients/TokenPriceClient/TokenPriceClient+Live.swift
@@ -48,6 +48,7 @@ extension TokenPricesClient.TokenPrices {
 		formatter.numberStyle = .decimal
 		formatter.maximumFractionDigits = Int(RETDecimal.maxDivisibility)
 		formatter.roundingMode = .down
+		formatter.decimalSeparator = "." // Enfore dot notation for RETDecimal
 
 		self = tokenPricesResponse.tokens.reduce(into: [:]) { partialResult, next in
 			let trimmed = formatter.string(for: next.price) ?? ""

--- a/RadixWallet/Core/FeaturePrelude/Loadable.swift
+++ b/RadixWallet/Core/FeaturePrelude/Loadable.swift
@@ -313,23 +313,25 @@ extension Loadable {
         case let (.idle, .success(otherValue)),
             let (.loading, .success(otherValue)),
             let (.failure, .success(otherValue)):
-            print("Refresh from nonSuccessValue")
+
             self = .success(otherValue)
 
         // Update to new value only if it changed
         case let (.success(oldValue), .success(newValue)):
-            print("Refresh from success value with success")
             if oldValue != newValue {
                 self = .success(valueChangeMap(oldValue, newValue))
             }
 
         // If current state is success, don't update if `other` is loading or failed
         case (.success, _):
-            print("Refresh from success value with other value")
             break
+
+        case (.loading, .loading),
+            (.idle, .idle):
+            break
+
         // If current state is other than .success
         case let (_, other):
-            print("Refresh from any value with other value")
             self = other
         }
     }

--- a/RadixWallet/Core/FeaturePrelude/Loadable.swift
+++ b/RadixWallet/Core/FeaturePrelude/Loadable.swift
@@ -292,6 +292,10 @@ extension Loadable {
         concat(other).map(join)
     }
 
+    public func reduce<Element>(_ join: (Element) -> Void) -> Void where Value == Array<Element> {
+
+    }
+
     public mutating func mutateValue(_ mutate: (inout Value) -> Void) {
         switch self {
         case .idle, .loading, .failure:

--- a/RadixWallet/Core/FeaturePrelude/Loadable.swift
+++ b/RadixWallet/Core/FeaturePrelude/Loadable.swift
@@ -307,18 +307,29 @@ extension Loadable {
     public mutating func refresh(
         from other: Loadable<Value>,
         valueChangeMap: (_ old: Value, _ new: Value) -> Value = { _, new in new }
-    ) {
+    ) where Value: Equatable {
         switch (self, other) {
-        // If `other` is success, update the content regardless of the current state
-        case let (.success(oldValue), .success(newValue)):
-            self = .success(valueChangeMap(oldValue, newValue))
-        case let (_, .success(otherValue)):
+        // Update to success if no current value
+        case let (.idle, .success(otherValue)),
+            let (.loading, .success(otherValue)),
+            let (.failure, .success(otherValue)):
+            print("Refresh from nonSuccessValue")
             self = .success(otherValue)
+
+        // Update to new value only if it changed
+        case let (.success(oldValue), .success(newValue)):
+            print("Refresh from success value with success")
+            if oldValue != newValue {
+                self = .success(valueChangeMap(oldValue, newValue))
+            }
+
         // If current state is success, don't update if `other` is loading or failed
         case (.success, _):
+            print("Refresh from success value with other value")
             break
         // If current state is other than .success
         case let (_, other):
+            print("Refresh from any value with other value")
             self = other
         }
     }

--- a/RadixWallet/Core/FeaturePrelude/Loadable.swift
+++ b/RadixWallet/Core/FeaturePrelude/Loadable.swift
@@ -223,7 +223,7 @@ extension Loadable {
 		}
 	}
 
-	public func firstd(where predicate: (Value.Element) -> Bool) -> Loadable<Value.Element?> where Value: Sequence {
+	public func first(where predicate: (Value.Element) -> Bool) -> Loadable<Value.Element?> where Value: Sequence {
 		switch self {
 		case .idle:
 			return .idle

--- a/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
@@ -195,7 +195,7 @@ public struct AssetsView: Sendable, FeatureReducer {
 				return nil
 			}
 
-			return .init(sections: sections)
+			return .init(sections: sections, destination: state.resources.fungibleTokenList?.destination)
 		}()
 
 		state.accountPortfolio.refresh(from: .success(portfolio))
@@ -210,7 +210,8 @@ public struct AssetsView: Sendable, FeatureReducer {
 					},
 					isSelected: mode.nonXrdRowSelected(poolUnit.resource.resourceAddress)
 				)
-			}.asIdentifiable()
+			}.asIdentifiable(),
+			destination: state.resources.poolUnitsList?.destination
 		)
 
 		let stakes = portfolio.account.poolUnitResources.radixNetworkStakes
@@ -234,13 +235,14 @@ public struct AssetsView: Sendable, FeatureReducer {
 						dict[resource] = selectedtokens
 					}
 				} : nil,
-			stakeUnitDetails: state.accountPortfolio.stakeUnitDetails.flatten()
+			stakeUnitDetails: state.accountPortfolio.stakeUnitDetails.flatten(),
+			destination: state.resources.stakeUnitList?.destination
 		)
 
 		state.totalFiatWorth.refresh(from: portfolio.totalFiatWorth)
 		state.resources = .init(
 			fungibleTokenList: fungibleTokenList,
-			nonFungibleTokenList: !nfts.isEmpty ? .init(rows: .init(uniqueElements: nfts)) : nil,
+			nonFungibleTokenList: !nfts.isEmpty ? .init(rows: nfts.asIdentifiable(), destination: state.resources.nonFungibleTokenList?.destination) : nil,
 			stakeUnitList: stakeUnitList,
 			poolUnitsList: poolUnitList
 		)

--- a/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
@@ -250,6 +250,8 @@ public struct AssetsView: Sendable, FeatureReducer {
 extension AccountPortfoliosClient.AccountPortfolio {
 	mutating func refresh(from portfolio: AccountPortfoliosClient.AccountPortfolio) {
 		self.account = portfolio.account
+		self.isCurrencyAmountVisible = portfolio.isCurrencyAmountVisible
+		self.fiatCurrency = portfolio.fiatCurrency
 		self.stakeUnitDetails.refresh(from: portfolio.stakeUnitDetails)
 		self.poolUnitDetails.refresh(from: portfolio.poolUnitDetails)
 	}

--- a/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
@@ -249,6 +249,7 @@ public struct AssetsView: Sendable, FeatureReducer {
 
 extension AccountPortfoliosClient.AccountPortfolio {
 	mutating func refresh(from portfolio: AccountPortfoliosClient.AccountPortfolio) {
+		self.account = portfolio.account
 		self.stakeUnitDetails.refresh(from: portfolio.stakeUnitDetails)
 		self.poolUnitDetails.refresh(from: portfolio.poolUnitDetails)
 	}

--- a/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
@@ -249,7 +249,6 @@ public struct AssetsView: Sendable, FeatureReducer {
 
 extension AccountPortfoliosClient.AccountPortfolio {
 	mutating func refresh(from portfolio: AccountPortfoliosClient.AccountPortfolio) {
-		self.account = portfolio.account
 		self.stakeUnitDetails.refresh(from: portfolio.stakeUnitDetails)
 		self.poolUnitDetails.refresh(from: portfolio.poolUnitDetails)
 	}

--- a/RadixWallet/Features/AssetsFeature/Components/FungibleAssetList/FungibleAssetList+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/FungibleAssetList/FungibleAssetList+Reducer.swift
@@ -4,16 +4,10 @@ import SwiftUI
 // MARK: - FungibleAssetList
 public struct FungibleAssetList: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
-		public var sections: IdentifiedArrayOf<FungibleAssetList.Section.State>
+		public var sections: IdentifiedArrayOf<FungibleAssetList.Section.State> = []
 
 		@PresentationState
 		public var destination: Destination.State?
-
-		public init(
-			sections: IdentifiedArrayOf<FungibleAssetList.Section.State> = []
-		) {
-			self.sections = sections
-		}
 	}
 
 	@CasePathable

--- a/RadixWallet/Features/AssetsFeature/Components/HelperViews/ResourceBalance/ResourceBalanceView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/HelperViews/ResourceBalance/ResourceBalanceView.swift
@@ -386,7 +386,7 @@ extension ResourceBalanceView {
 							}
 							.disabled(onTap == nil)
 							.buttonStyle(.borderless)
-							.roundedCorners(strokeColor: .red) // .app.gray3
+							.roundedCorners(strokeColor: .app.gray3)
 						}
 					}
 				}

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+Reducer.swift
@@ -7,10 +7,6 @@ public struct NonFungibleAssetList: Sendable, FeatureReducer {
 
 		@PresentationState
 		public var destination: Destination.State?
-
-		public init(rows: IdentifiedArrayOf<NonFungibleAssetList.Row.State>) {
-			self.rows = rows
-		}
 	}
 
 	public enum ChildAction: Sendable, Equatable {

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/ValidatorStakeView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/Components/ValidatorStakeView.swift
@@ -83,6 +83,7 @@ struct ValidatorStakeView: View {
 				onTap: onTap,
 				onClaimAllTapped: onClaimAllTapped
 			)
+			.padding(.small1)
 		}
 	}
 }

--- a/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/StakeUnitList.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/StakeUnitList/StakeUnitList.swift
@@ -23,11 +23,13 @@ public struct StakeUnitList: Sendable, FeatureReducer {
 			account: OnLedgerEntity.Account,
 			selectedLiquidStakeUnits: IdentifiedArrayOf<OnLedgerEntity.OwnedFungibleResource>?,
 			selectedStakeClaimTokens: SelectedStakeClaimTokens?,
-			stakeUnitDetails: Loadable<IdentifiedArrayOf<OnLedgerEntitiesClient.OwnedStakeDetails>>
+			stakeUnitDetails: Loadable<IdentifiedArrayOf<OnLedgerEntitiesClient.OwnedStakeDetails>>,
+			destination: Destination.State? = nil
 		) {
 			self.account = account
 			self.selectedLiquidStakeUnits = selectedLiquidStakeUnits
 			self.selectedStakeClaimTokens = selectedStakeClaimTokens
+			self.destination = destination
 
 			switch stakeUnitDetails {
 			case .idle, .loading:

--- a/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
+++ b/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
@@ -8,12 +8,7 @@ extension Home {
 			public var id: AccountAddress { account.address }
 			public var accountWithInfo: AccountWithInfo
 
-			public var portfolio: Loadable<AccountPortfoliosClient.AccountPortfolio> {
-				didSet {
-					totalFiatWorth.refresh(from: portfolio.totalFiatWorth.flatten())
-				}
-			}
-
+			public var accountWithResources: Loadable<OnLedgerEntity.Account>
 			public var showFiatWorth: Bool = true
 			public var totalFiatWorth: Loadable<FiatWorth>
 
@@ -21,7 +16,7 @@ extension Home {
 				account: Profile.Network.Account
 			) {
 				self.accountWithInfo = .init(account: account)
-				self.portfolio = .loading
+				self.accountWithResources = .loading
 				self.totalFiatWorth = .loading
 			}
 		}
@@ -34,7 +29,8 @@ extension Home {
 		}
 
 		public enum InternalAction: Sendable, Equatable {
-			case accountPortfolioUpdate(AccountPortfoliosClient.AccountPortfolio)
+			case accountUpdated(OnLedgerEntity.Account)
+			case fiatWorthUpdated(Loadable<FiatWorth>)
 			case checkAccountAccessToMnemonic
 		}
 
@@ -52,22 +48,28 @@ extension Home {
 			switch viewAction {
 			case .task:
 				let accountAddress = state.account.address
-				if state.portfolio.wrappedValue == nil {
-					state.portfolio = .loading
-				}
-
 				self.checkAccountAccessToMnemonic(state: &state)
 
-				return .run { [portfolio = state.portfolio] send in
-					for try await accountPortfolio in await accountPortfoliosClient.portfolioForAccount(accountAddress) {
+				return .run { send in
+					for try await accountPortfolio in await accountPortfoliosClient.portfolioForAccount(accountAddress).map(\.account).removeDuplicates() {
 						guard !Task.isCancelled else {
 							return
 						}
 						// if portfolio != .success(accountPortfolio) {
-						await send(.internal(.accountPortfolioUpdate(accountPortfolio)))
+						await send(.internal(.accountUpdated(accountPortfolio)))
 						//  }
 					}
 				}
+				.merge(with: .run { send in
+					for try await fiatWorth in await accountPortfoliosClient.portfolioForAccount(accountAddress).map(\.totalFiatWorth).removeDuplicates() {
+						guard !Task.isCancelled else {
+							return
+						}
+						// if portfolio != .success(accountPortfolio) {
+						await send(.internal(.fiatWorthUpdated(fiatWorth)))
+						//  }
+					}
+				})
 			case .exportMnemonicButtonTapped:
 				return .send(.delegate(.exportMnemonic))
 
@@ -81,26 +83,26 @@ extension Home {
 
 		public func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
 			switch internalAction {
-			case let .accountPortfolioUpdate(portfolio):
-				assert(portfolio.account.address == state.account.address)
+			case let .accountUpdated(account):
+				assert(account.address == state.account.address)
 
-				guard state.portfolio != .success(portfolio) else {
-					return .none
-				}
-
-				state.isDappDefinitionAccount = portfolio.account.metadata.accountType == .dappDefinition
-				state.portfolio.refresh(from: .success(portfolio))
+				state.isDappDefinitionAccount = account.metadata.accountType == .dappDefinition
+				state.accountWithResources.refresh(from: .success(account))
 
 				return .send(.internal(.checkAccountAccessToMnemonic))
 
 			case .checkAccountAccessToMnemonic:
 				checkAccountAccessToMnemonic(state: &state)
 				return .none
+
+			case let .fiatWorthUpdated(fiatWorth):
+				state.totalFiatWorth.refresh(from: fiatWorth)
+				return .none
 			}
 		}
 
 		private func checkAccountAccessToMnemonic(state: inout State) {
-			state.checkAccountAccessToMnemonic(portfolio: state.portfolio.account.wrappedValue)
+			state.checkAccountAccessToMnemonic(portfolio: state.accountWithResources.wrappedValue)
 		}
 	}
 }

--- a/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
+++ b/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
@@ -78,9 +78,13 @@ extension Home {
 				state.isDappDefinitionAccount = portfolio.account.metadata.accountType == .dappDefinition
 
 				assert(portfolio.account.address == state.account.address)
-
-				state.portfolio = .success(portfolio)
-				state.totalFiatWorth.refresh(from: portfolio.totalFiatWorth)
+				var newValue = state.portfolio
+				newValue.refresh(from: .success(portfolio))
+				if state.portfolio != newValue {
+					state.portfolio = newValue
+				}
+				// state.portfolio.refresh(from: .success(portfolio))
+				// state.totalFiatWorth.refresh(from: portfolio.totalFiatWorth)
 				return .send(.internal(.checkAccountAccessToMnemonic))
 
 			case .checkAccountAccessToMnemonic:

--- a/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
+++ b/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
@@ -47,17 +47,9 @@ extension Home {
 		public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 			switch viewAction {
 			case .task:
-				let accountAddress = state.account.address
 				self.checkAccountAccessToMnemonic(state: &state)
 
-				return .run { send in
-					for try await fiatWorth in await accountPortfoliosClient.portfolioForAccount(accountAddress).map(\.totalFiatWorth).removeDuplicates() {
-						guard !Task.isCancelled else {
-							return
-						}
-						await send(.internal(.fiatWorthUpdated(fiatWorth)))
-					}
-				}
+				return .none
 
 			case .exportMnemonicButtonTapped:
 				return .send(.delegate(.exportMnemonic))

--- a/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
+++ b/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
@@ -58,12 +58,14 @@ extension Home {
 
 				self.checkAccountAccessToMnemonic(state: &state)
 
-				return .run { send in
+				return .run { [portfolio = state.portfolio] send in
 					for try await accountPortfolio in await accountPortfoliosClient.portfolioForAccount(accountAddress) {
 						guard !Task.isCancelled else {
 							return
 						}
+						// if portfolio != .success(accountPortfolio) {
 						await send(.internal(.accountPortfolioUpdate(accountPortfolio)))
+						//  }
 					}
 				}
 			case .exportMnemonicButtonTapped:

--- a/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
+++ b/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+Reducer.swift
@@ -51,25 +51,14 @@ extension Home {
 				self.checkAccountAccessToMnemonic(state: &state)
 
 				return .run { send in
-					for try await accountPortfolio in await accountPortfoliosClient.portfolioForAccount(accountAddress).map(\.account).removeDuplicates() {
-						guard !Task.isCancelled else {
-							return
-						}
-						// if portfolio != .success(accountPortfolio) {
-						await send(.internal(.accountUpdated(accountPortfolio)))
-						//  }
-					}
-				}
-				.merge(with: .run { send in
 					for try await fiatWorth in await accountPortfoliosClient.portfolioForAccount(accountAddress).map(\.totalFiatWorth).removeDuplicates() {
 						guard !Task.isCancelled else {
 							return
 						}
-						// if portfolio != .success(accountPortfolio) {
 						await send(.internal(.fiatWorthUpdated(fiatWorth)))
-						//  }
 					}
-				})
+				}
+
 			case .exportMnemonicButtonTapped:
 				return .send(.delegate(.exportMnemonic))
 

--- a/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+View.swift
+++ b/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+View.swift
@@ -47,7 +47,7 @@ extension Home.AccountRow {
 			self.appearanceID = state.account.appearanceID
 			self.showFiatWorth = state.showFiatWorth
 			self.fiatWorth = state.totalFiatWorth
-			self.isLoadingResources = state.portfolio.isLoading
+			self.isLoadingResources = state.accountWithResources.isLoading
 
 			self.tag = .init(state: state)
 			self.isLedgerAccount = state.isLedgerAccount
@@ -55,7 +55,7 @@ extension Home.AccountRow {
 			self.mnemonicHandlingCallToAction = state.mnemonicHandlingCallToAction
 
 			// Resources
-			guard let portfolio = state.portfolio.wrappedValue else {
+			guard let accountWithResources = state.accountWithResources.wrappedValue else {
 				self.fungibleResourceIcons = []
 				self.nonFungibleResourcesCount = 0
 				self.stakedValidatorsCount = 0
@@ -64,13 +64,13 @@ extension Home.AccountRow {
 				return
 			}
 
-			let fungibleResources = portfolio.account.fungibleResources
+			let fungibleResources = accountWithResources.fungibleResources
 			let xrdIcon: [Thumbnail.TokenContent] = fungibleResources.xrdResource != nil ? [.xrd] : []
 			let otherIcons: [Thumbnail.TokenContent] = fungibleResources.nonXrdResources.map { .other($0.metadata.iconURL) }
 			self.fungibleResourceIcons = xrdIcon + otherIcons
-			self.nonFungibleResourcesCount = portfolio.account.nonFungibleResources.count
-			self.stakedValidatorsCount = portfolio.account.poolUnitResources.radixNetworkStakes.count
-			self.poolUnitsCount = portfolio.account.poolUnitResources.poolUnits.count
+			self.nonFungibleResourcesCount = accountWithResources.nonFungibleResources.count
+			self.stakedValidatorsCount = accountWithResources.poolUnitResources.radixNetworkStakes.count
+			self.poolUnitsCount = accountWithResources.poolUnitResources.poolUnits.count
 		}
 	}
 

--- a/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
@@ -6,7 +6,7 @@ extension Home.State {
 		.init(
 			hasNotification: shouldWriteDownPersonasSeedPhrase,
 			showRadixBanner: showRadixBanner,
-			totalFiatWorth: totalFiatWorth
+			totalFiatWorth: showFiatWorth ? totalFiatWorth : nil
 		)
 	}
 }

--- a/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
@@ -391,6 +391,28 @@ public struct Home: Sendable, FeatureReducer {
 			}
 		}
 	}
+
+	private func loadFiatValues() -> Effect<Action> {
+		.run { _ in
+			let observable = accountPortfoliosClient.portfolioUpdates()
+				.compactMap { portfoliosLoadable in
+					portfoliosLoadable.wrappedValue?.reduce(into: [AccountAddress: Loadable<FiatWorth>]()) { partialResult, portfolio in
+						partialResult[portfolio.account.address] = portfolio.totalFiatWorth
+					}
+				}
+				.filter {
+					Array($0.values).reduce(+)
+				}
+
+			//            for try await accountResources in accountPortfoliosClient.portfolioUpdates()
+			//                .map {
+			//                $0.map { $0.map { ($0.account.address, $0.totalFiatWorth)
+			//            } } }.removeDuplicates() {
+			//                guard !Task.isCancelled else { return }
+			//                await send(.internal(.accountsResourcesLoaded(accountResources)))
+			//            }
+		}
+	}
 }
 
 extension Home.State {

--- a/RadixWallet/Features/HomeFeature/Models/AccountWithInfoHolder.swift
+++ b/RadixWallet/Features/HomeFeature/Models/AccountWithInfoHolder.swift
@@ -47,12 +47,13 @@ extension DeviceFactorSourceControlled {
 			return
 		}
 
-		guard let xrdResource else {
-			mnemonicHandlingCallToAction = nil
-			return
-		}
+//		guard let xrdResource else {
+//			mnemonicHandlingCallToAction = nil
+//			return
+//		}
 
-		let hasValue = xrdResource.amount.nominalAmount > 0
+		// Disabled for now, to be revised with MFA
+		let hasValue = true // xrdResource.amount.nominalAmount > 0
 		let hasAlreadyBackedUpMnemonic = userDefaults.getFactorSourceIDOfBackedUpMnemonics().contains(factorSourceID)
 		let exportMnemonicNeeded = !hasAlreadyBackedUpMnemonic && hasValue
 


### PR DESCRIPTION
## Description
Reduce the slowness of loading the home screen.

After introducing fiatWorth on home screen, there are many more events which do trigger the updated of the state.
TCA seems to have issues when many actions are emitted in quick-ish succession, it has high impact on the main thread since all of the actions are resolved on the main thread.

There is still a small lag with this, potentially SharedState would help resolve this.

# Loading Before

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/020def6d-3c3f-494d-9823-7e0761de24e5

# Loading After

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/96be6621-8ce7-4279-977d-50df1d1632b7


#CPU load before
<img width="475" alt="Screenshot 2024-03-19 at 14 27 08" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/c1ee5312-411a-4505-ba58-d51bfbfda287">

# CPU load after
<img width="352" alt="Screenshot 2024-03-19 at 14 28 17" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/26ff688d-affa-4814-b4a5-f55a8d3bb8d5">


