### PR TITLE
Disable Create new persona button before checking primacy

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Children/Login/Coordinator/Login+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Login/Coordinator/Login+View.swift
@@ -12,6 +12,7 @@ extension Login {
 		let availablePersonas: IdentifiedArrayOf<PersonaRow.State>
 		let selectedPersona: PersonaRow.State?
 		let continueButtonRequirements: ContinueButtonRequirements?
+		let createPersonaControlState: ControlState
 
 		struct ContinueButtonRequirements: Equatable {
 			let persona: Persona
@@ -41,6 +42,8 @@ extension Login {
 			} else {
 				self.continueButtonRequirements = nil
 			}
+
+			self.createPersonaControlState = state.personaPrimacy == nil ? .disabled : .enabled
 		}
 	}
 
@@ -88,6 +91,7 @@ extension Login {
 							viewStore.send(.createNewPersonaButtonTapped)
 						}
 						.buttonStyle(.secondaryRectangular(shouldExpand: false))
+						.controlState(viewStore.createPersonaControlState)
 					}
 					.padding(.horizontal, .medium1)
 					.padding(.bottom, .medium2)


### PR DESCRIPTION
## Description
This PR solves a crash on debug builds reproduced if user tapped on `Create New Persona` too soon.

### Notes
The crash has been identified through Xcode organizer, showing the issue described.

![Screenshot 2024-05-07 at 13 30 11](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/7425b432-4c2e-4fe5-aa0d-cd90871c615a)

It has happened when using a very large profile with lots of accounts. I haven't been able to reproduce this issue (even with a similar profile) but the added solution should have no harm.