### PR TITLE
Remove the usage of crashing initialiser of IdentifiedArray

### DIFF
--- a/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Interface.swift
+++ b/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Interface.swift
@@ -226,7 +226,7 @@ public struct SigningFactor: Sendable, Hashable, Identifiable {
 	) {
 		self.init(
 			factorSource: factorSource,
-			signers: .init(rawValue: .init(uniqueElements: [signer]))! // ok to force unwrap since we know we have one element.
+			signers: .init(rawValue: [signer].asIdentifiable())! // ok to force unwrap since we know we have one element.
 		)
 	}
 }

--- a/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
+++ b/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
@@ -373,7 +373,7 @@ func signingFactors(
 				signingFactors[factorSource.kind] = existingArray // write back to Dictionary
 			} else {
 				// trivial case,
-				signingFactors[factorSource.kind] = .init(uniqueElements: [sigingFactor])
+				signingFactors[factorSource.kind] = [sigingFactor].asIdentifiable()
 			}
 		}
 	}

--- a/RadixWallet/Clients/GatewaysClient/GatewaysClient+Test.swift
+++ b/RadixWallet/Clients/GatewaysClient/GatewaysClient+Test.swift
@@ -23,7 +23,7 @@ extension GatewaysClient: TestDependencyKey {
 	public static let noop = Self(
 		currentGatewayValues: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
 		gatewaysValues: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
-		getAllGateways: { .init(rawValue: .init(uniqueElements: [.nebunet]))! },
+		getAllGateways: { .init(rawValue: [.nebunet].asIdentifiable())! },
 		getCurrentGateway: { .nebunet },
 		addGateway: { _ in },
 		removeGateway: { _ in },

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+Reducer.swift
@@ -28,7 +28,7 @@ public struct TransferAccountList: Sendable, FeatureReducer {
 		public init(fromAccount: Profile.Network.Account) {
 			self.init(
 				fromAccount: fromAccount,
-				receivingAccounts: .init(uniqueElements: [.empty(canBeRemovedWhenEmpty: false)])
+				receivingAccounts: [.empty(canBeRemovedWhenEmpty: false)].asIdentifiable()
 			)
 		}
 	}

--- a/RadixWallet/Features/ChooseAccounts/ChooseAccounts+Reducer.swift
+++ b/RadixWallet/Features/ChooseAccounts/ChooseAccounts+Reducer.swift
@@ -89,9 +89,9 @@ public struct ChooseAccounts: Sendable, FeatureReducer {
 		switch internalAction {
 		case let .loadAccountsResult(.success(accounts)):
 			// Uniqueness is guaranteed as per `Profile.Network.Accounts`
-			state.availableAccounts = .init(uniqueElements: accounts).filter {
+			state.availableAccounts = accounts.filter {
 				!state.filteredAccounts.contains($0.address)
-			}
+			}.asIdentifiable()
 			return .none
 
 		case let .loadAccountsResult(.failure(error)):

--- a/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+Reducer.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+Reducer.swift
@@ -181,7 +181,7 @@ struct AccountPermissionChooseAccounts: Sendable, FeatureReducer {
 
 				let chosenAccounts: AccountPermissionChooseAccountsResult = .withProofOfOwnership(
 					challenge: signedAuthChallenge.challenge,
-					IdentifiedArrayOf<P2P.Dapp.Response.Accounts.WithProof>.init(uniqueElements: walletAccountsWithProof)
+					walletAccountsWithProof.asIdentifiable()
 				)
 				return .send(.delegate(.continue(accessKind: state.accessKind, chosenAccounts: chosenAccounts)))
 

--- a/RadixWallet/Features/DappInteractionFeature/Children/Login/Coordinator/Login.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Login/Coordinator/Login.swift
@@ -124,14 +124,14 @@ struct Login: Sendable, FeatureReducer {
 			} else {
 				nil
 			}
-			state.personas = .init(uniqueElements:
-				personas.map { persona in
-					PersonaRow.State(
-						persona: persona,
-						lastLogin: persona == lastLoggedInPersona ? authorizedPersonaSimple?.lastLogin : nil
-					)
-				}
-			)
+			state.personas = personas.map { persona in
+				PersonaRow.State(
+					persona: persona,
+					lastLogin: persona == lastLoggedInPersona ? authorizedPersonaSimple?.lastLogin : nil
+				)
+			}
+			.asIdentifiable()
+
 			if
 				let lastLoggedInPersona,
 				let extractedLastLoggedInPersona = state.personas.remove(id: lastLoggedInPersona.id)

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -266,7 +266,7 @@ struct DappInteractionFlow: Sendable, FeatureReducer {
 				setAccountsResponse(
 					to: ongoingAccountsWithoutProofOfOwnership.requestItem,
 					accessKind: .ongoing,
-					chosenAccounts: .withoutProofOfOwnership(.init(uniqueElements: ongoingAccountsWithoutProofOfOwnership.accounts)),
+					chosenAccounts: .withoutProofOfOwnership(ongoingAccountsWithoutProofOfOwnership.accounts.asIdentifiable()),
 					into: &state
 				)
 			}

--- a/RadixWallet/Features/DappsAndPersonas/AuthorizedDApps/AuthorizedDApps+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/AuthorizedDApps/AuthorizedDApps+View.swift
@@ -75,7 +75,7 @@ extension AuthorizedDapps.State {
 			)
 		}
 
-		return .init(dApps: .init(uniqueElements: dAppViewStates))
+		return .init(dApps: dAppViewStates.asIdentifiable())
 	}
 }
 

--- a/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails.swift
+++ b/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails.swift
@@ -286,7 +286,7 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 			let dApps = try await authorizedDappsClient.getDappsAuthorizedByPersona(oldPersona.id)
 				.map(State.DappInfo.init)
 
-			return await .general(persona, dApps: addingDappMetadata(to: .init(uniqueElements: dApps)))
+			return await .general(persona, dApps: addingDappMetadata(to: dApps.asIdentifiable()))
 		}
 	}
 

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Child/List/PersonaList+Reducer.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Child/List/PersonaList+Reducer.swift
@@ -23,7 +23,7 @@ public struct PersonaList: Sendable, FeatureReducer {
 			dApp: Profile.Network.AuthorizedDappDetailed
 		) {
 			self.init(
-				personas: .init(uniqueElements: dApp.detailedAuthorizedPersonas.map(Persona.State.init)),
+				personas: dApp.detailedAuthorizedPersonas.map(Persona.State.init).asIdentifiable(),
 				strategy: .dApp(dApp.dAppDefinitionAddress)
 			)
 		}
