### PR TITLE
1.5.0 Hot fixes

### DIFF
--- a/Aux/Config/Common.xcconfig
+++ b/Aux/Config/Common.xcconfig
@@ -1,7 +1,7 @@
 // MARK: - Custom flags
 
 /// Application version shared across all targets and flavours
-APP_VERSION = 1.5.0
+APP_VERSION = 1.5.1
 
 /// App Icon base name
 APP_ICON = AppIcon

--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -1105,6 +1105,7 @@
 		835F196D2B3581C300E0B71D /* UnknownDappComponents+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835F196C2B3581C300E0B71D /* UnknownDappComponents+View.swift */; };
 		836878612B4551910029C808 /* UnknownDappComponents+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836878602B4551910029C808 /* UnknownDappComponents+Reducer.swift */; };
 		8370FC5C2B99C780007AD882 /* NPSSurveyClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370FC5B2B99C780007AD882 /* NPSSurveyClient+Interface.swift */; };
+		8381C8B02BBD2CD400A470B4 /* TokenPriceCientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8381C8AF2BBD2CD400A470B4 /* TokenPriceCientTests.swift */; };
 		83823EA72B722DB000827211 /* HTTPClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83823EA62B722DB000827211 /* HTTPClient+Interface.swift */; };
 		83823EAA2B72365000827211 /* TokenPriceClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83823EA92B72365000827211 /* TokenPriceClient+Interface.swift */; };
 		83856D622B0279080026452A /* VerifyMnemonic+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83856D602B0279080026452A /* VerifyMnemonic+View.swift */; };
