### PR TITLE
Fix 400 error in transaction history

### DIFF
--- a/PreviewApps/ManageSecurityStructurePreview/ManageSecurityStructurePreviewApp.swift
+++ b/PreviewApps/ManageSecurityStructurePreview/ManageSecurityStructurePreviewApp.swift
@@ -51,7 +51,7 @@ extension FactorSourcesClient {
 						mnemonic: Mnemonic(phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong", language: .english)
 					)
 				)
-				return NonEmpty<IdentifiedArrayOf<FactorSource>>.init(rawValue: [device.embed()])!
+				return NonEmpty<IdentifiedArrayOf<FactorSource>>(rawValue: [device.embed()])!
 			}
 		}
 }

--- a/PreviewApps/SecurityStructureConfigurationListPreview/SecurityStructureConfigurationListPreviewApp.swift
+++ b/PreviewApps/SecurityStructureConfigurationListPreview/SecurityStructureConfigurationListPreviewApp.swift
@@ -48,7 +48,7 @@ extension FactorSourcesClient {
 						mnemonic: Mnemonic(phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong", language: .english)
 					)
 				)
-				return NonEmpty<IdentifiedArrayOf<FactorSource>>.init(rawValue: [device.embed()])!
+				return NonEmpty<IdentifiedArrayOf<FactorSource>>(rawValue: [device.embed()])!
 			}
 		}
 }

--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -1173,6 +1173,7 @@
 		A41557532B7645E70040AD4E /* TransactionHistory+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41557522B7645E70040AD4E /* TransactionHistory+Reducer.swift */; };
 		A41557552B7645F70040AD4E /* TransactionHistory+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41557542B7645F70040AD4E /* TransactionHistory+View.swift */; };
 		A41557572B7D4BF10040AD4E /* ResourceBalanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41557562B7D4BF10040AD4E /* ResourceBalanceView.swift */; };
+		A43F1E232BC72884001DD3FA /* AnyRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43F1E222BC72884001DD3FA /* AnyRange.swift */; };
 		A462B5792B8210A400C26D20 /* TransactionHistoryClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A462B5782B820D2300C26D20 /* TransactionHistoryClient+Interface.swift */; };
 		A462B57A2B8210A600C26D20 /* TransactionHistoryClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = A462B5762B820D2200C26D20 /* TransactionHistoryClient+Live.swift */; };
 		A462B57B2B8210A900C26D20 /* TransactionHistoryClient+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A462B5772B820D2300C26D20 /* TransactionHistoryClient+Mock.swift */; };
@@ -2477,6 +2478,7 @@
 		A41557522B7645E70040AD4E /* TransactionHistory+Reducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistory+Reducer.swift"; sourceTree = "<group>"; };
 		A41557542B7645F70040AD4E /* TransactionHistory+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistory+View.swift"; sourceTree = "<group>"; };
 		A41557562B7D4BF10040AD4E /* ResourceBalanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceBalanceView.swift; sourceTree = "<group>"; };
+		A43F1E222BC72884001DD3FA /* AnyRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRange.swift; sourceTree = "<group>"; };
 		A462B5762B820D2200C26D20 /* TransactionHistoryClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistoryClient+Live.swift"; sourceTree = "<group>"; };
 		A462B5772B820D2300C26D20 /* TransactionHistoryClient+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistoryClient+Mock.swift"; sourceTree = "<group>"; };
 		A462B5782B820D2300C26D20 /* TransactionHistoryClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistoryClient+Interface.swift"; sourceTree = "<group>"; };
@@ -5953,6 +5955,7 @@
 				48CFC13C2ADC10D900E77A5C /* Selection+Extra.swift */,
 				48CFC13D2ADC10D900E77A5C /* SwiftUINavigation+Extra.swift */,
 				48CFC13E2ADC10D900E77A5C /* TaskResult+Unit.swift */,