@@ -74,7 +74,7 @@ public struct PersonaList: Sendable, FeatureReducer {
 					guard result.count == ids.count else {
 						throw UpdatePersonaError.personasMissingFromClient(ids.subtracting(result.map(\.id)))
 					}
-					await send(.internal(.personasLoaded(.init(uniqueElements: result))))
+					await send(.internal(.personasLoaded(result.asIdentifiable())))
 				}
 			} catch: { error, _ in
 				loggerGlobal.error("Failed to update personas from client, error: \(error)")

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+Reducer.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Coordinator/PersonasCoordinator+Reducer.swift
@@ -141,7 +141,7 @@ public struct PersonasCoordinator: Sendable, FeatureReducer {
 			return .run { send in
 				let dApps = try await authorizedDappsClient.getDappsAuthorizedByPersona(persona.id)
 					.map(PersonaDetails.State.DappInfo.init)
-				let personaDetailsState = PersonaDetails.State(.general(persona, dApps: .init(uniqueElements: dApps)))
+				let personaDetailsState = PersonaDetails.State(.general(persona, dApps: dApps.asIdentifiable()))
 				await send(.internal(.loadedPersonaDetails(personaDetailsState)))
 			}
 

--- a/RadixWallet/Features/GatewaySettingsFeature/Components/GatewayList/GatewayList+View.swift
+++ b/RadixWallet/Features/GatewaySettingsFeature/Components/GatewayList/GatewayList+View.swift
@@ -53,8 +53,9 @@ struct GatewayList_Preview: PreviewProvider {
 
 extension GatewayList.State {
 	static let previewValue = Self(
-		gateways: .init(uniqueElements: [
+		gateways: [
 			.previewValue1, .previewValue2, .previewValue3,
-		]))
+		].asIdentifiable()
+	)
 }
 #endif

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
@@ -363,9 +363,10 @@ extension TransactionReview {
 		let proofs = try await accountProofs
 			.map { try ResourceAddress(validatingAddress: $0.addressString()) }
 			.asyncMap(extractProofInfo)
+
 		guard !proofs.isEmpty else { return nil }
 
-		return TransactionReviewProofs.State(proofs: .init(uniqueElements: proofs))
+		return TransactionReviewProofs.State(proofs: proofs.asIdentifiable())
 	}
 
 	private func extractProofInfo(_ address: ResourceAddress) async throws -> ProofEntity {

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -423,7 +423,7 @@ public struct TransactionReview: Sendable, FeatureReducer {
 
 		case .deposits(.delegate(.showCustomizeGuarantees)):
 			guard let guarantees = state.deposits?.accounts.customizableGuarantees, !guarantees.isEmpty else { return .none }
-			state.destination = .customizeGuarantees(.init(guarantees: .init(uniqueElements: guarantees)))
+			state.destination = .customizeGuarantees(.init(guarantees: guarantees.asIdentifiable()))
 
 			return .none
 

--- a/RadixWalletTests/Features/GatewaySettingsFeatureTests/GatewaySettingsFeatureTests.swift
+++ b/RadixWalletTests/Features/GatewaySettingsFeatureTests/GatewaySettingsFeatureTests.swift
@@ -16,21 +16,21 @@ final class GatewaySettingsFeatureTests: TestCase {
 
 	func test_whenViewAppeared_thenCurrentGatewayAndGatewayListIsLoaded() async throws {
 		// given
-		let otherGateways: [Radix.Gateway] = [.stokenet, .rcnet]
+		let otherGateways: [Radix.Gateway] = [.stokenet, .rcnet].asIdentifiable()
 		let currentGateway: Radix.Gateway = .mainnet
 		let gateways = try! Gateways(
 			current: currentGateway,
-			other: .init(uniqueElements: otherGateways)
+			other: otherGateways
 		)
 		let store = TestStore(
 			initialState: GatewaySettings.State(),
 			reducer: GatewaySettings.init
 		) {
 			$0.gatewaysClient.getAllGateways = {
-				.init(rawValue: .init(uniqueElements: otherGateways))!
+				.init(rawValue: otherGateways)!
 			}
 			$0.gatewaysClient.gatewaysValues = { AsyncLazySequence([
-				try! .init(current: currentGateway, other: .init(uniqueElements: otherGateways)),
+				try! .init(current: currentGateway, other: otherGateways),
 			]
 			).eraseToAnyAsyncSequence() }
 		}
@@ -79,16 +79,16 @@ final class GatewaySettingsFeatureTests: TestCase {
 	func test_whenNonCurrentGatewayRemovalIsConfirmed_removeGateway() async throws {
 		// given
 		let gatewayToBeDeleted = GatewayRow.State(gateway: .rcnet, isSelected: false, canBeDeleted: true)
-		let otherGateways: [Radix.Gateway] = [.stokenet, .rcnet]
+		let otherGateways: [Radix.Gateway] = [.stokenet, .rcnet].asIdentifiable()
 		let currentGateway: Radix.Gateway = .mainnet
-		let otherAfterDeletion: [Radix.Gateway] = [.stokenet]
+		let otherAfterDeletion: [Radix.Gateway] = [.stokenet].asIdentifiable()
 		let gateways = try! Gateways(
 			current: currentGateway,
-			other: .init(uniqueElements: otherGateways)
+			other: otherGateways
 		)
 		let gatewaysAfterDeletion = try! Gateways(
 			current: currentGateway,
-			other: .init(uniqueElements: otherAfterDeletion)
+			other: otherAfterDeletion
 		)
 
 		var initialState = GatewaySettings.State()


### PR DESCRIPTION
Jira ticket: https://radixdlt.atlassian.net/browse/ABW-3148

## Description
We have several crash reports relating to transaction that did contain proofs, and a problems seem to be having multiple identical proofs which caused the app to crash:

<img width="1305" alt="Screenshot 2024-04-08 at 12 27 50" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/3dc28dd4-694b-4cbd-9a45-5338f1584020">

The problem was the usage of the crashing initialiser of IdentifiedArray. I went a bit overboard and replaced all these usages with safe `asIdentifiable`.