### PR TITLE
Fix Decimal192 initialization on release

### DIFF
--- a/RadixWallet/Clients/TransactionClient/Models/TransactionFee.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionFee.swift
@@ -105,7 +105,7 @@ extension TransactionFee {
 extension TransactionFee {
 	public enum PredefinedFeeConstants {
 		/// 15% margin is added here to make up for the ambiguity of the transaction preview estimate)
-		public static let networkFeeMultiplier = Decimal192(0.15)
+		public static let networkFeeMultiplier = try! Decimal192(0.15)
 
 		/// Network fees -> https://radixdlt.atlassian.net/wiki/spaces/S/pages/3134783512/Manifest+Mutation+Cost+Addition+Estimates
 		// swiftformat:disable all

--- a/RadixWallet/Clients/TransactionClient/Models/TransactionFee.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionFee.swift
@@ -105,7 +105,7 @@ extension TransactionFee {
 extension TransactionFee {
 	public enum PredefinedFeeConstants {
 		/// 15% margin is added here to make up for the ambiguity of the transaction preview estimate)
-		public static let networkFeeMultiplier: Decimal192 = 0.15
+		public static let networkFeeMultiplier = Decimal192(0.15)
 
 		/// Network fees -> https://radixdlt.atlassian.net/wiki/spaces/S/pages/3134783512/Manifest+Mutation+Cost+Addition+Estimates
 		// swiftformat:disable all

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/DefaultDepositGuarantees/DefaultDepositGuarantees+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/DefaultDepositGuarantees/DefaultDepositGuarantees+Reducer.swift
@@ -16,7 +16,7 @@ public struct DefaultDepositGuarantees: Sendable, FeatureReducer {
 		var percentageStepper: MinimumPercentageStepper.State
 
 		public init(depositGuarantee: Decimal192) {
-			self.percentageStepper = .init(value: 100 * depositGuarantee)
+			self.percentageStepper = .init(value: Decimal192(100) * depositGuarantee)
 		}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/DefaultDepositGuarantees/DefaultDepositGuarantees+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/DefaultDepositGuarantees/DefaultDepositGuarantees+Reducer.swift
@@ -10,7 +10,7 @@ public struct DefaultDepositGuarantees: Sendable, FeatureReducer {
 
 	public struct State: Sendable, Hashable {
 		public var depositGuarantee: Decimal192? {
-			percentageStepper.value.map { 0.01 * $0 }
+			percentageStepper.value.map { Decimal192(0.01) * $0 }
 		}
 
 		var percentageStepper: MinimumPercentageStepper.State

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/DefaultDepositGuarantees/DefaultDepositGuarantees+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/DefaultDepositGuarantees/DefaultDepositGuarantees+Reducer.swift
@@ -16,7 +16,7 @@ public struct DefaultDepositGuarantees: Sendable, FeatureReducer {
 		var percentageStepper: MinimumPercentageStepper.State
 
 		public init(depositGuarantee: Decimal192) {
-			self.percentageStepper = .init(value: Decimal192(100) * depositGuarantee)
+			self.percentageStepper = .init(value: 100 * depositGuarantee)
 		}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/AccountSecurity/DefaultDepositGuarantees/DefaultDepositGuarantees+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/AccountSecurity/DefaultDepositGuarantees/DefaultDepositGuarantees+Reducer.swift
@@ -10,7 +10,7 @@ public struct DefaultDepositGuarantees: Sendable, FeatureReducer {
 
 	public struct State: Sendable, Hashable {
 		public var depositGuarantee: Decimal192? {
-			percentageStepper.value.map { Decimal192(0.01) * $0 }
+			percentageStepper.value.map { try! Decimal192(0.01) * $0 }
 		}
 
 		var percentageStepper: MinimumPercentageStepper.State

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees.swift
@@ -149,7 +149,7 @@ extension TransactionReviewGuarantee.State {
 	mutating func updateAmount() {
 		guard let value = percentageStepper.value else { return }
 
-		let newMinimumDecimal = value * Decimal192(0.01)
+		let newMinimumDecimal = value * (try! Decimal192(0.01))
 		let divisibility: UInt8 = resource.divisibility ?? Decimal192.maxDivisibility
 		guarantee.amount = (newMinimumDecimal * amount).rounded(decimalPlaces: divisibility)
 	}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewGuarantees/TransactionReviewGuarantees.swift
@@ -149,7 +149,7 @@ extension TransactionReviewGuarantee.State {
 	mutating func updateAmount() {
 		guard let value = percentageStepper.value else { return }
 
-		let newMinimumDecimal = value * 0.01
+		let newMinimumDecimal = value * Decimal192(0.01)
 		let divisibility: UInt8 = resource.divisibility ?? Decimal192.maxDivisibility
 		guarantee.amount = (newMinimumDecimal * amount).rounded(decimalPlaces: divisibility)
 	}

--- a/RadixWallet/Profile/AppPreferences/Transaction/AppPreferences+Transaction.swift
+++ b/RadixWallet/Profile/AppPreferences/Transaction/AppPreferences+Transaction.swift
@@ -8,7 +8,7 @@ extension AppPreferences {
 		CustomStringConvertible,
 		CustomDumpReflectable
 	{
-		public static let defaultDepositGuaranteePreset = Decimal192(floatLiteral: 0.99)
+		public static let defaultDepositGuaranteePreset = Decimal192(0.99)
 		public var defaultDepositGuarantee: Decimal192
 
 		public init(

--- a/RadixWallet/Profile/AppPreferences/Transaction/AppPreferences+Transaction.swift
+++ b/RadixWallet/Profile/AppPreferences/Transaction/AppPreferences+Transaction.swift
@@ -8,7 +8,7 @@ extension AppPreferences {
 		CustomStringConvertible,
 		CustomDumpReflectable
 	{
-		public static let defaultDepositGuaranteePreset = Decimal192(0.99)
+		public static let defaultDepositGuaranteePreset = try! Decimal192(0.99)
 		public var defaultDepositGuarantee: Decimal192
 
 		public init(


### PR DESCRIPTION
## Description
This PR fixes the initialization of `Decimal192` from literal `Float`, which isn't possible on RELEASE.

## Notes
Reason why CD is [failing](https://github.com/radixdlt/babylon-wallet-ios/commit/1f6c403665bd94f8f120e5e8808b2559111d0635/checks).