### PR TITLE
CAP-36 New Linking Flow Updates

### DIFF
--- a/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Interface.swift
+++ b/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Interface.swift
@@ -29,6 +29,6 @@ extension P2PLinksClient {
 	public typealias UpdateOrAddP2PLink = @Sendable (P2PLink) async throws -> P2PLink?
 	public typealias DeleteP2PLinkByPassword = @Sendable (ConnectionPassword) async throws -> Void
 	public typealias DeleteAllP2PLinks = @Sendable () async throws -> Void
-	public typealias GetP2PLinkPrivateKey = @Sendable (Curve25519PublicKeyBytes) async throws -> (privateKey: Curve25519.PrivateKey, isNew: Bool)
-	public typealias StoreP2PLinkPrivateKey = @Sendable (Curve25519PublicKeyBytes, Curve25519.PrivateKey) async throws -> Void
+	public typealias GetP2PLinkPrivateKey = @Sendable () async throws -> (privateKey: Curve25519.PrivateKey, isNew: Bool)
+	public typealias StoreP2PLinkPrivateKey = @Sendable (Curve25519.PrivateKey) async throws -> Void
 }

--- a/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Live.swift
+++ b/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Live.swift
@@ -18,29 +18,21 @@ extension P2PLinksClient: DependencyKey {
 			},
 			deleteP2PLinkByPassword: { password in
 				try secureStorageClient.updatingP2PLinks {
-					try $0.links
-						.filter { $0.connectionPassword == password }
-						.forEach {
-							try secureStorageClient.deleteP2PLinkPrivateKey($0.publicKey)
-						}
 					$0.links.removeAll(where: { $0.connectionPassword == password })
 				}
 			},
 			deleteAllP2PLinks: {
 				try secureStorageClient.updatingP2PLinks {
-					try $0.links.forEach {
-						try secureStorageClient.deleteP2PLinkPrivateKey($0.publicKey)
-					}
 					$0.links.removeAll()
 				}
 			},
-			getP2PLinkPrivateKey: { publicKey in
-				let privateKey = try secureStorageClient.loadP2PLinkPrivateKey(publicKey)
+			getP2PLinkPrivateKey: {
+				let privateKey = try secureStorageClient.loadP2PLinksPrivateKey()
 				let isNew = privateKey == nil
 				return (privateKey ?? Curve25519.PrivateKey(), isNew)
 			},
-			storeP2PLinkPrivateKey: { publicKey, privateKey in
-				try secureStorageClient.saveP2PLinkPrivateKey(publicKey, privateKey)
+			storeP2PLinkPrivateKey: { privateKey in
+				try secureStorageClient.saveP2PLinksPrivateKey(privateKey)
 			}
 		)
 	}

