### PR TITLE
[ABW-3021] Close button placement on sheets

### DIFF
--- a/RadixWallet/Core/FeaturePrelude/SlideUpPanel/SlideUpPanel+View.swift
+++ b/RadixWallet/Core/FeaturePrelude/SlideUpPanel/SlideUpPanel+View.swift
@@ -10,28 +10,23 @@ extension SlideUpPanel.State {
 
 // MARK: - WithNavigationBar
 public struct WithNavigationBar<Content: View>: View {
-	private let closeButtonLocation: ToolbarItemPlacement
 	private let closeAction: () -> Void
 	private let content: Content
 
 	public init(
-		_ closeButtonLocation: ToolbarItemPlacement = .primaryAction,
 		closeAction: @escaping () -> Void,
 		@ViewBuilder content: () -> Content
 	) {
 		self.init(
-			closeButtonLocation,
 			closeAction: closeAction,
 			content: content()
 		)
 	}
 
 	init(
-		_ closeButtonLocation: ToolbarItemPlacement = .primaryAction,
 		closeAction: @escaping () -> Void,
 		content: Content
 	) {
-		self.closeButtonLocation = closeButtonLocation
 		self.content = content
 		self.closeAction = closeAction
 	}
@@ -41,7 +36,7 @@ public struct WithNavigationBar<Content: View>: View {
 			content
 				.presentationDragIndicator(.visible)
 				.toolbar {
-					ToolbarItem(placement: closeButtonLocation) {
+					ToolbarItem(placement: .cancellationAction) {
 						CloseButton(action: closeAction)
 					}
 				}
@@ -64,10 +59,9 @@ extension View {
 	}
 
 	public func withNavigationBar(
-		_ closeButtonLocation: ToolbarItemPlacement = .primaryAction,
 		closeAction: @escaping () -> Void
 	) -> some View {
-		WithNavigationBar(closeButtonLocation, closeAction: closeAction, content: self)
+		WithNavigationBar(closeAction: closeAction, content: self)
 	}
 }
 

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+View.swift
@@ -146,7 +146,7 @@ private extension View {
 		return sheet(store: destinationStore.scope(state: \.reviewTransaction, action: \.reviewTransaction)) {
 			// FIXME: Should use DappInteractionClient instead to schedule a transaction
 			TransactionReview.View(store: $0)
-				.withNavigationBar(.topBarLeading) {
+				.withNavigationBar {
 					store.send(.view(.closeTransactionButtonTapped))
 				}
 		}

--- a/RadixWallet/Features/AccountRecoveryScan/Children/AccountRecoveryScanInProgress/AccountRecoveryScanInProgress+View.swift
+++ b/RadixWallet/Features/AccountRecoveryScan/Children/AccountRecoveryScanInProgress/AccountRecoveryScanInProgress+View.swift
@@ -89,7 +89,7 @@ public extension AccountRecoveryScanInProgress {
 					}
 					.toolbar {
 						if viewStore.showToolbar {
-							ToolbarItem(placement: .automatic) {
+							ToolbarItem(placement: .cancellationAction) {
 								CloseButton {
 									store.send(.view(.closeButtonTapped))
 								}

--- a/RadixWallet/Features/AddLedgerFactorSource/AddLedgerFactorSource+View.swift
+++ b/RadixWallet/Features/AddLedgerFactorSource/AddLedgerFactorSource+View.swift
@@ -41,7 +41,7 @@ extension AddLedgerFactorSource {
 						.padding(.bottom, .large2)
 					}
 					.toolbar {
-						ToolbarItem(placement: .primaryAction) {
+						ToolbarItem(placement: .cancellationAction) {
 							CloseButton {
 								viewStore.send(.closeButtonTapped)
 							}

--- a/RadixWallet/Features/AssetsFeature/Components/DetailsContainerWithHeaderView.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/DetailsContainerWithHeaderView.swift
@@ -108,7 +108,7 @@ struct DetailsContainer<Contents: View>: View {
 			.navigationBarTitleDisplayMode(.inline)
 			.navigationBarInlineTitleFont(.app.secondaryHeader)
 			.toolbar {
-				ToolbarItem(placement: .primaryAction) {
+				ToolbarItem(placement: .cancellationAction) {
 					CloseButton(action: closeButtonAction)
 				}
 			}

--- a/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
+++ b/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+View.swift
@@ -32,7 +32,7 @@ extension CreateAccountCoordinator {
 						destinations(for: $0, shouldDisplayNavBar: viewStore.shouldDisplayNavBar)
 							.toolbar {
 								if viewStore.shouldDisplayNavBar {
-									ToolbarItem(placement: .primaryAction) {
+									ToolbarItem(placement: .cancellationAction) {
 										CloseButton {
 											store.send(.view(.closeButtonTapped))
 										}

--- a/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersona+View.swift
@@ -95,7 +95,7 @@ extension EditPersona {
 					.navigationTitle(viewStore.personaLabel)
 					.navigationBarTitleDisplayMode(.inline)
 					.toolbar {
-						ToolbarItem(placement: .primaryAction) {
+						ToolbarItem(placement: .cancellationAction) {
 							CloseButton { viewStore.send(.closeButtonTapped) }
 						}
 					}

--- a/RadixWallet/Features/EditPersonaFeature/EditPersonaAddEntryKinds+View.swift
+++ b/RadixWallet/Features/EditPersonaFeature/EditPersonaAddEntryKinds+View.swift
@@ -48,7 +48,7 @@ extension EditPersonaAddEntryKinds {
 					.navigationBarTitleDisplayMode(.inline)
 					.navigationBarInlineTitleFont(.app.secondaryHeader)
 					.toolbar {
-						ToolbarItem(placement: .primaryAction) {
+						ToolbarItem(placement: .cancellationAction) {
 							CloseButton(action: { viewStore.send(.closeButtonTapped) })
 						}
 					}

--- a/RadixWallet/Features/NewConnectionFeature/Coordinator/NewConnection+View.swift
+++ b/RadixWallet/Features/NewConnectionFeature/Coordinator/NewConnection+View.swift
@@ -44,7 +44,7 @@ extension NewConnection {
 					}
 				}
 				.toolbar {
-					ToolbarItem(placement: .primaryAction) {
+					ToolbarItem(placement: .cancellationAction) {
 						CloseButton {
 							store.send(.view(.closeButtonTapped))
 						}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ConfirmSkippingBDFS/ConfirmSkippingBDFS+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ConfirmSkippingBDFS/ConfirmSkippingBDFS+View.swift
@@ -33,7 +33,7 @@ extension ConfirmSkippingBDFS {
 					.padding(.bottom, .medium2)
 				}
 				.toolbar {
-					ToolbarItem(placement: .primaryAction) {
+					ToolbarItem(placement: .cancellationAction) {
 						CloseButton {
 							store.send(.view(.closeButtonTapped))
 						}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
@@ -16,7 +16,7 @@ extension SelectBackup {
 			WithViewStore(store, observe: { $0 }, send: { .view($0) }) { viewStore in
 				coreView(store, with: viewStore)
 					.toolbar {
-						ToolbarItem(placement: .automatic) {
+						ToolbarItem(placement: .cancellationAction) {
 							CloseButton {
 								store.send(.view(.closeButtonTapped))
 							}

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+View.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/ManualAccountRecoveryScan/ManualAccountRecoveryCoordinator+View.swift
@@ -51,7 +51,7 @@ extension ManualAccountRecoveryCoordinator.View {
 		}
 		.background(.app.white)
 		.toolbar {
-			ToolbarItem(placement: .automatic) {
+			ToolbarItem(placement: .cancellationAction) {
 				CloseButton {
 					store.send(.view(.closeButtonTapped))
 				}

--- a/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator+View.swift
+++ b/RadixWallet/Features/SettingsFeature/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator+View.swift
@@ -16,7 +16,7 @@ extension ImportOlympiaWalletCoordinator {
 				let scanQRStore = store.scope(state: \.scanQR, action: { .child(.scanQR($0)) })
 				ScanMultipleOlympiaQRCodes.View(store: scanQRStore)
 					.toolbar {
-						ToolbarItem(placement: .primaryAction) {
+						ToolbarItem(placement: .cancellationAction) {
 							CloseButton {
 								store.send(.view(.closeButtonTapped))
 							}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewDapps/UnknownDappComponents+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewDapps/UnknownDappComponents+View.swift
@@ -17,7 +17,7 @@ extension UnknownDappComponents {
 			}
 			.navigationBarTitleDisplayMode(.inline)
 			.toolbar {
-				ToolbarItem(placement: .primaryAction) {
+				ToolbarItem(placement: .cancellationAction) {
 					CloseButton { store.send(.view(.closeButtonTapped)) }
 				}
 			}


### PR DESCRIPTION
Jira ticket: [ABW-3021](https://radixdlt.atlassian.net/jira/software/c/projects/ABW/issues/ABW-3021)

## Description
Places the `CloseButton` always on the leading side of the navigation bar of every sheet that includes it.

## Screenshot

| Before |  After |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-01 at 14 52 25](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/410e4acd-e178-4114-b1b8-26f0518d20ac) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-01 at 14 56 17](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/662bc374-a15e-40d9-a9b1-1f935505e8a0) |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-01 at 14 53 25](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/550e74cf-e4aa-42aa-8870-a62cb003a65f) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-01 at 14 56 21](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/9cd18c76-99f6-4693-bda1-7aa36bb60f15) |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-01 at 14 53 37](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/e8aacf9c-7c53-43cd-b9b2-3ce376efbead) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-01 at 14 56 31](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/f705ac51-c3f4-4d05-957c-add081e9b4cb) |
