### PR TITLE
Downcase flavour for setting appIdKey

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :ios do
 
     desc "Populates SensitiveInfo.plist with environment values"
     lane :populate_sensitive_info do |options|
-        appIdKey = "APPS_FLYER_APP_ID_%s" % options[:flavour]
+        appIdKey = "APPS_FLYER_APP_ID_%s" % options[:flavour].downcase
         Dotenv.load "../.env.secret"
         update_plist( 
                 plist_path: "Aux/SensitiveInfo.plist",


### PR DESCRIPTION
Complements https://github.com/radixdlt/babylon-wallet-ios/pull/1073

## Description
This PR fixes the definition of the `appIdKey` used on CD to populate the Sensitive Info.