--- a/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Test.swift
+++ b/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Test.swift
@@ -14,8 +14,8 @@ extension P2PLinksClient: TestDependencyKey {
 		updateOrAddP2PLink: { _ in nil },
 		deleteP2PLinkByPassword: { _ in },
 		deleteAllP2PLinks: {},
-		getP2PLinkPrivateKey: { _ in (.init(), false) },
-		storeP2PLinkPrivateKey: { _, _ in }
+		getP2PLinkPrivateKey: { (.init(), false) },
+		storeP2PLinkPrivateKey: { _ in }
 	)
 	public static let testValue = Self(
 		getP2PLinks: unimplemented("\(Self.self).getP2PLinks"),

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Interface.swift
@@ -29,9 +29,8 @@ public struct SecureStorageClient: Sendable {
 	public var loadP2PLinks: LoadP2PLinks
 	public var saveP2PLinks: SaveP2PLinks
 
-	public var loadP2PLinkPrivateKey: LoadP2PLinkPrivateKey
-	public var saveP2PLinkPrivateKey: SaveP2PLinkPrivateKey
-	public var deleteP2PLinkPrivateKey: DeleteP2PLinkPrivateKey
+	public var loadP2PLinksPrivateKey: LoadP2PLinksPrivateKey
+	public var saveP2PLinksPrivateKey: SaveP2PLinksPrivateKey
 
 	#if DEBUG
 	public var getAllMnemonics: GetAllMnemonics
@@ -58,9 +57,8 @@ public struct SecureStorageClient: Sendable {
 		deleteDeprecatedDeviceID: @escaping DeleteDeprecatedDeviceID,
 		loadP2PLinks: @escaping LoadP2PLinks,
 		saveP2PLinks: @escaping SaveP2PLinks,
-		loadP2PLinkPrivateKey: @escaping LoadP2PLinkPrivateKey,
-		saveP2PLinkPrivateKey: @escaping SaveP2PLinkPrivateKey,
-		deleteP2PLinkPrivateKey: @escaping DeleteP2PLinkPrivateKey,
+		loadP2PLinksPrivateKey: @escaping LoadP2PLinksPrivateKey,
+		saveP2PLinksPrivateKey: @escaping SaveP2PLinksPrivateKey,
 		getAllMnemonics: @escaping GetAllMnemonics
 	) {
 		self.saveProfileSnapshot = saveProfileSnapshot
@@ -82,9 +80,8 @@ public struct SecureStorageClient: Sendable {
 		self.deleteDeprecatedDeviceID = deleteDeprecatedDeviceID
 		self.loadP2PLinks = loadP2PLinks
 		self.saveP2PLinks = saveP2PLinks
-		self.loadP2PLinkPrivateKey = loadP2PLinkPrivateKey
-		self.saveP2PLinkPrivateKey = saveP2PLinkPrivateKey
-		self.deleteP2PLinkPrivateKey = deleteP2PLinkPrivateKey
+		self.loadP2PLinksPrivateKey = loadP2PLinksPrivateKey
+		self.saveP2PLinksPrivateKey = saveP2PLinksPrivateKey
 		self.getAllMnemonics = getAllMnemonics
 	}
 	#else
@@ -109,9 +106,8 @@ public struct SecureStorageClient: Sendable {
 		deleteDeprecatedDeviceID: @escaping DeleteDeprecatedDeviceID,
 		loadP2PLinks: @escaping LoadP2PLinks,
 		saveP2PLinks: @escaping SaveP2PLinks,
-		loadP2PLinkPrivateKey: @escaping LoadP2PLinkPrivateKey,
-		saveP2PLinkPrivateKey: @escaping SaveP2PLinkPrivateKey,
-		deleteP2PLinkPrivateKey: @escaping DeleteP2PLinkPrivateKey
+		loadP2PLinksPrivateKey: @escaping LoadP2PLinksPrivateKey,
+		saveP2PLinksPrivateKey: @escaping SaveP2PLinksPrivateKey
 	) {
 		self.saveProfileSnapshot = saveProfileSnapshot
 		self.loadProfileSnapshotData = loadProfileSnapshotData
@@ -132,9 +128,8 @@ public struct SecureStorageClient: Sendable {
 		self.deleteDeprecatedDeviceID = deleteDeprecatedDeviceID
 		self.loadP2PLinks = loadP2PLinks
 		self.saveP2PLinks = saveP2PLinks
-		self.loadP2PLinkPrivateKey = loadP2PLinkPrivateKey
-		self.saveP2PLinkPrivateKey = saveP2PLinkPrivateKey
-		self.deleteP2PLinkPrivateKey = deleteP2PLinkPrivateKey
+		self.loadP2PLinksPrivateKey = loadP2PLinksPrivateKey
+		self.saveP2PLinksPrivateKey = saveP2PLinksPrivateKey
 	}
 	#endif // DEBUG
 }
@@ -178,9 +173,8 @@ extension SecureStorageClient {
 	public typealias LoadP2PLinks = @Sendable () throws -> P2PLinks?
 	public typealias SaveP2PLinks = @Sendable (P2PLinks) throws -> Void
 
-	public typealias LoadP2PLinkPrivateKey = @Sendable (Curve25519PublicKeyBytes) throws -> Curve25519.PrivateKey?
-	public typealias SaveP2PLinkPrivateKey = @Sendable (Curve25519PublicKeyBytes, Curve25519.PrivateKey) throws -> Void
-	public typealias DeleteP2PLinkPrivateKey = @Sendable (Curve25519PublicKeyBytes) throws -> Void
+	public typealias LoadP2PLinksPrivateKey = @Sendable () throws -> Curve25519.PrivateKey?
+	public typealias SaveP2PLinksPrivateKey = @Sendable (Curve25519.PrivateKey) throws -> Void
 
 	public enum LoadMnemonicPurpose: Sendable, Hashable, CustomStringConvertible {
 		case signTransaction

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -403,7 +403,7 @@ extension SecureStorageClient: DependencyKey {
 
 		@Sendable func loadP2PLinksPrivateKey() throws -> Curve25519.PrivateKey? {
 			try keychainClient
-				.getDataWithoutAuth(forKey: p2pLinksPrivateKeyKey)
+				.getDataWithoutAuth(forKey: p2pLinksPKKey)
 				.map {
 					try Curve25519.PrivateKey(rawRepresentation: $0)
 				}
@@ -419,7 +419,7 @@ extension SecureStorageClient: DependencyKey {
 		@Sendable func saveP2PLinksPrivateKey(privateKey: Curve25519.PrivateKey) throws {
 			try keychainClient.setDataWithoutAuth(
 				privateKey.rawRepresentation,
-				forKey: p2pLinksPrivateKeyKey,
+				forKey: p2pLinksPKKey,
 				attributes: p2pLinksPrivateKeyAttributes
 			)
 			loggerGlobal.notice("Saved p2pLinksPrivateKeyKey")
@@ -483,7 +483,7 @@ let profileHeaderListKeychainKey: KeychainClient.Key = "profileHeaderList"
 private let deviceIdentifierKey: KeychainClient.Key = "deviceIdentifier"
 private let deviceInfoKey: KeychainClient.Key = "deviceInfo"
 private let p2pLinksKey: KeychainClient.Key = "p2pLinks"
-private let p2pLinksPrivateKeyKey: KeychainClient.Key = "p2pLinksPrivateKey"
+private let p2pLinksPKKey: KeychainClient.Key = "p2pLinksWalletPK"
 
 extension ProfileSnapshot.Header.ID {
 	private static let profileSnapshotKeychainKeyPrefix = "profileSnapshot"

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -401,32 +401,28 @@ extension SecureStorageClient: DependencyKey {
 			loggerGlobal.notice("Saved p2pLinks: \(p2pLinks)")
 		}
 
-		@Sendable func loadP2PLinkPrivateKey(_ publicKey: Curve25519PublicKeyBytes) throws -> Curve25519.PrivateKey? {
+		@Sendable func loadP2PLinksPrivateKey() throws -> Curve25519.PrivateKey? {
 			try keychainClient
-				.getDataWithoutAuth(forKey: key(publicKey: publicKey))
+				.getDataWithoutAuth(forKey: p2pLinksPrivateKeyKey)
 				.map {
 					try Curve25519.PrivateKey(rawRepresentation: $0)
 				}
 		}
 
-		let p2pLinkPrivateKeyAttributes = KeychainClient.AttributesWithoutAuth(
+		let p2pLinksPrivateKeyAttributes = KeychainClient.AttributesWithoutAuth(
 			iCloudSyncEnabled: false,
 			accessibility: .whenUnlocked,
 			label: importantKeychainIdentifier("Radix Wallet Private Key Per P2P link"),
 			comment: "Contains a wallet private key for a specific P2P link"
 		)
 
-		@Sendable func saveP2PLinkPrivateKey(_ publicKey: Curve25519PublicKeyBytes, privateKey: Curve25519.PrivateKey) throws {
+		@Sendable func saveP2PLinksPrivateKey(privateKey: Curve25519.PrivateKey) throws {
 			try keychainClient.setDataWithoutAuth(
 				privateKey.rawRepresentation,
-				forKey: key(publicKey: publicKey),
-				attributes: p2pLinkPrivateKeyAttributes
+				forKey: p2pLinksPrivateKeyKey,
+				attributes: p2pLinksPrivateKeyAttributes
 			)
-			loggerGlobal.notice("Saved private key for CE public key: \(publicKey)")
-		}
-
-		@Sendable func deleteP2PLinkPrivateKey(_ publicKey: Curve25519PublicKeyBytes) throws {
-			try keychainClient.removeData(forKey: key(publicKey: publicKey))
+			loggerGlobal.notice("Saved p2pLinksPrivateKeyKey")
 		}
 
 		#if DEBUG
@@ -450,9 +446,8 @@ extension SecureStorageClient: DependencyKey {
 			deleteDeprecatedDeviceID: deleteDeprecatedDeviceID,
 			loadP2PLinks: loadP2PLinks,
 			saveP2PLinks: saveP2PLinks,
-			loadP2PLinkPrivateKey: loadP2PLinkPrivateKey,
-			saveP2PLinkPrivateKey: saveP2PLinkPrivateKey,
-			deleteP2PLinkPrivateKey: deleteP2PLinkPrivateKey,
+			loadP2PLinksPrivateKey: loadP2PLinksPrivateKey,
+			saveP2PLinksPrivateKey: saveP2PLinksPrivateKey,
 			getAllMnemonics: getAllMnemonics
 		)
 		#else
@@ -476,9 +471,8 @@ extension SecureStorageClient: DependencyKey {
 			deleteDeprecatedDeviceID: deleteDeprecatedDeviceID,
 			loadP2PLinks: loadP2PLinks,
 			saveP2PLinks: saveP2PLinks,
-			loadP2PLinkPrivateKey: loadP2PLinkPrivateKey,
-			saveP2PLinkPrivateKey: saveP2PLinkPrivateKey,
-			deleteP2PLinkPrivateKey: deleteP2PLinkPrivateKey
+			loadP2PLinksPrivateKey: loadP2PLinksPrivateKey,
+			saveP2PLinksPrivateKey: saveP2PLinksPrivateKey
 		)
 		#endif
 	}()
@@ -489,6 +483,7 @@ let profileHeaderListKeychainKey: KeychainClient.Key = "profileHeaderList"
 private let deviceIdentifierKey: KeychainClient.Key = "deviceIdentifier"
 private let deviceInfoKey: KeychainClient.Key = "deviceInfo"
 private let p2pLinksKey: KeychainClient.Key = "p2pLinks"
+private let p2pLinksPrivateKeyKey: KeychainClient.Key = "p2pLinksPrivateKey"
 
 extension ProfileSnapshot.Header.ID {
 	private static let profileSnapshotKeychainKeyPrefix = "profileSnapshot"
@@ -500,10 +495,6 @@ extension ProfileSnapshot.Header.ID {
 
 private func key(factorSourceID: FactorSourceID.FromHash) -> KeychainClient.Key {
 	.init(rawValue: .init(rawValue: factorSourceID.keychainKey)!)
-}
-
-private func key(publicKey: Curve25519PublicKeyBytes) -> KeychainClient.Key {
-	.init(rawValue: .init(rawValue: publicKey.data.hex())!)
 }
 
 extension OverlayWindowClient.Item.AlertState {

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Test.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Test.swift
@@ -29,9 +29,8 @@ extension SecureStorageClient: TestDependencyKey {
 		deleteDeprecatedDeviceID: {},
 		loadP2PLinks: { nil },
 		saveP2PLinks: { _ in },
-		loadP2PLinkPrivateKey: { _ in nil },
-		saveP2PLinkPrivateKey: { _, _ in },
-		deleteP2PLinkPrivateKey: { _ in },
+		loadP2PLinksPrivateKey: { nil },
+		saveP2PLinksPrivateKey: { _ in },
 		getAllMnemonics: { [] }
 	)
 	#else
@@ -55,9 +54,8 @@ extension SecureStorageClient: TestDependencyKey {
 		deleteDeprecatedDeviceID: {},
 		loadP2PLinks: { nil },
 		saveP2PLinks: { _ in },
-		loadP2PLinkPrivateKey: { _ in nil },
-		saveP2PLinkPrivateKey: { _, _ in },
-		deleteP2PLinkPrivateKey: { _ in }
+		loadP2PLinksPrivateKey: { nil },
+		saveP2PLinksPrivateKey: { _ in }
 	)
 	#endif // DEBUG
 
@@ -84,9 +82,8 @@ extension SecureStorageClient: TestDependencyKey {
 		deleteDeprecatedDeviceID: unimplemented("\(Self.self).deleteDeprecatedDeviceID"),
 		loadP2PLinks: unimplemented("\(Self.self).loadP2PLinks"),
 		saveP2PLinks: unimplemented("\(Self.self).saveP2PLinks"),
-		loadP2PLinkPrivateKey: unimplemented("\(Self.self).loadP2PLinkPrivateKey"),
-		saveP2PLinkPrivateKey: unimplemented("\(Self.self).saveP2PLinkPrivateKey"),
-		deleteP2PLinkPrivateKey: unimplemented("\(Self.self).deleteP2PLinkPrivateKey"),
+		loadP2PLinksPrivateKey: unimplemented("\(Self.self).loadP2PLinksPrivateKey"),
+		saveP2PLinksPrivateKey: unimplemented("\(Self.self).saveP2PLinksPrivateKey"),
 		getAllMnemonics: unimplemented("\(Self.self).getAllMnemonics")
 	)
 	#else
@@ -110,9 +107,8 @@ extension SecureStorageClient: TestDependencyKey {
 		deleteDeprecatedDeviceID: unimplemented("\(Self.self).deleteDeprecatedDeviceID"),
 		loadP2PLinks: unimplemented("\(Self.self).loadP2PLinks"),
 		saveP2PLinks: unimplemented("\(Self.self).saveP2PLinks"),
-		loadP2PLinkPrivateKey: unimplemented("\(Self.self).loadP2PLinkPrivateKey"),
-		saveP2PLinkPrivateKey: unimplemented("\(Self.self).saveP2PLinkPrivateKey"),
-		deleteP2PLinkPrivateKey: unimplemented("\(Self.self).deleteP2PLinkPrivateKey")
+		loadP2PLinksPrivateKey: unimplemented("\(Self.self).loadP2PLinksPrivateKey"),
+		saveP2PLinksPrivateKey: unimplemented("\(Self.self).saveP2PLinksPrivateKey")
 	)
 	#endif
 }

--- a/RadixWallet/Core/Resources/Generated/L10n.generated.swift
+++ b/RadixWallet/Core/Resources/Generated/L10n.generated.swift
@@ -2052,7 +2052,7 @@ public enum L10n {
     /// Link New Connector
     public static let linkNewConnector = L10n.tr("Localizable", "linkedConnectors_linkNewConnector", fallback: "Link New Connector")
     /// This is an old version of the Radix Connector browser extension. Please update to the latest Connector and try linking again.
-    public static let oldFormatQRCodeErrorMessage = L10n.tr("Localizable", "linkedConnectors_oldFormatQRCodeErrorMessage", fallback: "This is an old version of the Radix Connector browser extension. Please update to the latest Connector and try linking again.")
+    public static let oldQRErrorMessage = L10n.tr("Localizable", "linkedConnectors_oldQRErrorMessage", fallback: "This is an old version of the Radix Connector browser extension. Please update to the latest Connector and try linking again.")
     /// Connect your Radix Wallet to desktop web browsers by linking to the Radix Connector browser extension. Here are your linked Connectors.
     public static let subtitle = L10n.tr("Localizable", "linkedConnectors_subtitle", fallback: "Connect your Radix Wallet to desktop web browsers by linking to the Radix Connector browser extension. Here are your linked Connectors.")
     /// Linked Connectors

--- a/RadixWallet/Core/Resources/Generated/L10n.generated.swift
+++ b/RadixWallet/Core/Resources/Generated/L10n.generated.swift
@@ -2051,6 +2051,8 @@ public enum L10n {
     public static let linkFailedErrorTitle = L10n.tr("Localizable", "linkedConnectors_linkFailedErrorTitle", fallback: "Link Failed")
     /// Link New Connector
     public static let linkNewConnector = L10n.tr("Localizable", "linkedConnectors_linkNewConnector", fallback: "Link New Connector")
+    /// This is an old version of the Radix Connector browser extension. Please update to the latest Connector and try linking again.
+    public static let oldFormatQRCodeErrorMessage = L10n.tr("Localizable", "linkedConnectors_oldFormatQRCodeErrorMessage", fallback: "This is an old version of the Radix Connector browser extension. Please update to the latest Connector and try linking again.")
     /// Connect your Radix Wallet to desktop web browsers by linking to the Radix Connector browser extension. Here are your linked Connectors.
     public static let subtitle = L10n.tr("Localizable", "linkedConnectors_subtitle", fallback: "Connect your Radix Wallet to desktop web browsers by linking to the Radix Connector browser extension. Here are your linked Connectors.")
     /// Linked Connectors

--- a/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
+++ b/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
@@ -1167,5 +1167,5 @@ Only continue if you are linking to the **official Radix Connector browser exten
 "linkedConnectors_linkFailedErrorTitle" = "Link Failed";
 "linkedConnectors_unknownPurposeErrorMessage" = "This type of Connector link is not supported.";
 "linkedConnectors_changingPurposeNotSupportedErrorMessage" = "Changing a Connector’s type is not supported.";
-"linkedConnectors_oldFormatQRCodeErrorMessage" = "This is an old version of the Radix Connector browser extension. Please update to the latest Connector and try linking again.";
+"linkedConnectors_oldQRErrorMessage" = "This is an old version of the Radix Connector browser extension. Please update to the latest Connector and try linking again.";
 "common_dismiss" = "Dismiss";

--- a/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
+++ b/RadixWallet/Core/Resources/Resources/en.lproj/Localizable.strings
@@ -1167,4 +1167,5 @@ Only continue if you are linking to the **official Radix Connector browser exten
 "linkedConnectors_linkFailedErrorTitle" = "Link Failed";
 "linkedConnectors_unknownPurposeErrorMessage" = "This type of Connector link is not supported.";
 "linkedConnectors_changingPurposeNotSupportedErrorMessage" = "Changing a Connector’s type is not supported.";
+"linkedConnectors_oldFormatQRCodeErrorMessage" = "This is an old version of the Radix Connector browser extension. Please update to the latest Connector and try linking again.";
 "common_dismiss" = "Dismiss";

--- a/RadixWallet/Features/NewConnectionFeature/Coordinator/NewConnection+Reducer.swift
+++ b/RadixWallet/Features/NewConnectionFeature/Coordinator/NewConnection+Reducer.swift
@@ -314,7 +314,7 @@ extension AlertState<NewConnection.Destination.Action.ErrorAlert> {
 				TextState(L10n.Common.dismiss)
 			}
 		} message: {
-			TextState(L10n.LinkedConnectors.oldFormatQRCodeErrorMessage)
+			TextState(L10n.LinkedConnectors.oldQRErrorMessage)
 		}
 	}
 }

--- a/RadixWallet/RadixConnect/RadixConnect/RTC/PeerConnection/PeerConnectionNegotiator.swift
+++ b/RadixWallet/RadixConnect/RadixConnect/RTC/PeerConnection/PeerConnectionNegotiator.swift
@@ -212,7 +212,7 @@ extension PeerConnectionNegotiator {
 		@Dependency(\.p2pLinksClient) var p2pLinkClient
 		@Dependency(\.jsonEncoder) var jsonEncoder
 
-		let (privateKey, isNewPrivateKey) = try await p2pLinkClient.getP2PLinkPrivateKey(p2pLink.publicKey)
+		let (privateKey, isNewPrivateKey) = try await p2pLinkClient.getP2PLinkPrivateKey()
 		let hashedMessageToSign = p2pLink.connectionPassword.messageToHash.hash().data
 		let linkClientInteractionResponse = try P2P.ConnectorExtension.Request.LinkClientInteractionResponse(
 			discriminator: .linkClient,
@@ -223,7 +223,7 @@ extension PeerConnectionNegotiator {
 		onSuccess()
 
 		if isNewPrivateKey {
-			try await p2pLinkClient.storeP2PLinkPrivateKey(p2pLink.publicKey, privateKey)
+			try await p2pLinkClient.storeP2PLinkPrivateKey(privateKey)
 		}
 	}
 


### PR DESCRIPTION
Updates for PR [#1089](https://github.com/radixdlt/babylon-wallet-ios/pull/1089)

## Description
What was updated:
- After 1.6.0 is out, we will for sure encounter cases when users scan the old QR code, we may want to identify this and tell them that they are using old CE
- Updated the Wallet to have only one public key for all CE links, so CE can identify the Wallet as being the same client in the same way the Wallet sees the CE being the same client