+				A43F1E222BC72884001DD3FA /* AnyRange.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -8759,6 +8762,7 @@
 				48CFC5AD2ADC10DA00E77A5C /* WarningView.swift in Sources */,
 				48CFC5982ADC10DA00E77A5C /* ControlState.swift in Sources */,
 				A41266F92B160F4C00EA38E9 /* ManualAccountRecoveryCoordinator+View.swift in Sources */,
+				A43F1E232BC72884001DD3FA /* AnyRange.swift in Sources */,
 				48CFC2CA2ADC10D900E77A5C /* NonFungibleResourceAsset+Reducer+View.swift in Sources */,
 				48CFC4B72ADC10DA00E77A5C /* TransactionPreviewResponse.swift in Sources */,
 				48CFC3CA2ADC10D900E77A5C /* BIP39+Wordlists.swift in Sources */,

--- a/RadixWallet/Clients/TransactionHistoryClient/TransactionHistoryClient+Interface.swift
+++ b/RadixWallet/Clients/TransactionHistoryClient/TransactionHistoryClient+Interface.swift
@@ -23,7 +23,7 @@ public struct TransactionHistoryRequest: Sendable, Hashable {
 
 	// MARK: - Parameters
 	public struct Parameters: Sendable, Hashable {
-		public let period: Range<Date>
+		public let period: AnyRange<Date>
 		public let filters: [TransactionFilter]
 		public let direction: TransactionHistory.Direction
 	}

--- a/RadixWallet/Clients/TransactionHistoryClient/TransactionHistoryClient+Live.swift
+++ b/RadixWallet/Clients/TransactionHistoryClient/TransactionHistoryClient+Live.swift
@@ -234,8 +234,8 @@ extension TransactionHistoryClient {
 extension TransactionHistoryRequest {
 	var gatewayRequest: GatewayAPI.StreamTransactionsRequest {
 		.init(
-			atLedgerState: .init(timestamp: parameters.period.upperBound),
-			fromLedgerState: .init(timestamp: parameters.period.lowerBound),
+			atLedgerState: parameters.period.upperBound.map { .init(timestamp: $0) },
+			fromLedgerState: parameters.period.lowerBound.map { .init(timestamp: $0) },
 			cursor: cursor,
 			limitPerPage: 20,
 			manifestResourcesFilter: manifestResourcesFilter(parameters.filters),

--- a/RadixWallet/Core/FeaturePrelude/Extensions/AnyRange.swift
+++ b/RadixWallet/Core/FeaturePrelude/Extensions/AnyRange.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+// MARK: - AnyRange
+public struct AnyRange<Bound: Comparable & Sendable>: Sendable {
+	public let lowerBound: Bound?
+	public let upperBound: Bound?
+
+	public init(lowerBound: Bound? = nil, upperBound: Bound? = nil) {
+		self.lowerBound = lowerBound
+		self.upperBound = upperBound
+	}
+}
+
+// MARK: Equatable
+extension AnyRange: Equatable where Bound: Equatable {}
+
+// MARK: Hashable
+extension AnyRange: Hashable where Bound: Hashable {}
+
+extension AnyRange {
+	public func contains(_ element: Bound) -> Bool {
+		switch (lowerBound, upperBound) {
+		case let (lowerBound?, upperBound?):
+			(lowerBound ..< upperBound).contains(element)
+		case (let lowerBound?, nil):
+			lowerBound <= element
+		case (nil, let upperBound?):
+			element < upperBound
+		case (nil, nil):
+			true
+		}
+	}
+
+	public var isEmpty: Bool {
+		lowerBound != nil && lowerBound == upperBound
+	}
+}
+
+extension AnyRange {
+	public func contains(_ otherRange: AnyRange) -> Bool {
+		switch (otherRange.lowerBound, otherRange.upperBound) {
+		case let (lowerBound?, upperBound?):
+			contains(lowerBound) && contains(upperBound)
+		case (let lowerBound?, nil):
+			contains(lowerBound) && upperBound == nil
+		case (nil, let upperBound?):
+			lowerBound == nil && contains(upperBound)
+		case (nil, nil):
+			lowerBound == nil && upperBound == nil
+		}
+	}
+
+	public var polymorphic: PolyMorhpic {
+		switch (lowerBound, upperBound) {
+		case let (lowerBound?, upperBound?):
+			.range(lowerBound ..< upperBound)
+		case (let lowerBound?, nil):
+			.partialRangeFrom(lowerBound...)
+		case (nil, let upperBound?):
+			.partialRangeUpTo(..<upperBound)
+		case (nil, nil):
+			.unboundedRange
+		}
+	}
+
+	public enum PolyMorhpic: Sendable {
+		case range(Range<Bound>)
+		case partialRangeFrom(PartialRangeFrom<Bound>)
+		case partialRangeUpTo(PartialRangeUpTo<Bound>)
+		case unboundedRange
+	}
+}

--- a/RadixWallet/Core/FeaturePrelude/Extensions/AnyRange.swift
+++ b/RadixWallet/Core/FeaturePrelude/Extensions/AnyRange.swift
@@ -35,38 +35,3 @@ extension AnyRange {
 		lowerBound != nil && lowerBound == upperBound
 	}
 }
-
-extension AnyRange {
-	public func contains(_ otherRange: AnyRange) -> Bool {
-		switch (otherRange.lowerBound, otherRange.upperBound) {
-		case let (lowerBound?, upperBound?):
-			contains(lowerBound) && contains(upperBound)
-		case (let lowerBound?, nil):
-			contains(lowerBound) && upperBound == nil
-		case (nil, let upperBound?):
-			lowerBound == nil && contains(upperBound)
-		case (nil, nil):
-			lowerBound == nil && upperBound == nil
-		}
-	}
-
-	public var polymorphic: PolyMorhpic {
-		switch (lowerBound, upperBound) {
-		case let (lowerBound?, upperBound?):
-			.range(lowerBound ..< upperBound)
-		case (let lowerBound?, nil):
-			.partialRangeFrom(lowerBound...)
-		case (nil, let upperBound?):
-			.partialRangeUpTo(..<upperBound)
-		case (nil, nil):
-			.unboundedRange
-		}
-	}
-
-	public enum PolyMorhpic: Sendable {
-		case range(Range<Bound>)
-		case partialRangeFrom(PartialRangeFrom<Bound>)
-		case partialRangeUpTo(PartialRangeUpTo<Bound>)
-		case unboundedRange
-	}
-}

--- a/RadixWallet/Core/SharedModels/Assets/OnLedgerEntity.swift
+++ b/RadixWallet/Core/SharedModels/Assets/OnLedgerEntity.swift
@@ -130,7 +130,7 @@ extension OnLedgerEntity {
 			public func mapArray<T>(_ transform: (Value) throws -> [T]?) rethrows -> [ValueAtStateVersion<T>]? {
 				guard let elements = try transform(value) else { return nil }
 				return elements.map { (element: T) in
-					ValueAtStateVersion<T>.init(value: element, lastUpdatedAtStateVersion: lastUpdatedAtStateVersion)
+					ValueAtStateVersion<T>(value: element, lastUpdatedAtStateVersion: lastUpdatedAtStateVersion)
 				}
 			}
 		}

--- a/RadixWallet/Cryptography/Mnemonic/BIP39/BIP39+WordList.swift
+++ b/RadixWallet/Cryptography/Mnemonic/BIP39/BIP39+WordList.swift
@@ -129,7 +129,7 @@ extension BIP39.WordList {
 		}
 
 		let arrayOfCandidates = words.filter { $0.word.starts(with: string) }
-		let setOfCandidates = OrderedSet<BIP39.Word>.init(uncheckedUniqueElements: arrayOfCandidates)
+		let setOfCandidates = OrderedSet<BIP39.Word>(uncheckedUniqueElements: arrayOfCandidates)
 
 		guard
 			let candidates = NonEmpty<OrderedSet<BIP39.Word>>(rawValue: setOfCandidates)

--- a/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+Reducer.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+Reducer.swift
@@ -115,7 +115,7 @@ struct AccountPermissionChooseAccounts: Sendable, FeatureReducer {
 				)))
 			}
 
-			guard let signers = NonEmpty<Set<EntityPotentiallyVirtual>>.init(rawValue: Set(selectedAccounts.map { EntityPotentiallyVirtual.account($0) })) else {
+			guard let signers = NonEmpty<Set<EntityPotentiallyVirtual>>(rawValue: Set(selectedAccounts.map { EntityPotentiallyVirtual.account($0) })) else {
 				return .send(.delegate(.continue(
 					accessKind: state.accessKind,
 					chosenAccounts: .withoutProofOfOwnership(selectedAccounts)

--- a/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList.swift
+++ b/RadixWallet/Features/ManageSecurityStructure/Children/FactorSourcesOfKindList/FactorSourcesOfKindList.swift
@@ -222,7 +222,7 @@ public struct FactorSourcesOfKindList<FactorSourceOfKind: Sendable & Hashable>: 
 					}
 					return specificType.extract(from: $0) as! FactorSourceOfKind
 				}
-				return IdentifiedArrayOf<FactorSourceOfKind>.init(uncheckedUniqueElements: filteredType)
+				return IdentifiedArrayOf<FactorSourceOfKind>(uncheckedUniqueElements: filteredType)
 			}
 			await send(.internal(.loadedFactorSources(result)))
 		}

--- a/RadixWallet/Features/TransactionHistory/TransactionHistory+Reducer.swift
+++ b/RadixWallet/Features/TransactionHistory/TransactionHistory+Reducer.swift
@@ -207,12 +207,10 @@ public struct TransactionHistory: Sendable, FeatureReducer {
 
 	public func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
 		switch internalAction {
-		case let .loadedFirstTransactionDate(date):
+		case let .loadedFirstTransactionDate(firstDate):
 			state.loading.isLoading = false
-			let lastDate: Date = .now
-			// Make sure firstDate is firmly in the past, even when there have been no transactions (i.e. date is nil)
-			let firstDate = date ?? lastDate.addingTimeInterval(-24 * 3600)
-			state.fullPeriod = firstDate ..< lastDate
+			guard let firstDate else { return .none }
+			state.fullPeriod = firstDate ..< .now
 			state.availableMonths = (try? .init(period: state.fullPeriod)) ?? []
 
 			return loadTransactionsFirstTime(state: &state)

--- a/RadixWallet/Features/TransactionHistory/TransactionHistory+Reducer.swift
+++ b/RadixWallet/Features/TransactionHistory/TransactionHistory+Reducer.swift
@@ -50,13 +50,13 @@ public struct TransactionHistory: Sendable, FeatureReducer {
 		var currentMonth: DateRangeItem.ID
 
 		/// Values related to loading. Note that `parameters` are set **when receiving the response**
-		var loading: Loading = .init(pivotDate: .now, filters: [])
+		var loading: Loading = .init(pivotDate: nil, filters: [])
 
 		/// Workaround, TCA sends the sectionDisappeared after we dismiss, causing a run-time warning
 		var didDismiss: Bool = false
 
 		struct Loading: Hashable, Sendable {
-			let pivotDate: Date
+			let pivotDate: Date? // nil means "now"
 			let filters: [TransactionFilter]
 
 			var isLoading: Bool = false
@@ -209,8 +209,8 @@ public struct TransactionHistory: Sendable, FeatureReducer {
 		switch internalAction {
 		case let .loadedFirstTransactionDate(date):
 			state.loading.isLoading = false
-			let lastDate: Date = .init(timeIntervalSinceNow: -10)
-			let firstDate = date ?? lastDate
+			let lastDate: Date = .now
+			let firstDate = date ?? lastDate.addingTimeInterval(-24 * 3600)
 			state.fullPeriod = firstDate ..< lastDate
 			state.availableMonths = (try? .init(period: state.fullPeriod)) ?? []
 
@@ -259,16 +259,20 @@ public struct TransactionHistory: Sendable, FeatureReducer {
 	/// Load history for the provided month, keeping the same period and filters
 	func loadTransactionsForMonth(_ month: Date, state: inout State) -> Effect<Action> {
 		guard let endOfMonth = Calendar.current.date(byAdding: .month, value: 1, to: month) else { return .none }
-		let clampedEndOfMonth = min(endOfMonth, state.fullPeriod.upperBound)
-
-		if state.sections.dateSpan?.contains(month ..< clampedEndOfMonth) == true {
-			state.setScrollTarget(.beforeDate(clampedEndOfMonth))
-			return .none
+		if endOfMonth > state.fullPeriod.upperBound {
+			state.sections = []
+			state.loading = state.loading.withNewPivotDate(nil)
+			return loadHistory(.down, scrollTarget: .latestTransaction, state: &state)
+		} else {
+			if state.sections.dateSpan?.contains(month ..< endOfMonth) == true {
+				// We have already loaded all transactions for the chosen month
+				state.setScrollTarget(.beforeDate(endOfMonth))
+				return .none
+			}
+			state.sections = []
+			state.loading = state.loading.withNewPivotDate(endOfMonth)
+			return loadHistory(.down, scrollTarget: .beforeDate(endOfMonth), state: &state)
 		}
-
-		state.sections = []
-		state.loading = state.loading.withNewPivotDate(clampedEndOfMonth)
-		return loadHistory(.down, scrollTarget: .beforeDate(clampedEndOfMonth), state: &state)
 	}
 
 	/// Loads (more) transactions
@@ -287,9 +291,9 @@ public struct TransactionHistory: Sendable, FeatureReducer {
 
 	/// Makes the TransactionHitosryRequest. **NB: don't call this directly**, instead use the specialised functions like `loadHistoryForMonth`
 	func loadHistory(_ direction: Direction, scrollTarget: ScrollTarget? = nil, state: inout State) -> Effect<Action> {
-		let parameters = state.requestParameters(for: direction)
+		guard let parameters = state.requestParameters(for: direction) else { return .none }
 		let cursor = state.loading[cursor: direction]
-		guard !state.loading.isLoading, cursor != .loadedAll, !parameters.period.isEmpty else { return .none }
+		guard !state.loading.isLoading, cursor != .loadedAll else { return .none }
 
 		state.loading.isLoading = true
 
@@ -341,8 +345,7 @@ extension TransactionHistory.State {
 	}
 
 	var shouldAlsoLoadUpwards: Bool {
-		let upwardsPeriod = requestParameters(for: .up).period
-		guard !upwardsPeriod.isEmpty else { return false }
+		guard let upwardsPeriod = requestParameters(for: .up)?.period else { return false }
 		guard let lastLoaded = sections.dateSpan?.upperBound else { return true }
 		return !upwardsPeriod.contains(lastLoaded)
 	}
@@ -374,17 +377,33 @@ extension TransactionHistory.State {
 		}
 	}
 
-	func requestParameters(for direction: TransactionHistory.Direction) -> TransactionHistoryRequest.Parameters {
-		.init(
-			period: fullPeriod.split(before: direction == .down, point: loading.pivotDate),
+	func requestParameters(for direction: TransactionHistory.Direction) -> TransactionHistoryRequest.Parameters? {
+		guard let period = period(for: direction), !period.isEmpty else { return nil }
+		return .init(
+			period: period,
 			filters: loading.filters,
 			direction: direction
 		)
 	}
+
+	private func period(for direction: TransactionHistory.Direction) -> AnyRange<Date>? {
+		// Note that pivotDate == nil means that we are loading right up to the present
+		switch direction {
+		case .down:
+			.init(lowerBound: fullPeriod.lowerBound, upperBound: loading.pivotDate)
+		case .up:
+			if let pivotDate = loading.pivotDate {
+				.init(lowerBound: pivotDate)
+			} else {
+				// The up direction does not make sense
+				nil
+			}
+		}
+	}
 }
 
 extension TransactionHistory.State.Loading {
-	func withNewPivotDate(_ newPivotDate: Date) -> Self {
+	func withNewPivotDate(_ newPivotDate: Date?) -> Self {
 		.init(pivotDate: newPivotDate, filters: filters)
 	}
 
@@ -427,18 +446,6 @@ extension TransactionHistory.TransactionSection: CustomStringConvertible {
 extension Range {
 	func contains(_ otherRange: Range) -> Bool {
 		otherRange.lowerBound >= lowerBound && otherRange.upperBound <= upperBound
-	}
-
-	/// Returns the part of the range that is before (or after, respectivel) the provided point
-	func split(before: Bool, point: Bound) -> Range {
-		let clamped = Swift.min(Swift.max(point, lowerBound), upperBound)
-		return before ? lowerBound ..< clamped : clamped ..< upperBound
-	}
-}
-
-extension Range<Date> {
-	var debugString: String {
-		"\(lowerBound.formatted(date: .abbreviated, time: .omitted)) -- \(upperBound.formatted(date: .abbreviated, time: .omitted))"
 	}
 }
 

--- a/RadixWallet/Features/TransactionHistory/TransactionHistory+Reducer.swift
+++ b/RadixWallet/Features/TransactionHistory/TransactionHistory+Reducer.swift
@@ -210,6 +210,7 @@ public struct TransactionHistory: Sendable, FeatureReducer {
 		case let .loadedFirstTransactionDate(date):
 			state.loading.isLoading = false
 			let lastDate: Date = .now
+			// Make sure firstDate is firmly in the past, even when there have been no transactions (i.e. date is nil)
 			let firstDate = date ?? lastDate.addingTimeInterval(-24 * 3600)
 			state.fullPeriod = firstDate ..< lastDate
 			state.availableMonths = (try? .init(period: state.fullPeriod)) ?? []

--- a/RadixWallet/Features/TransactionHistory/TransactionHistory+Reducer.swift
+++ b/RadixWallet/Features/TransactionHistory/TransactionHistory+Reducer.swift
@@ -386,16 +386,17 @@ extension TransactionHistory.State {
 	}
 
 	private func period(for direction: TransactionHistory.Direction) -> AnyRange<Date>? {
+		guard !fullPeriod.isEmpty else { return nil }
 		// Note that pivotDate == nil means that we are loading right up to the present
 		switch direction {
 		case .down:
-			.init(lowerBound: fullPeriod.lowerBound, upperBound: loading.pivotDate)
+			return .init(lowerBound: fullPeriod.lowerBound, upperBound: loading.pivotDate)
 		case .up:
 			if let pivotDate = loading.pivotDate {
-				.init(lowerBound: pivotDate)
+				return .init(lowerBound: pivotDate)
 			} else {
 				// The up direction does not make sense
-				nil
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
Slack discussion: [thread](https://rdxworks.slack.com/archives/C05V4202J90/p1712242660583689)

## Description
Some users have experienced an HTTP error, that may be due to them having their clock going a little fast. When we make the requests in transaction history, the Gateway will complain if the upper bound date is more than a few seconds into the future.

This PR removes the upper bound when it would have otherwise been *now*. 

I tested setting the clock forward and on main that does cause the 400 error, and it is indeed fixed by this PR.

It also improves the handling when there are no transactions at all.

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works
