### PR TITLE
[AVW-2908] Transaction Review Header

### DIFF
--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+View.swift
@@ -93,7 +93,12 @@ extension TransactionReview {
 
 	@MainActor
 	public struct View: SwiftUI.View {
+		@SwiftUI.State private var showNavigationTitle: Bool = false
+
 		private let store: StoreOf<TransactionReview>
+
+		private let coordSpace: String = "TransactionReviewCoordSpace"
+		private let navTitleID: String = "TransactionReview.title"
 
 		public init(store: StoreOf<TransactionReview>) {
 			self.store = store
@@ -122,6 +127,8 @@ extension TransactionReview {
 							}
 						}
 					}
+					.navigationTitle(showNavigationTitle ? L10n.TransactionReview.title : "")
+					.navigationBarTitleDisplayMode(.inline)
 					.destinations(with: store)
 					.onAppear {
 						viewStore.send(.appeared)
@@ -220,6 +227,10 @@ extension TransactionReview {
 				.background(.app.gray5.gradient.shadow(.inner(color: shadowColor, radius: 15)))
 				.animation(.easeInOut, value: viewStore.canToggleViewMode ? viewStore.rawTransaction : nil)
 			}
+			.coordinateSpace(name: coordSpace)
+			.onPreferenceChange(PositionsPreferenceKey.self) { positions in
+				showNavigationTitle = (positions[navTitleID]?.maxY ?? 0) <= 0
+			}
 		}
 
 		private let shadowColor: Color = .app.gray2.opacity(0.4)
@@ -232,6 +243,7 @@ extension TransactionReview {
 						.lineLimit(2)
 						.multilineTextAlignment(.leading)
 						.foregroundColor(.app.gray1)
+						.measurePosition(navTitleID, coordSpace: coordSpace)
 
 					Spacer(minLength: 0)
 


### PR DESCRIPTION
Jira ticket: [ABW-2908](https://radixdlt.atlassian.net/browse/ABW-2908)

## Description
Show the title in the navigation bar in Transaction Review, when scrolling away the other title.

### Notes
We could do the same thing in other places too, like the home screen, it's fairly painless.

## How to test

- Go to transaction view and scroll down far enough for the main title to disappear.
 
## Screenshot
<img src="https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/4612d4f7-5a72-432a-a781-365162a1e7eb" width="250" />

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/0bad2d48-0b58-46c7-8386-ddc78e864e75


## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-2908]: https://radixdlt.atlassian.net/browse/ABW-2908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