@@ -2401,6 +2402,7 @@
 		835F196C2B3581C300E0B71D /* UnknownDappComponents+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnknownDappComponents+View.swift"; sourceTree = "<group>"; };
 		836878602B4551910029C808 /* UnknownDappComponents+Reducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UnknownDappComponents+Reducer.swift"; sourceTree = "<group>"; };
 		8370FC5B2B99C780007AD882 /* NPSSurveyClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NPSSurveyClient+Interface.swift"; sourceTree = "<group>"; };
+		8381C8AF2BBD2CD400A470B4 /* TokenPriceCientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenPriceCientTests.swift; sourceTree = "<group>"; };
 		83823EA62B722DB000827211 /* HTTPClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPClient+Interface.swift"; sourceTree = "<group>"; };
 		83823EA92B72365000827211 /* TokenPriceClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TokenPriceClient+Interface.swift"; sourceTree = "<group>"; };
 		83856D602B0279080026452A /* VerifyMnemonic+View.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VerifyMnemonic+View.swift"; sourceTree = "<group>"; };
@@ -6827,6 +6829,14 @@
 			path = NPSSurveyClient;
 			sourceTree = "<group>";
 		};
+		8381C8AE2BBD2CC100A470B4 /* TokenPriceCientTests */ = {
+			isa = PBXGroup;
+			children = (
+				8381C8AF2BBD2CD400A470B4 /* TokenPriceCientTests.swift */,
+			);
+			path = TokenPriceCientTests;
+			sourceTree = "<group>";
+		};
 		83823EA52B722D9000827211 /* HTTPClient */ = {
 			isa = PBXGroup;
 			children = (
@@ -7448,6 +7458,7 @@
 		E6DBA2E02ADEBFB300A38425 /* Clients */ = {
 			isa = PBXGroup;
 			children = (
+				8381C8AE2BBD2CC100A470B4 /* TokenPriceCientTests */,
 				48FF43132AE4364000C568B9 /* KeychainClientTests */,
 				E6DBA2E32ADEBFB300A38425 /* OnLedgerEntitiesClientTests */,
 				E6DBA2EA2ADEBFB300A38425 /* ROLAClientTests */,
@@ -7899,6 +7910,7 @@
 				E6DBA3542ADEBFB300A38425 /* SLIP10PathTests.swift in Sources */,
 				8328806C2AE6725F0014FBF3 /* AccountPreferencesTests.swift in Sources */,
 				E6DBA3192ADEBFB300A38425 /* PackagesEncodingDecodingTests.swift in Sources */,
+				8381C8B02BBD2CD400A470B4 /* TokenPriceCientTests.swift in Sources */,
 				E6DBA34A2ADEBFB300A38425 /* EncryptionTests.swift in Sources */,
 				E6DBA3472ADEBFB300A38425 /* HexStringToDataTests.swift in Sources */,
 				E6DBA35A2ADEBFB300A38425 /* BIP44Tests.swift in Sources */,

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
@@ -133,7 +133,7 @@ extension AccountPortfoliosClient: DependencyKey {
 				cacheClient.removeFolder(.onLedgerEntity(.account(accountAddress.asGeneral)))
 			}
 
-			let account = try await onLedgerEntitiesClient.getAccount(accountAddress)
+			let account = try await onLedgerEntitiesClient.getAccount(accountAddress).nonEmptyVaults
 			let portfolio = AccountPortfolio(account: account)
 
 			let currentResources = await state.tokenPrices.keys

--- a/RadixWallet/Clients/TokenPriceClient/TokenPriceClient+Live.swift
+++ b/RadixWallet/Clients/TokenPriceClient/TokenPriceClient+Live.swift
@@ -45,10 +45,12 @@ extension TokenPricesClient {
 extension TokenPricesClient.TokenPrices {
 	fileprivate init(_ tokenPricesResponse: TokensPriceResponse) {
 		let formatter = NumberFormatter()
+		formatter.locale = Locale(identifier: "en_US_POSIX") // Just ignore the users locale
 		formatter.numberStyle = .decimal
 		formatter.maximumFractionDigits = Int(RETDecimal.maxDivisibility)
 		formatter.roundingMode = .down
-		formatter.decimalSeparator = "." // Enfore dot notation for RETDecimal
+		formatter.decimalSeparator = "." // Enforce dot notation for RETDecimal
+		formatter.usesGroupingSeparator = false // No grouping separator for RETDecimal
 
 		self = tokenPricesResponse.tokens.reduce(into: [:]) { partialResult, next in
 			let trimmed = formatter.string(for: next.price) ?? ""

--- a/RadixWallet/Clients/TokenPriceClient/TokenPriceClient+Live.swift
+++ b/RadixWallet/Clients/TokenPriceClient/TokenPriceClient+Live.swift
@@ -4,11 +4,8 @@ extension TokenPricesClient {
 		@Dependency(\.jsonDecoder) var jsonDecoder
 		@Dependency(\.jsonEncoder) var jsonEncoder
 		@Dependency(\.cacheClient) var cacheClient
-		#if DEBUG
-		let rootURL = URL(string: "https://dev-token-price.extratools.works")!
-		#else
+
 		let rootURL = URL(string: "https://token-price-service.radixdlt.com")!
-		#endif
 
 		@Sendable
 		func getTokenPrices(_ fetchRequest: FetchPricesRequest) async throws -> TokenPrices {

--- a/RadixWallet/Clients/TokenPriceClient/TokenPriceClient+Live.swift
+++ b/RadixWallet/Clients/TokenPriceClient/TokenPriceClient+Live.swift
@@ -40,7 +40,7 @@ extension TokenPricesClient {
 }
 
 extension TokenPricesClient.TokenPrices {
-	fileprivate init(_ tokenPricesResponse: TokensPriceResponse) {
+	public init(_ tokenPricesResponse: TokensPriceResponse) {
 		let formatter = NumberFormatter()
 		formatter.locale = Locale(identifier: "en_US_POSIX") // Just ignore the users locale
 		formatter.numberStyle = .decimal
@@ -59,19 +59,28 @@ extension TokenPricesClient.TokenPrices {
 }
 
 // MARK: - TokensPriceResponse
-private struct TokensPriceResponse: Decodable {
+public struct TokensPriceResponse: Decodable {
 	public let tokens: [TokenPrice]
+
+	public init(tokens: [TokenPrice]) {
+		self.tokens = tokens
+	}
 }
 
 // MARK: TokensPriceResponse.TokenPrice
 extension TokensPriceResponse {
-	struct TokenPrice: Decodable {
+	public struct TokenPrice: Decodable {
 		enum CodingKeys: String, CodingKey {
 			case resourceAddress = "resource_address"
 			case price = "usd_price"
 		}
 
-		let resourceAddress: ResourceAddress
-		let price: Double
+		public let resourceAddress: ResourceAddress
+		public let price: Double
+
+		public init(resourceAddress: ResourceAddress, price: Double) {
+			self.resourceAddress = resourceAddress
+			self.price = price
+		}
 	}
 }

--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressFormat.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressFormat.swift
@@ -74,3 +74,16 @@ extension NonFungibleLocalId {
 		}
 	}
 }
+
+extension TXID {
+	public func formatted(_ format: AddressFormat = .default) -> String {
+		let str = asStr()
+
+		switch format {
+		case .default:
+			return str.truncatedMiddle(keepFirst: 4, last: 6)
+		case .full, .raw:
+			return str
+		}
+	}
+}

--- a/RadixWallet/EngineKit/TXID.swift
+++ b/RadixWallet/EngineKit/TXID.swift
@@ -3,10 +3,6 @@ import EngineToolkit
 public typealias TXID = TransactionHash
 
 extension TXID {
-	public func formatted(_ format: AddressFormat = .default) -> String {
-		asStr()
-	}
-
 	public var hex: String {
 		bytes().hex()
 	}

--- a/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
@@ -144,9 +144,10 @@ public struct AssetsView: Sendable, FeatureReducer {
 
 	public func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
 		switch internalAction {
-		case let .portfolioUpdated(portfolio):
+		case var .portfolioUpdated(portfolio):
 			state.isLoadingResources = false
 			state.isRefreshing = false
+			portfolio.account = portfolio.account.nonEmptyVaults
 			updateFromPortfolio(state: &state, from: portfolio)
 			return .none
 		}

--- a/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+View.swift
+++ b/RadixWallet/Features/HomeFeature/Children/AccountRow/Home+AccountRow+View.swift
@@ -55,7 +55,7 @@ extension Home.AccountRow {
 			self.mnemonicHandlingCallToAction = state.mnemonicHandlingCallToAction
 
 			// Resources
-			guard let accountWithResources = state.accountWithResources.wrappedValue else {
+			guard let accountWithResources = state.accountWithResources.wrappedValue?.nonEmptyVaults else {
 				self.fungibleResourceIcons = []
 				self.nonFungibleResourcesCount = 0
 				self.stakedValidatorsCount = 0

--- a/RadixWalletTests/Clients/TokenPriceCientTests/TokenPriceCientTests.swift
+++ b/RadixWalletTests/Clients/TokenPriceCientTests/TokenPriceCientTests.swift
@@ -1,0 +1,82 @@
+@testable import Radix_Wallet_Dev
+import XCTest
+
+final class TokenPriceCientTests: XCTestCase {
+	func test_zeroPrice() {
+		validateDecimalPriceConversion(0, expected: .zero())
+	}
+
+	func test_noDecimalPlaces_1() {
+		validateDecimalPriceConversion(10, expected: 10)
+	}
+
+	func test_noDecimalPlaces_2() {
+		validateDecimalPriceConversion(10000, expected: 10000)
+	}
+
+	func test_noDecimalPlaces_3() {
+		validateDecimalPriceConversion(10_000_000, expected: 10_000_000)
+	}
+
+	func test_withDecimalPlaces_1() {
+		validateDecimalPriceConversion(1.99, expected: try! .init(value: "1.99"))
+	}
+
+	func test_withDecimalPlaces_2() {
+		validateDecimalPriceConversion(1.000099, expected: try! .init(value: "1.000099"))
+	}
+
+	func test_belowOne_1() {
+		validateDecimalPriceConversion(0.99, expected: 0.99)
+	}
+
+	func test_belowOne_2() {
+		validateDecimalPriceConversion(0.000099, expected: try! .init(value: "0.000099"))
+	}
+
+	// NOTE: All of the below values would be rounded to 14 decimal places
+	//       As it seems that Swift number formatter for Double cannot express more decimals.
+	func test_closeToRETDecimalDivisibility() {
+		// 17 decimal places
+		validateDecimalPriceConversion(1.12345678901234567, expected: try! .init(value: "1.12345678901235"))
+	}
+
+	func test_maxRETDecimalDivisibility() {
+		// 18 decimal places
+		validateDecimalPriceConversion(1.123456789012345678, expected: try! .init(value: "1.12345678901235"))
+	}
+
+	func test_overMaxRETDecimalDivisibility() {
+		// 22 decimal places
+		validateDecimalPriceConversion(1.1234567890123456789012, expected: try! .init(value: "1.12345678901235"))
+	}
+
+	private func validateDecimalPriceConversion(
+		_ price: Double,
+		expected: RETDecimal,
+		file: StaticString = #filePath,
+		line: UInt = #line
+	) {
+		let tokenPrice = tokenWithPrice(price)
+		guard let decimalPrice = TokenPricesClient.TokenPrices(tokenPrice).first?.value else {
+			XCTFail("Could'nt convert \(tokenPrice) to RETDecimal", file: file, line: line)
+			return
+		}
+		XCTAssertEqual(
+			decimalPrice,
+			expected,
+			"expected \(expected.formattedPlain()), got \(decimalPrice.formattedPlain())",
+			file: file,
+			line: line
+		)
+	}
+
+	private func tokenWithPrice(_ price: Double) -> TokensPriceResponse {
+		TokensPriceResponse(tokens: [
+			TokensPriceResponse.TokenPrice(
+				resourceAddress: try! .init(validatingAddress: "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd"),
+				price: price
+			),
+		])
+	}
+}


### PR DESCRIPTION
1.5.0 Hot fixes

- Properly truncate price before initialising the RETDecimal.
- Apply empty vaults when refreshing the portfolio for a given account.
- TXID truncation.

FLOOP worth:
<img width="256" alt="Screenshot 2024-04-03 at 09 07 07" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/8e104505-f562-4149-b5ee-b29ece7f2026">

Tokens with near zero value are still shown
<img width="256" alt="Screenshot 2024-04-03 at 09 07 43" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/1df5a26d-021a-4d43-b077-274f7eccf4f7">

TXID truncation
<img width="256" alt="Screenshot 2024-04-03" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/e5d4eb53-bda3-4d1b-8184-9f52a85ff346">

