### PR TITLE
Use IdentifiedArrayOf for collection types

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1074,6 +1074,7 @@
 		E66EEB9C2B06694E007624BC /* RecoverWalletWithoutProfileStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66EEB9A2B06694E007624BC /* RecoverWalletWithoutProfileStart.swift */; };
 		E67F14452AE029BA00738BE1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E67F14442AE029BA00738BE1 /* Assets.xcassets */; };
 		E68878592BDBFD42003F3393 /* Stage2MigrateToSargon+LedgerHardwareWalletFactorSource+New.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68878582BDBFD42003F3393 /* Stage2MigrateToSargon+LedgerHardwareWalletFactorSource+New.swift */; };
+		E695F2DE2BECDD7C00761ACE /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = E695F2DD2BECDD7C00761ACE /* Sargon */; };
 		E6A2D9E12AFA6BFE001857EC /* DeviceFactorSourceControlled.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A2D9E02AFA6BFE001857EC /* DeviceFactorSourceControlled.swift */; };
 		E6A2D9E32AFA6C0D001857EC /* AccountWithInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A2D9E22AFA6C0D001857EC /* AccountWithInfo.swift */; };
 		E6A2D9E52AFA6C1E001857EC /* AccountWithInfoHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A2D9E42AFA6C1E001857EC /* AccountWithInfoHolder.swift */; };
@@ -2272,6 +2273,7 @@
 				48FFFABA2ADC209100B2B213 /* Nuke in Frameworks */,
 				48FFFAE42ADC222100B2B213 /* Validated in Frameworks */,
 				48FFFAED2ADC226B00B2B213 /* CodeScanner in Frameworks */,
+				E695F2DE2BECDD7C00761ACE /* Sargon in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6371,6 +6373,7 @@
 				5B1C4FD42BBB0B0C00B9436F /* AppsFlyerLib-Strict */,
 				489FEF902BDD0B80003EC10D /* Sargon */,
 				48C845C62BEA6DC600F74DA7 /* Sargon */,
+				E695F2DD2BECDD7C00761ACE /* Sargon */,
 			);
 			productName = RadixWallet;
 			productReference = 48CFBC4F2ADC106300E77A5C /* Radix Wallet Dev.app */;
@@ -6440,7 +6443,7 @@
 				A415574E2B757C5E0040AD4E /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
 				5B1C4FD32BBB0B0C00B9436F /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Strict" */,
 				8318BB172BC8403800057BCB /* XCRemoteSwiftPackageReference "swift-custom-dump" */,
-				48C845C52BEA6DC600F74DA7 /* XCLocalSwiftPackageReference "../sargon" */,
+				E695F2DC2BECDD7C00761ACE /* XCRemoteSwiftPackageReference "sargon" */,
 			);
 			productRefGroup = 48CFBC502ADC106300E77A5C /* Products */;
 			projectDirPath = "";
@@ -8036,13 +8039,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		48C845C52BEA6DC600F74DA7 /* XCLocalSwiftPackageReference "../sargon" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../sargon;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		48FFFA972ADC1EEC00B2B213 /* XCRemoteSwiftPackageReference "AsyncExtensions" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -8308,6 +8304,14 @@
 				minimumVersion = 1.9.10;
 			};
 		};
+		E695F2DC2BECDD7C00761ACE /* XCRemoteSwiftPackageReference "sargon" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/radixdlt/sargon";
+			requirement = {
+				kind = exactVersion;
+				version = 0.7.7;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -8518,6 +8522,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 48FFFAB22ADC206300B2B213 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = SwiftUIIntrospect;
+		};
+		E695F2DD2BECDD7C00761ACE /* Sargon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E695F2DC2BECDD7C00761ACE /* XCRemoteSwiftPackageReference "sargon" */;
+			productName = Sargon;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		4855B1C32BCAC59C00DD0A47 /* Stage1MigrateToSargon+Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4855B1C22BCAC59C00DD0A47 /* Stage1MigrateToSargon+Account.swift */; };
 		4855B1C72BCAC82200DD0A47 /* Stage1MigrateToSargon+SignatureOfEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4855B1C62BCAC82200DD0A47 /* Stage1MigrateToSargon+SignatureOfEntity.swift */; };
 		48649AD52ADC7CAC006307CF /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 48649AD42ADC7CAC006307CF /* AppIcon.xcassets */; };
-		4871C4C72BD04A4A0090D243 /* CanBeEmptyIdentifiedCollection+IdentifiedArrayOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4871C4C62BD04A4A0090D243 /* CanBeEmptyIdentifiedCollection+IdentifiedArrayOf.swift */; };
 		4884BDBA2BD98EF6003B1ED6 /* TestFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4884BDB92BD98EF6003B1ED6 /* TestFixture.swift */; };
 		4884F3332BD83B4600A19B83 /* Stage1MigrateToSargon+OnLedgerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4884F3322BD83B4600A19B83 /* Stage1MigrateToSargon+OnLedgerSettings.swift */; };
 		4884F3352BD83D9200A19B83 /* Stage1MigrateToSargon+ThirdPartyDeposits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4884F3342BD83D9200A19B83 /* Stage1MigrateToSargon+ThirdPartyDeposits.swift */; };
@@ -1165,7 +1164,6 @@
 		4855B1C22BCAC59C00DD0A47 /* Stage1MigrateToSargon+Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stage1MigrateToSargon+Account.swift"; sourceTree = "<group>"; };
 		4855B1C62BCAC82200DD0A47 /* Stage1MigrateToSargon+SignatureOfEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stage1MigrateToSargon+SignatureOfEntity.swift"; sourceTree = "<group>"; };
 		48649AD42ADC7CAC006307CF /* AppIcon.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AppIcon.xcassets; sourceTree = "<group>"; };
-		4871C4C62BD04A4A0090D243 /* CanBeEmptyIdentifiedCollection+IdentifiedArrayOf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CanBeEmptyIdentifiedCollection+IdentifiedArrayOf.swift"; sourceTree = "<group>"; };
 		4884BDB92BD98EF6003B1ED6 /* TestFixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFixture.swift; sourceTree = "<group>"; };
 		4884F3322BD83B4600A19B83 /* Stage1MigrateToSargon+OnLedgerSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stage1MigrateToSargon+OnLedgerSettings.swift"; sourceTree = "<group>"; };
 		4884F3342BD83D9200A19B83 /* Stage1MigrateToSargon+ThirdPartyDeposits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stage1MigrateToSargon+ThirdPartyDeposits.swift"; sourceTree = "<group>"; };
@@ -2298,7 +2296,6 @@
 		482752142BDB8F5A007854E0 /* SargonExtensions */ = {
 			isa = PBXGroup;
 			children = (
-				4871C4C62BD04A4A0090D243 /* CanBeEmptyIdentifiedCollection+IdentifiedArrayOf.swift */,
 				E63257642BB314F600952051 /* ExecutionSummary+Extensions.swift */,
 				48AF19CD2BB71C1600796130 /* IntoSargon+Bridge.swift */,
 				4827521B2BDB9597007854E0 /* Persona+ShouldWriteDownMnemonic.swift */,
@@ -7297,7 +7294,6 @@
 				48CFC4CB2ADC10DA00E77A5C /* Extensions.swift in Sources */,
 				5B9846C22BBD5F7600E814F3 /* SensitiveInfoClient+Live.swift in Sources */,
 				48CFC4302ADC10DA00E77A5C /* Collection+Extra.swift in Sources */,
-				4871C4C72BD04A4A0090D243 /* CanBeEmptyIdentifiedCollection+IdentifiedArrayOf.swift in Sources */,
 				83EE47832AF0EE3C00155F03 /* ProgrammaticScryptoSborValuePreciseDecimal.swift in Sources */,
 				48CFC2D62ADC10D900E77A5C /* ChooseAccountsRow.swift in Sources */,
 				A462B5BB2B90C5E800C26D20 /* ResourceBalance+Helpers.swift in Sources */,

--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -67,6 +67,8 @@
 		48AE39EC2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AE39EA2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete+View.swift */; };
 		48AE39ED2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AE39EB2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete.swift */; };
 		48AF19CE2BB71C1600796130 /* IntoSargon+Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AF19CD2BB71C1600796130 /* IntoSargon+Bridge.swift */; };
+		48C845C72BEA6DC600F74DA7 /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = 48C845C62BEA6DC600F74DA7 /* Sargon */; };
+		48C845CA2BEA6E2000F74DA7 /* Stage0MigrateToSargon+Accounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C845C92BEA6E2000F74DA7 /* Stage0MigrateToSargon+Accounts.swift */; };
 		48CFC23F2ADC10D900E77A5C /* PreferenceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48CFBC6E2ADC10D800E77A5C /* PreferenceList.swift */; };
 		48CFC2402ADC10D900E77A5C /* AccountPreferences+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48CFBC6F2ADC10D800E77A5C /* AccountPreferences+Reducer.swift */; };
 		48CFC2412ADC10D900E77A5C /* DevAccountPreferences+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48CFBC712ADC10D800E77A5C /* DevAccountPreferences+Reducer.swift */; };
@@ -1068,7 +1070,6 @@
 		E65D6CE72BC9815B001D8A39 /* Stage2MigrateToSargon+AppPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D6CE62BC9815B001D8A39 /* Stage2MigrateToSargon+AppPreferences.swift */; };
 		E65D6CEC2BC98237001D8A39 /* Stage2MigrateToSargon+Gateways.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D6CEB2BC98237001D8A39 /* Stage2MigrateToSargon+Gateways.swift */; };
 		E65D6CEE2BC98267001D8A39 /* Stage2MigrateToSargon+AppPreferences+ViaProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D6CED2BC98267001D8A39 /* Stage2MigrateToSargon+AppPreferences+ViaProfile.swift */; };
-		E6632B172BDFCCB100703B01 /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = E6632B162BDFCCB100703B01 /* Sargon */; };
 		E66DCC402BD93EC000547CF4 /* Stage1MigrateToSargon+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66DCC3F2BD93EC000547CF4 /* Stage1MigrateToSargon+Header.swift */; };
 		E66EEB9B2B06694E007624BC /* RecoverWalletWithoutProfileStart+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66EEB992B06694E007624BC /* RecoverWalletWithoutProfileStart+View.swift */; };
 		E66EEB9C2B06694E007624BC /* RecoverWalletWithoutProfileStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66EEB9A2B06694E007624BC /* RecoverWalletWithoutProfileStart.swift */; };
@@ -1185,6 +1186,7 @@
 		48AE39EA2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecoverWalletControlWithBDFSComplete+View.swift"; sourceTree = "<group>"; };
 		48AE39EB2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverWalletControlWithBDFSComplete.swift; sourceTree = "<group>"; };
 		48AF19CD2BB71C1600796130 /* IntoSargon+Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntoSargon+Bridge.swift"; sourceTree = "<group>"; };
+		48C845C92BEA6E2000F74DA7 /* Stage0MigrateToSargon+Accounts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stage0MigrateToSargon+Accounts.swift"; sourceTree = "<group>"; };
 		48CFBC4F2ADC106300E77A5C /* Radix Wallet Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Radix Wallet Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		48CFBC6E2ADC10D800E77A5C /* PreferenceList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferenceList.swift; sourceTree = "<group>"; };
 		48CFBC6F2ADC10D800E77A5C /* AccountPreferences+Reducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AccountPreferences+Reducer.swift"; sourceTree = "<group>"; };
@@ -2258,7 +2260,7 @@
 				48FFFABC2ADC209100B2B213 /* NukeExtensions in Frameworks */,
 				A41557502B757C5E0040AD4E /* ComposableArchitecture in Frameworks */,
 				48FFFAFD2ADC241A00B2B213 /* HeapModule in Frameworks */,
-				E6632B172BDFCCB100703B01 /* Sargon in Frameworks */,
+				48C845C72BEA6DC600F74DA7 /* Sargon in Frameworks */,
 				48FFFAD52ADC21B900B2B213 /* LegibleError in Frameworks */,
 				48FFFB082ADC6FD300B2B213 /* SwiftUINavigationCore in Frameworks */,
 				48FFFAD82ADC21D200B2B213 /* NonEmpty in Frameworks */,
@@ -2359,6 +2361,14 @@
 				48AE39EB2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete.swift */,
 			);
 			path = Completed;
+			sourceTree = "<group>";
+		};
+		48C845C82BEA6E1400F74DA7 /* Stage0 */ = {
+			isa = PBXGroup;
+			children = (
+				48C845C92BEA6E2000F74DA7 /* Stage0MigrateToSargon+Accounts.swift */,
+			);
+			path = Stage0;
 			sourceTree = "<group>";
 		};
 		48CFBC462ADC106300E77A5C = {
@@ -5798,6 +5808,7 @@
 		E65D6CE42BC980FE001D8A39 /* MIGRATE_TO_SARGON */ = {
 			isa = PBXGroup;
 			children = (
+				48C845C82BEA6E1400F74DA7 /* Stage0 */,
 				E65D6CE82BC9819C001D8A39 /* Stage1 */,
 				E65D6CE52BC98129001D8A39 /* Stage2 */,
 			);
@@ -6362,7 +6373,7 @@
 				A415574F2B757C5E0040AD4E /* ComposableArchitecture */,
 				5B1C4FD42BBB0B0C00B9436F /* AppsFlyerLib-Strict */,
 				489FEF902BDD0B80003EC10D /* Sargon */,
-				E6632B162BDFCCB100703B01 /* Sargon */,
+				48C845C62BEA6DC600F74DA7 /* Sargon */,
 			);
 			productName = RadixWallet;
 			productReference = 48CFBC4F2ADC106300E77A5C /* Radix Wallet Dev.app */;
@@ -6432,7 +6443,7 @@
 				A415574E2B757C5E0040AD4E /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
 				5B1C4FD32BBB0B0C00B9436F /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Strict" */,
 				8318BB172BC8403800057BCB /* XCRemoteSwiftPackageReference "swift-custom-dump" */,
-				E6632B152BDFCCB100703B01 /* XCRemoteSwiftPackageReference "sargon" */,
+				48C845C52BEA6DC600F74DA7 /* XCLocalSwiftPackageReference "../sargon" */,
 			);
 			productRefGroup = 48CFBC502ADC106300E77A5C /* Products */;
 			projectDirPath = "";
@@ -7169,6 +7180,7 @@
 				48CFC28F2ADC10D900E77A5C /* TransactionReviewAccount+View.swift in Sources */,
 				48CFC33D2ADC10D900E77A5C /* DappInteractionCoordinator.swift in Sources */,
 				48CFC4502ADC10DA00E77A5C /* PersonasClient+Live.swift in Sources */,
+				48C845CA2BEA6E2000F74DA7 /* Stage0MigrateToSargon+Accounts.swift in Sources */,
 				48CFC47A2ADC10DA00E77A5C /* LocalAuthenticationClient+Interface.swift in Sources */,
 				48CFC4C32ADC10DA00E77A5C /* ValidatorsUptimeResponse.swift in Sources */,
 				48CFC4F82ADC10DA00E77A5C /* ComponentEntityRoleAssignmentEntryAssignment.swift in Sources */,
@@ -8028,6 +8040,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		48C845C52BEA6DC600F74DA7 /* XCLocalSwiftPackageReference "../sargon" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../sargon;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		48FFFA972ADC1EEC00B2B213 /* XCRemoteSwiftPackageReference "AsyncExtensions" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -8293,18 +8312,14 @@
 				minimumVersion = 1.9.10;
 			};
 		};
-		E6632B152BDFCCB100703B01 /* XCRemoteSwiftPackageReference "sargon" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/radixdlt/sargon";
-			requirement = {
-				kind = exactVersion;
-				version = 0.7.4;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		489FEF902BDD0B80003EC10D /* Sargon */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Sargon;
+		};
+		48C845C62BEA6DC600F74DA7 /* Sargon */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Sargon;
 		};
@@ -8507,11 +8522,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 48FFFAB22ADC206300B2B213 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = SwiftUIIntrospect;
-		};
-		E6632B162BDFCCB100703B01 /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E6632B152BDFCCB100703B01 /* XCRemoteSwiftPackageReference "sargon" */;
-			productName = Sargon;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "136e3a1717e535f7f4817c4c452e7f0f9a077f467187dd7381b7e2ab133531b1",
+  "originHash" : "8472c5c6ff7cb099e55a5730eab8b1fff03773273fb27e4f525674f7930391a1",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -107,15 +107,6 @@
       "state" : {
         "revision" : "33f7e93be5d4ec027d42af77a8ec4680d1862ad2",
         "version" : "11.6.4"
-      }
-    },
-    {
-      "identity" : "sargon",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/radixdlt/sargon",
-      "state" : {
-        "revision" : "a02679cd3f4be02964ccd7a3cc07f1f685cca332",
-        "version" : "0.7.4"
       }
     },
     {

--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8472c5c6ff7cb099e55a5730eab8b1fff03773273fb27e4f525674f7930391a1",
+  "originHash" : "3cdd7744e36817138fd8635ea3d7c4a20d0a97dcdf4565a3b4b324eff4eb80ff",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -107,6 +107,15 @@
       "state" : {
         "revision" : "33f7e93be5d4ec027d42af77a8ec4680d1862ad2",
         "version" : "11.6.4"
+      }
+    },
+    {
+      "identity" : "sargon",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/radixdlt/sargon",
+      "state" : {
+        "revision" : "e5d80d8b51861fc3f04e07c7d564fc20ffff385e",
+        "version" : "0.7.7"
       }
     },
     {

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
@@ -76,7 +76,7 @@ extension AccountPortfoliosClient.State {
 
 	func setTokenPrices(_ tokenPrices: TokenPrices) {
 		self.tokenPrices = tokenPrices
-		if var existingPortfolios = portfoliosSubject.value.values.wrappedValue.map(Array.init) {
+		if var existingPortfolios = portfoliosSubject.value.values.wrappedValue.map({ Array($0) }) {
 			applyTokenPrices(to: &existingPortfolios)
 			setOrUpdateAccountPortfolios(existingPortfolios)
 		}
@@ -84,7 +84,7 @@ extension AccountPortfoliosClient.State {
 
 	func setIsCurrencyAmountVisble(_ isVisible: Bool) {
 		self.isCurrencyAmountVisible = isVisible
-		if var existingPortfolios = portfoliosSubject.value.values.wrappedValue.map(Array.init) {
+		if var existingPortfolios = portfoliosSubject.value.values.wrappedValue.map({ Array($0) }) {
 			applyCurrencyVisibility(to: &existingPortfolios)
 			setOrUpdateAccountPortfolios(existingPortfolios)
 		}
@@ -92,7 +92,7 @@ extension AccountPortfoliosClient.State {
 
 	func setSelectedCurrency(_ currency: FiatCurrency) {
 		self.selectedCurrency = currency
-		if var existingPortfolios = portfoliosSubject.value.values.wrappedValue.map(Array.init) {
+		if var existingPortfolios = portfoliosSubject.value.values.wrappedValue.map({ Array($0) }) {
 			applyFiatCurrency(to: &existingPortfolios)
 			setOrUpdateAccountPortfolios(existingPortfolios)
 		}

--- a/RadixWallet/Clients/AuthorizedDappsClient/AuthorizedDappsClient+Interface.swift
+++ b/RadixWallet/Clients/AuthorizedDappsClient/AuthorizedDappsClient+Interface.swift
@@ -92,7 +92,9 @@ extension AuthorizedDappsClient {
 				authorizedPersonaSimple.sharedPersonaData.remove(ids: idsOfEntriesToDelete)
 
 				// Write back to `updatedAuthedDapp`
-				updatedAuthedDapp.referencesToAuthorizedPersonas[id: authorizedPersonaSimple.id] = authorizedPersonaSimple
+				var referencesToAuthorizedPersonas = updatedAuthedDapp.referencesToAuthorizedPersonas.asIdentified()
+				referencesToAuthorizedPersonas[id: authorizedPersonaSimple.id] = authorizedPersonaSimple
+				updatedAuthedDapp.referencesToAuthorizedPersonas = referencesToAuthorizedPersonas.elements
 
 				// Soundness check
 				if
@@ -100,7 +102,7 @@ extension AuthorizedDappsClient {
 					.isSuperset(
 						of:
 						updatedAuthedDapp
-							.referencesToAuthorizedPersonas[id: authorizedPersonaSimple.id]!
+							.referencesToAuthorizedPersonas.asIdentified()[id: authorizedPersonaSimple.id]!
 							.sharedPersonaData
 							.entryIDs
 					)

--- a/RadixWallet/Clients/AuthorizedDappsClient/AuthorizedDappsClient+Live.swift
+++ b/RadixWallet/Clients/AuthorizedDappsClient/AuthorizedDappsClient+Live.swift
@@ -10,7 +10,7 @@ extension AuthorizedDappsClient: DependencyKey {
 				guard let network = await profileStore.profile.network else {
 					return .init()
 				}
-				return network.authorizedDapps
+				return network.authorizedDapps.asIdentified()
 			},
 			addAuthorizedDapp: { newDapp in
 				try await profileStore.updating {

--- a/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
+++ b/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
@@ -10,7 +10,7 @@ extension FactorSourcesClient: DependencyKey {
 		@Dependency(\.secureStorageClient) var secureStorageClient
 
 		let getFactorSources: GetFactorSources = {
-			await profileStore.profile.factorSources
+			await profileStore.profile.factorSources.asIdentified()
 		}
 
 		let saveFactorSource: SaveFactorSource = { source in
@@ -24,9 +24,11 @@ extension FactorSourcesClient: DependencyKey {
 
 		let updateFactorSource: UpdateFactorSource = { source in
 			try await profileStore.updating { profile in
-				try profile.factorSources.updateFactorSource(id: source.id) {
+				var identifiedFactorSources = profile.factorSources.asIdentified()
+				try identifiedFactorSources.updateFactorSource(id: source.id) {
 					$0 = source
 				}
+				profile.factorSources = identifiedFactorSources.elements
 			}
 		}
 
@@ -179,7 +181,7 @@ extension FactorSourcesClient: DependencyKey {
 				let model = await device.model
 				let name = await device.name
 
-				let mnemonicWithPassphrase = try MnemonicWithPassphrase(
+				let mnemonicWithPassphrase = MnemonicWithPassphrase(
 					mnemonic: mnemonicClient.generate(
 						BIP39WordCount.twentyFour,
 						BIP39Language.english
@@ -303,27 +305,27 @@ extension FactorSourcesClient: DependencyKey {
 				assert(request.signers.allSatisfy { $0.networkID == request.networkID })
 				return try await signingFactors(
 					for: request.signers,
-					from: getFactorSources().asIdentified(),
+					from: getFactorSources(),
 					signingPurpose: request.signingPurpose
 				)
 			},
 			updateLastUsed: { request in
 				_ = try await profileStore.updating { profile in
-					var factorSources = profile.factorSources
+					var identifiedFactorSources = profile.factorSources.asIdentified()
 					for id in request.factorSourceIDs {
-						guard var factorSource = factorSources.get(id: id) else {
+						guard var factorSource = identifiedFactorSources[id: id] else {
 							throw FactorSourceNotFound()
 						}
 						factorSource.common.lastUsedOn = request.lastUsedOn
-						let updated = factorSources.updateOrAppend(factorSource)
+						let updated = identifiedFactorSources.updateOrAppend(factorSource)
 						assert(updated != nil)
 					}
-					profile.factorSources = factorSources
+					profile.factorSources = identifiedFactorSources.elements
 				}
 			},
 			flagFactorSourceForDeletion: { id in
 				let factorSources = try await getFactorSources()
-				guard var factorSource = factorSources.get(id: id) else {
+				guard var factorSource = factorSources[id: id] else {
 					throw FactorSourceNotFound()
 				}
 				factorSource.flag(.deletedByUser)

--- a/RadixWallet/Clients/GatewaysClient/GatewaysClient+Interface.swift
+++ b/RadixWallet/Clients/GatewaysClient/GatewaysClient+Interface.swift
@@ -34,7 +34,7 @@ extension GatewaysClient {
 	public typealias CurrentGatewayValues = @Sendable () async -> AnyAsyncSequence<Gateway>
 	public typealias GatewaysValues = @Sendable () async -> AnyAsyncSequence<SavedGateways>
 	public typealias GetCurrentGateway = @Sendable () async -> Gateway
-	public typealias GetAllGateways = @Sendable () async -> [Gateway]
+	public typealias GetAllGateways = @Sendable () async -> Gateways
 	public typealias AddGateway = @Sendable (Gateway) async throws -> Void
 	public typealias RemoveGateway = @Sendable (Gateway) async throws -> Void
 	public typealias ChangeGateway = @Sendable (Gateway) async throws -> Void

--- a/RadixWallet/Clients/GatewaysClient/GatewaysClient+Interface.swift
+++ b/RadixWallet/Clients/GatewaysClient/GatewaysClient+Interface.swift
@@ -32,7 +32,7 @@ public struct GatewaysClient: Sendable {
 
 extension GatewaysClient {
 	public typealias CurrentGatewayValues = @Sendable () async -> AnyAsyncSequence<Gateway>
-	public typealias GatewaysValues = @Sendable () async -> AnyAsyncSequence<Gateways>
+	public typealias GatewaysValues = @Sendable () async -> AnyAsyncSequence<SavedGateways>
 	public typealias GetCurrentGateway = @Sendable () async -> Gateway
 	public typealias GetAllGateways = @Sendable () async -> [Gateway]
 	public typealias AddGateway = @Sendable (Gateway) async throws -> Void

--- a/RadixWallet/Clients/GatewaysClient/GatewaysClient+Live.swift
+++ b/RadixWallet/Clients/GatewaysClient/GatewaysClient+Live.swift
@@ -10,7 +10,7 @@ extension GatewaysClient: DependencyKey {
 		return Self(
 			currentGatewayValues: { await profileStore.currentGatewayValues() },
 			gatewaysValues: { await profileStore.gatewaysValues() },
-			getAllGateways: { await appPreferencesClient.getPreferences().gateways.all },
+			getAllGateways: { await appPreferencesClient.getPreferences().gateways.all.asIdentified() },
 			getCurrentGateway: { await appPreferencesClient.getPreferences().gateways.current },
 			addGateway: { gateway in
 				try await profileStore.updating { profile in

--- a/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Live.swift
+++ b/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Live.swift
@@ -9,7 +9,7 @@ extension P2PLinksClient: DependencyKey {
 
 		return Self(
 			getP2PLinks: {
-				await appPreferencesClient.getPreferences().p2pLinks
+				await appPreferencesClient.getPreferences().p2pLinks.asIdentified()
 			},
 			addP2PLink: { newLink in
 				try await appPreferencesClient.updating {

--- a/RadixWallet/Clients/ProfileStore/ProfileStore+AsyncSequence+Updates.swift
+++ b/RadixWallet/Clients/ProfileStore/ProfileStore+AsyncSequence+Updates.swift
@@ -34,7 +34,7 @@ extension ProfileStore {
 	}
 
 	/// A multicasting replaying AsyncSequence of distinct Gateways
-	public func gatewaysValues() -> AnyAsyncSequence<Gateways> {
+	public func gatewaysValues() -> AnyAsyncSequence<SavedGateways> {
 		_lens {
 			$0.appPreferences.gateways
 		}

--- a/RadixWallet/Clients/ProfileStore/ProfileStore+AsyncSequence+Updates.swift
+++ b/RadixWallet/Clients/ProfileStore/ProfileStore+AsyncSequence+Updates.swift
@@ -43,7 +43,7 @@ extension ProfileStore {
 	/// A multicasting replaying AsyncSequence of distinct FactorSources
 	public func factorSourcesValues() -> AnyAsyncSequence<FactorSources> {
 		_lens {
-			$0.factorSources
+			$0.factorSources.asIdentified()
 		}
 	}
 

--- a/RadixWallet/Clients/ProfileStore/ProfileStore.swift
+++ b/RadixWallet/Clients/ProfileStore/ProfileStore.swift
@@ -244,9 +244,7 @@ extension ProfileStore {
 					numberOfNetworks: 1
 				)
 			),
-			factorSources: FactorSources(
-				element: bdfs.asGeneral
-			),
+			factorSources: [bdfs.asGeneral],
 			appPreferences: .default,
 			networks: [network]
 		)
@@ -514,7 +512,7 @@ extension ProfileStore {
 		do {
 			if var existing = try _tryLoadSavedProfile() {
 				if
-					case let bdfs = existing.factorSources.babylonDevice,
+					case let bdfs = existing.factorSources.asIdentified().babylonDevice,
 					!secureStorageClient.containsMnemonicIdentifiedByFactorSourceID(bdfs.id),
 					existing.networks.isEmpty
 				{

--- a/RadixWallet/Clients/ProfileStore/ProfileStore.swift
+++ b/RadixWallet/Clients/ProfileStore/ProfileStore.swift
@@ -248,9 +248,7 @@ extension ProfileStore {
 				element: bdfs.asGeneral
 			),
 			appPreferences: .default,
-			networks: ProfileNetworks(
-				element: network
-			)
+			networks: [network]
 		)
 
 		// We can "piggyback" on importProfile! Same logic applies!

--- a/RadixWallet/Clients/ProfileStore/ProfileStore.swift
+++ b/RadixWallet/Clients/ProfileStore/ProfileStore.swift
@@ -224,7 +224,7 @@ extension ProfileStore {
 		// she creates her first account.
 		let network = ProfileNetwork(
 			id: .mainnet,
-			accounts: accounts,
+			accounts: accounts.elements, // FIXME: Declare init in (Swift)Sargon accepting `Accounts` (IdentifiedArrayOf<Account>) ?
 			personas: [],
 			authorizedDapps: []
 		)

--- a/RadixWallet/Core/SargonExtensions/CanBeEmptyIdentifiedCollection+IdentifiedArrayOf.swift
+++ b/RadixWallet/Core/SargonExtensions/CanBeEmptyIdentifiedCollection+IdentifiedArrayOf.swift
@@ -1,8 +1,0 @@
-import Foundation
-import Sargon
-
-extension CanBeEmptyIdentifiedCollection {
-	public init(identified: IdentifiedArrayOf<Element>) {
-		self.init(identified.elements)
-	}
-}

--- a/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
+++ b/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
@@ -145,7 +145,7 @@ public struct AccountRecoveryScanCoordinator: Sendable, FeatureReducer {
 		active: IdentifiedArrayOf<Account>,
 		inactive: IdentifiedArrayOf<Account>
 	) -> Effect<Action> {
-		let sortedAccounts: IdentifiedArrayOf<Account> = { () -> IdentifiedArrayOf<Account> in
+		let sortedAccounts: Accounts = { () -> IdentifiedArrayOf<Account> in
 			var accounts = active
 			accounts.append(contentsOf: inactive)
 			accounts.sort() // by index
@@ -156,7 +156,7 @@ public struct AccountRecoveryScanCoordinator: Sendable, FeatureReducer {
 		switch purpose {
 		case let .createProfile(privateHD):
 			let recoveredAccountAndBDFS = AccountsRecoveredFromScanningUsingMnemonic(
-				accounts: Accounts(identified: sortedAccounts),
+				accounts: sortedAccounts,
 				deviceFactorSource: privateHD.factorSource
 			)
 			return .run { send in
@@ -174,7 +174,7 @@ public struct AccountRecoveryScanCoordinator: Sendable, FeatureReducer {
 			return .run { send in
 				let result = await TaskResult<EqVoid> {
 					try await accountsClient.saveVirtualAccounts(
-						Accounts(identified: sortedAccounts)
+						sortedAccounts
 					)
 				}
 				await send(.internal(.addAccountsToExistingProfileResult(result)))

--- a/RadixWallet/Features/DappInteractionFeature/Children/Login/Coordinator/Login.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Login/Coordinator/Login.swift
@@ -170,7 +170,7 @@ struct Login: Sendable, FeatureReducer {
 					return nil
 				}
 				return personas.reduce(into: nil) { mostRecentlyAuthorizedPersona, currentPersona in
-					guard let currentAuthorizedPersona = authorizedDapp.referencesToAuthorizedPersonas[id: currentPersona.address] else {
+					guard let currentAuthorizedPersona = authorizedDapp.referencesToAuthorizedPersonas.asIdentified()[id: currentPersona.address] else {
 						return
 					}
 					if let mostRecentlyAuthorizedPersonaCopy = mostRecentlyAuthorizedPersona {

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -483,7 +483,9 @@ extension DappInteractionFlow {
 		if resetItem.personaData {
 			authorizedPersona.sharedPersonaData = .default
 		}
-		authorizedDapp.referencesToAuthorizedPersonas[id: authorizedPersona.id] = authorizedPersona
+		var identifiedReferencesToAuthorizedPersonas = authorizedDapp.referencesToAuthorizedPersonas.asIdentified()
+		identifiedReferencesToAuthorizedPersonas[id: authorizedPersona.id] = authorizedPersona
+		authorizedDapp.referencesToAuthorizedPersonas = identifiedReferencesToAuthorizedPersonas.elements
 		state.authorizedDapp = authorizedDapp
 		state.authorizedPersona = authorizedPersona
 	}
@@ -768,7 +770,9 @@ extension DappInteractionFlow {
 				)
 			}
 		}()
-		authorizedDapp.referencesToAuthorizedPersonas[id: authorizedPersona.id] = authorizedPersona
+		var identifiedDeferencesToAuthorizedPersonas = authorizedDapp.referencesToAuthorizedPersonas.asIdentified()
+		identifiedDeferencesToAuthorizedPersonas[id: authorizedPersona.id] = authorizedPersona
+		authorizedDapp.referencesToAuthorizedPersonas = identifiedDeferencesToAuthorizedPersonas.elements
 		try await authorizedDappsClient.updateOrAddAuthorizedDapp(authorizedDapp)
 	}
 

--- a/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails.swift
+++ b/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails.swift
@@ -235,7 +235,12 @@ public struct DappDetails: Sendable, FeatureReducer {
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
 		case let .personaList(.delegate(.openDetails(persona))):
-			guard let dApp = state.authorizedDapp, let detailedPersona = dApp.detailedAuthorizedPersonas[id: persona.id] else { return .none }
+			
+			guard
+				let dApp = state.authorizedDapp,
+				let detailedPersona = dApp.detailedAuthorizedPersonas.asIdentified()[id: persona.id]
+			else { return .none }
+			
 			let personaDetailsState = PersonaDetails.State(.dApp(dApp, persona: detailedPersona))
 			state.destination = .personaDetails(personaDetailsState)
 			return .none

--- a/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails.swift
+++ b/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails.swift
@@ -235,12 +235,12 @@ public struct DappDetails: Sendable, FeatureReducer {
 	public func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
 		case let .personaList(.delegate(.openDetails(persona))):
-			
+
 			guard
 				let dApp = state.authorizedDapp,
 				let detailedPersona = dApp.detailedAuthorizedPersonas.asIdentified()[id: persona.id]
 			else { return .none }
-			
+
 			let personaDetailsState = PersonaDetails.State(.dApp(dApp, persona: detailedPersona))
 			state.destination = .personaDetails(personaDetailsState)
 			return .none

--- a/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
@@ -166,9 +166,12 @@ extension PersonaDetails.State {
 	var accountSection: AccountSection? {
 		switch mode {
 		case .general:
-			nil
+			return nil
 		case let .dApp(dApp, persona):
-			.init(dAppName: dApp.displayName?.rawValue ?? L10n.DAppRequest.Metadata.unknownName, sharingAccounts: persona.simpleAccounts ?? [])
+			return AccountSection(
+				dAppName: dApp.displayName?.rawValue ?? L10n.DAppRequest.Metadata.unknownName,
+				sharingAccounts: persona.simpleAccounts?.asIdentified() ?? []
+			)
 		}
 	}
 

--- a/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
@@ -166,9 +166,9 @@ extension PersonaDetails.State {
 	var accountSection: AccountSection? {
 		switch mode {
 		case .general:
-			return nil
+			nil
 		case let .dApp(dApp, persona):
-			return AccountSection(
+			AccountSection(
 				dAppName: dApp.displayName?.rawValue ?? L10n.DAppRequest.Metadata.unknownName,
 				sharingAccounts: persona.simpleAccounts?.asIdentified() ?? []
 			)

--- a/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails.swift
+++ b/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails.swift
@@ -277,7 +277,8 @@ public struct PersonaDetails: Sendable, FeatureReducer {
 		switch mode {
 		case let .dApp(dApp, persona: persona):
 			let updatedDapp = try await authorizedDappsClient.getDetailedDapp(dApp.dAppDefinitionAddress)
-			guard let updatedPersona = updatedDapp.detailedAuthorizedPersonas[id: persona.id] else {
+			let identifiedDetailedAuthorizedPersonas = updatedDapp.detailedAuthorizedPersonas.asIdentified()
+			guard let updatedPersona = identifiedDetailedAuthorizedPersonas[id: persona.id] else {
 				throw ReloadError.personaNotPresentInDapp(persona.id, updatedDapp.dAppDefinitionAddress)
 			}
 			return .dApp(updatedDapp, persona: updatedPersona)

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Child/List/PersonaList+Reducer.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Child/List/PersonaList+Reducer.swift
@@ -100,7 +100,7 @@ public struct PersonaList: Sendable, FeatureReducer {
 			return ids
 		case let .dApp(dAppID):
 			guard let dApp = try? await authorizedDappsClient.getDetailedDapp(dAppID) else { return [] }
-			return OrderedSet(dApp.detailedAuthorizedPersonas.ids)
+			return OrderedSet(dApp.detailedAuthorizedPersonas.map(\.id))
 		}
 	}
 

--- a/RadixWallet/Features/DebugInspectProfile/InspectProfile+View.swift
+++ b/RadixWallet/Features/DebugInspectProfile/InspectProfile+View.swift
@@ -56,7 +56,7 @@ extension ProfileView {
 				)
 
 				PerNetworkView(
-					networks: profile.networks,
+					networks: profile.networks.asIdentified(),
 					indentation: inOneLevel
 				)
 

--- a/RadixWallet/Features/DebugInspectProfile/InspectProfile+View.swift
+++ b/RadixWallet/Features/DebugInspectProfile/InspectProfile+View.swift
@@ -262,7 +262,7 @@ extension AppPreferencesView {
 			)
 
 			GatewaysView(
-				gateways: appPreferences.gateways,
+				savedGateways: appPreferences.gateways,
 				indentation: inOneLevel
 			)
 
@@ -277,17 +277,17 @@ extension AppPreferencesView {
 
 // MARK: - GatewaysView
 public struct GatewaysView: IndentedView {
-	public let gateways: Gateways
+	public let savedGateways: SavedGateways
 	public let indentation: Indentation
 }
 
 extension GatewaysView {
 	public var body: some View {
 		VStack(alignment: .leading, spacing: indentation.spacing) {
-			ForEach(gateways.all) { gateway in
+			ForEach(savedGateways.all) { gateway in
 				GatewayView(
 					gateway: gateway,
-					isCurrent: self.gateways.current == gateway,
+					isCurrent: savedGateways.current == gateway,
 					indentation: inOneLevel
 				)
 			}

--- a/RadixWallet/Features/DebugInspectProfile/InspectProfile+View.swift
+++ b/RadixWallet/Features/DebugInspectProfile/InspectProfile+View.swift
@@ -66,7 +66,7 @@ extension ProfileView {
 				)
 
 				FactorSourcesView(
-					factorSources: profile.factorSources,
+					factorSources: profile.factorSources.asIdentified(),
 					indentation: inOneLevel
 				)
 			}
@@ -385,7 +385,7 @@ extension AuthorizedDappsView {
 					AuthorizedDappView(
 						authorizedDapp: authorizedDapp,
 						indentation: inOneLevel,
-						authorizedPersonas: getDetailedAuthorizedDapp(authorizedDapp)?.detailedAuthorizedPersonas
+						authorizedPersonas: getDetailedAuthorizedDapp(authorizedDapp)?.detailedAuthorizedPersonas.asIdentified()
 					)
 				}
 			}
@@ -543,7 +543,7 @@ extension ProfileNetworkView {
 			)
 
 			AuthorizedDappsView(
-				authorizedDapps: network.authorizedDapps,
+				authorizedDapps: network.authorizedDapps.asIdentified(),
 				indentation: inOneLevel
 			) {
 				try? network.detailsForAuthorizedDapp($0)

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Coordinator/RestoreProfileFromBackupCoordinator.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Coordinator/RestoreProfileFromBackupCoordinator.swift
@@ -90,7 +90,7 @@ public struct RestoreProfileFromBackupCoordinator: Sendable, FeatureReducer {
 			state.profileSelection = .init(snapshot: profileSnapshot, isInCloud: isInCloud)
 			return .run { send in
 				try? await clock.sleep(for: .milliseconds(300))
-				try await radixConnectClient.connectToP2PLinks(profileSnapshot.appPreferences.p2pLinks)
+				try await radixConnectClient.connectToP2PLinks(profileSnapshot.appPreferences.p2pLinks.asIdentified())
 				await send(.internal(.delayedAppendToPath(
 					.importMnemonicsFlow(.init(context: .fromOnboarding(profileSnapshot: profileSnapshot))
 					))))

--- a/RadixWallet/Features/SettingsFeature/Troubleshooting/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator.swift
+++ b/RadixWallet/Features/SettingsFeature/Troubleshooting/ImportFromOlympiaLegacyWallet/Coordinator/ImportOlympiaWalletCoordinator.swift
@@ -515,7 +515,7 @@ public struct ImportOlympiaWalletCoordinator: Sendable, FeatureReducer {
 
 		state.progress = .migratedSoftwareAccounts(.init(
 			previous: progress.previous,
-			migratedSoftwareAccounts: softwareAccounts.babylonAccounts.asIdentified()
+			migratedSoftwareAccounts: softwareAccounts.babylonAccounts
 		))
 
 		return migrateHardwareAccounts(in: &state)

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
@@ -10,6 +10,8 @@ import Sargon
 import IdentifiedCollections
 
 public typealias Accounts = IdentifiedArrayOf<Account>
+public typealias Personas = IdentifiedArrayOf<Persona>
+public typealias ProfileNetworks = IdentifiedArrayOf<ProfileNetwork>
 
 public typealias EntityFlags = IdentifiedArrayOf<EntityFlag>
 

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
@@ -1,0 +1,33 @@
+//
+//  Stage0MigrateToSargon+Accounts.swift
+//  RadixWallet
+//
+//  Created by Alexander Cyon on 2024-05-07.
+//
+
+import Foundation
+import Sargon
+import IdentifiedCollections
+
+public typealias Accounts = IdentifiedArrayOf<Account>
+
+public typealias EntityFlags = IdentifiedArrayOf<EntityFlag>
+
+extension Account {
+	public var entityFlags: EntityFlags {
+		get { flags.asIdentified() }
+		set {
+			flags = newValue.elements
+		}
+	}
+}
+
+
+extension Persona {
+	public var entityFlags: EntityFlags {
+		get { flags.asIdentified() }
+		set {
+			flags = newValue.elements
+		}
+	}
+}

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
@@ -13,6 +13,7 @@ public typealias AuthorizedDapps = IdentifiedArrayOf<AuthorizedDapp>
 public typealias ReferencesToAuthorizedPersonas = IdentifiedArrayOf<AuthorizedPersonaSimple>
 public typealias DetailedAuthorizedPersonas = IdentifiedArrayOf<AuthorizedPersonaDetailed>
 public typealias AccountsForDisplay = IdentifiedArrayOf<AccountForDisplay>
+public typealias Gateways = IdentifiedArrayOf<Gateway>
 
 public typealias EntityFlags = IdentifiedArrayOf<EntityFlag>
 

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
@@ -12,6 +12,15 @@ import IdentifiedCollections
 public typealias Accounts = IdentifiedArrayOf<Account>
 public typealias Personas = IdentifiedArrayOf<Persona>
 public typealias ProfileNetworks = IdentifiedArrayOf<ProfileNetwork>
+public typealias AssetsExceptionList = IdentifiedArrayOf<AssetException>
+public typealias DepositorsAllowList = IdentifiedArrayOf<ResourceOrNonFungible>
+public typealias FactorSources = IdentifiedArrayOf<FactorSource>
+public typealias P2PLinks = IdentifiedArrayOf<P2PLink>
+public typealias AuthorizedDapps = IdentifiedArrayOf<AuthorizedDapp>
+public typealias ReferencesToAuthorizedPersonas = IdentifiedArrayOf<AuthorizedPersonaSimple>
+public typealias DetailedAuthorizedPersonas = IdentifiedArrayOf<AuthorizedPersonaDetailed>
+public typealias AccountsForDisplay = IdentifiedArrayOf<AccountForDisplay>
+
 
 public typealias EntityFlags = IdentifiedArrayOf<EntityFlag>
 

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage0/Stage0MigrateToSargon+Accounts.swift
@@ -1,13 +1,6 @@
-//
-//  Stage0MigrateToSargon+Accounts.swift
-//  RadixWallet
-//
-//  Created by Alexander Cyon on 2024-05-07.
-//
-
 import Foundation
-import Sargon
 import IdentifiedCollections
+import Sargon
 
 public typealias Accounts = IdentifiedArrayOf<Account>
 public typealias Personas = IdentifiedArrayOf<Persona>
@@ -21,7 +14,6 @@ public typealias ReferencesToAuthorizedPersonas = IdentifiedArrayOf<AuthorizedPe
 public typealias DetailedAuthorizedPersonas = IdentifiedArrayOf<AuthorizedPersonaDetailed>
 public typealias AccountsForDisplay = IdentifiedArrayOf<AccountForDisplay>
 
-
 public typealias EntityFlags = IdentifiedArrayOf<EntityFlag>
 
 extension Account {
@@ -32,7 +24,6 @@ extension Account {
 		}
 	}
 }
-
 
 extension Persona {
 	public var entityFlags: EntityFlags {

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+Account.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+Account.swift
@@ -30,7 +30,6 @@ extension Account {
 }
 
 extension Account {
-	
 	public var accountAddress: AccountAddress {
 		address
 	}
@@ -53,7 +52,6 @@ extension Accounts {
 		filter(\.isHidden)
 	}
 }
-
 
 extension [Account] {
 	public var nonHidden: Accounts {

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+Account.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+Account.swift
@@ -1,9 +1,6 @@
 import Foundation
 import Sargon
 
-// MARK: - Account + EntityBaseProtocol
-extension Account: EntityBaseProtocol {}
-
 // MARK: - Account + Comparable
 extension Account: Comparable {
 	public static func < (lhs: Self, rhs: Self) -> Bool {
@@ -33,6 +30,7 @@ extension Account {
 }
 
 extension Account {
+	
 	public var accountAddress: AccountAddress {
 		address
 	}
@@ -42,7 +40,7 @@ extension Account {
 	}
 
 	public mutating func unhide() {
-		flags.remove(element: .deletedByUser)
+		entityFlags.remove(.deletedByUser)
 	}
 }
 
@@ -53,5 +51,16 @@ extension Accounts {
 
 	public var hidden: Accounts {
 		filter(\.isHidden)
+	}
+}
+
+
+extension [Account] {
+	public var nonHidden: Accounts {
+		asIdentified().nonHidden
+	}
+
+	public var hidden: Accounts {
+		asIdentified().hidden
 	}
 }

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+FactorSourceCryptoParameters.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+FactorSourceCryptoParameters.swift
@@ -2,6 +2,7 @@ import Foundation
 import OrderedCollections
 import Sargon
 
+// MARK: - CannotBeEmpty
 struct CannotBeEmpty: Swift.Error {}
 extension Array {
 	public init(notEmpty elements: some Collection<Element>) throws {

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+FactorSourceCryptoParameters.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+FactorSourceCryptoParameters.swift
@@ -2,6 +2,16 @@ import Foundation
 import OrderedCollections
 import Sargon
 
+struct CannotBeEmpty: Swift.Error {}
+extension Array {
+	public init(notEmpty elements: some Collection<Element>) throws {
+		guard !elements.isEmpty else {
+			throw CannotBeEmpty()
+		}
+		self = Array(elements)
+	}
+}
+
 extension FactorSourceCryptoParameters {
 	/// Appends  `supportedCurves` and `supportedDerivationPathSchemes` from `other`. This is used if a user tries to
 	/// add an Olympia Factor Source from Manual Account Recovery Scan where the mnemonic already existed as BDFS => append
@@ -11,9 +21,9 @@ extension FactorSourceCryptoParameters {
 		guard self != other else {
 			return
 		}
-		var curves = supportedCurves.elements
+		var curves = supportedCurves
 		var derivationSchemes = supportedDerivationPathSchemes
-		curves.append(contentsOf: other.supportedCurves.elements)
+		curves.append(contentsOf: other.supportedCurves)
 		derivationSchemes.append(contentsOf: other.supportedDerivationPathSchemes)
 
 		curves = OrderedSet(
@@ -24,7 +34,7 @@ extension FactorSourceCryptoParameters {
 			uncheckedUniqueElements: derivationSchemes.sorted(by: \.preference)
 		).elements
 
-		self.supportedCurves = try! .init(curves)
+		self.supportedCurves = try! .init(notEmpty: curves)
 		self.supportedDerivationPathSchemes = derivationSchemes
 	}
 }

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+FactorSources.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+FactorSources.swift
@@ -15,7 +15,7 @@ extension FactorSources {
 		id: FactorSourceID,
 		_ mutate: (inout FactorSource) throws -> Void
 	) throws {
-		guard var factorSource = self.get(id: id) else {
+		guard var factorSource = self[id: id] else {
 			throw FactorSourceWithIDNotFound()
 		}
 		try mutate(&factorSource)

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+Persona.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+Persona.swift
@@ -1,9 +1,6 @@
 import Foundation
 import Sargon
 
-// MARK: - Persona + EntityBaseProtocol
-extension Persona: EntityBaseProtocol {}
-
 // MARK: - PersonaDataCollectionElement
 public protocol PersonaDataCollectionElement: Hashable & Identifiable where ID == PersonaDataEntryID {
 	associatedtype Value: Hashable

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+ThirdPartyDeposits.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+ThirdPartyDeposits.swift
@@ -2,7 +2,6 @@ import Foundation
 import OrderedCollections
 import Sargon
 
-
 extension ThirdPartyDeposits {
 	public func assetsExceptionSet() -> OrderedSet<AssetException> {
 		assetsExceptionList.map(OrderedSet.init) ?? []

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+ThirdPartyDeposits.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+ThirdPartyDeposits.swift
@@ -2,6 +2,7 @@ import Foundation
 import OrderedCollections
 import Sargon
 
+
 extension ThirdPartyDeposits {
 	public func assetsExceptionSet() -> OrderedSet<AssetException> {
 		assetsExceptionList.map(OrderedSet.init) ?? []
@@ -19,11 +20,12 @@ extension ThirdPartyDeposits {
 	)
 
 	public mutating func appendToAssetsExceptionList(_ new: AssetException) {
-		if assetsExceptionList == nil {
+		guard var identifiedAssetsExceptions = assetsExceptionList?.asIdentified() else {
 			assetsExceptionList = [new]
-		} else {
-			assetsExceptionList!.updateOrAppend(new)
+			return
 		}
+		identifiedAssetsExceptions.updateOrAppend(new)
+		assetsExceptionList = identifiedAssetsExceptions.elements
 	}
 
 	public mutating func removeAllAssetsExceptions() {
@@ -35,18 +37,23 @@ extension ThirdPartyDeposits {
 	}
 
 	public mutating func updateAssetsExceptionList(_ update: (inout AssetsExceptionList?) -> Void) {
-		update(&self.assetsExceptionList)
+		var identifiedExceptions = assetsExceptionList?.asIdentified()
+		update(&identifiedExceptions)
+		assetsExceptionList = identifiedExceptions?.elements
 	}
 
 	public mutating func updateDepositorsAllowList(_ update: (inout DepositorsAllowList?) -> Void) {
-		update(&self.depositorsAllowList)
+		var identifiedExceptions = depositorsAllowList?.asIdentified()
+		update(&identifiedExceptions)
+		depositorsAllowList = identifiedExceptions?.elements
 	}
 
 	public mutating func appendToDepositorsAllowList(_ new: ResourceOrNonFungible) {
-		if depositorsAllowList == nil {
+		guard var identifiedAssetsExceptions = depositorsAllowList?.asIdentified() else {
 			depositorsAllowList = [new]
-		} else {
-			depositorsAllowList!.updateOrAppend(new)
+			return
 		}
+		identifiedAssetsExceptions.updateOrAppend(new)
+		depositorsAllowList = identifiedAssetsExceptions.elements
 	}
 }

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+AppPreferences.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+AppPreferences.swift
@@ -15,7 +15,10 @@ extension AppPreferences {
 	/// Appends a new `P2PLink`, returns `nil` if it was not inserted (because already present).
 	@discardableResult
 	public mutating func appendP2PLink(_ p2pLink: P2PLink) -> P2PLink? {
-		self.p2pLinks.appendP2PLink(p2pLink)
+		var identifiedP2PLinks = p2pLinks.asIdentified()
+		let appended = identifiedP2PLinks.appendP2PLink(p2pLink)
+		p2pLinks = identifiedP2PLinks.elements
+		return appended
 	}
 }
 
@@ -23,11 +26,11 @@ extension P2PLinks {
 	/// Appends a new `P2PLink`, returns `nil` if it was not inserted (because already present).
 	@discardableResult
 	public mutating func appendP2PLink(_ link: P2PLink) -> P2PLink? {
-		guard !contains(id: link.id) else {
+		guard !contains(link) else {
 			return nil
 		}
 		append(link)
-		assert(contains(id: link.id))
+		assert(contains(link))
 		return link
 	}
 }

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Gateways.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Gateways.swift
@@ -15,7 +15,9 @@ extension SavedGateways {
 	}
 
 	public mutating func remove(_ gateway: Gateway) {
-		other.remove(element: gateway)
+		var identifiedOther = other.asIdentified()
+		identifiedOther.remove(gateway)
+		other = identifiedOther.elements
 	}
 
 	public var customDumpMirror: Mirror {

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Gateways.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Gateways.swift
@@ -3,7 +3,7 @@ import Sargon
 
 // MARK: - DiscrepancyOtherShouldNotContainCurrent
 struct DiscrepancyOtherShouldNotContainCurrent: Swift.Error {}
-extension Gateways {
+extension SavedGateways {
 	public mutating func changeCurrentToMainnetIfNeeded() {
 		if current == .mainnet { return }
 		try? changeCurrent(to: .mainnet)

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Persona.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Persona.swift
@@ -3,11 +3,11 @@ import Sargon
 
 extension Persona {
 	public mutating func hide() {
-		flags.append(.deletedByUser)
+		entityFlags.append(.deletedByUser)
 	}
 
 	public mutating func unhide() {
-		flags.remove(.deletedByUser)
+		entityFlags.remove(.deletedByUser)
 	}
 }
 

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Persona.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Persona.swift
@@ -16,7 +16,7 @@ extension Personas {
 		filter(not(\.isHidden))
 	}
 
-	public var hiden: Personas {
+	public var hidden: Personas {
 		filter(\.isHidden)
 	}
 }

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+ProfileNetwork.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+ProfileNetwork.swift
@@ -107,7 +107,9 @@ extension ProfileNetwork {
 
 			/// Remove the persona reference on any authorized dapp
 			authorizedDapps.mutateAll { dapp in
-				dapp.referencesToAuthorizedPersonas.remove(id)
+				var referencesToAuthorizedPersonas = dapp.referencesToAuthorizedPersonas.asIdentified()
+				referencesToAuthorizedPersonas.remove(id: id)
+				dapp.referencesToAuthorizedPersonas = referencesToAuthorizedPersonas.elements
 			}
 		}
 		self.personas = identifiedPersonas.elements

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Profile/Profile/Profile+Account+Add.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Profile/Profile/Profile+Account+Add.swift
@@ -43,8 +43,9 @@ extension Profile {
 				personas: [],
 				authorizedDapps: []
 			)
-
-			try networks.add(network)
+			var identifiedNetworks = networks.asIdentified()
+			try identifiedNetworks.add(network)
+			self.networks = identifiedNetworks.elements
 
 			if network.id == .mainnet {
 				do {

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Profile/Profile/Profile+Account+Add.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Profile/Profile/Profile+Account+Add.swift
@@ -39,7 +39,7 @@ extension Profile {
 		} else {
 			let network = ProfileNetwork(
 				id: networkID,
-				accounts: Accounts(element: account),
+				accounts: [account],
 				personas: [],
 				authorizedDapps: []
 			)

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Profile/Profile/Profile+UpdateNetwork.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Profile/Profile/Profile+UpdateNetwork.swift
@@ -2,7 +2,9 @@ import Sargon
 
 extension Profile {
 	mutating func updateOnNetwork(_ network: ProfileNetwork) throws {
-		try networks.update(network)
+		var identifiedNetworks = networks.asIdentified()
+		try identifiedNetworks.update(network)
+		self.networks = identifiedNetworks.elements
 	}
 }
 
@@ -18,7 +20,7 @@ extension Profile {
 	}
 
 	public func network(id needle: NetworkID) throws -> ProfileNetwork {
-		try networks.network(id: needle)
+		try networks.asIdentified().network(id: needle)
 	}
 
 	public func containsNetwork(withID networkID: NetworkID) -> Bool {

--- a/RadixWallet/Prelude/Extensions/Array+Identifiable.swift
+++ b/RadixWallet/Prelude/Extensions/Array+Identifiable.swift
@@ -1,3 +1,6 @@
+import IdentifiedCollections
+import NonEmpty
+
 extension Array where Element: Identifiable {
 	/// Returns an `IdentifiedArray` of the `Element`, omitting clashing elements
 	public func asIdentified() -> IdentifiedArrayOf<Element> {
@@ -13,5 +16,11 @@ extension Array where Element: Identifiable {
 extension Array {
 	var nonEmpty: NonEmpty<Self>? {
 		.init(self)
+	}
+}
+
+extension IdentifiedArrayOf {
+	var nonEmptyElements: NonEmpty<[Element]>? {
+		.init(rawValue: elements)
 	}
 }

--- a/RadixWallet/Prelude/Extensions/Array+Identifiable.swift
+++ b/RadixWallet/Prelude/Extensions/Array+Identifiable.swift
@@ -1,10 +1,3 @@
-extension BaseIdentifiedCollection {
-	/// Returns an `IdentifiedArray` of the `Element`, omitting clashing elements
-	public func asIdentified() -> IdentifiedArrayOf<Element> {
-		elements.asIdentified()
-	}
-}
-
 extension Array where Element: Identifiable {
 	/// Returns an `IdentifiedArray` of the `Element`, omitting clashing elements
 	public func asIdentified() -> IdentifiedArrayOf<Element> {

--- a/RadixWalletTests/Clients/ProfileStoreTests/ProfileStoreTests.swift
+++ b/RadixWalletTests/Clients/ProfileStoreTests/ProfileStoreTests.swift
@@ -625,7 +625,7 @@ final class ProfileStoreExistingProfileTests: TestCase {
 			let mnemonicGotDeleted = self.expectation(description: "Mnemonic got deleted")
 			// GIVEN saved profile
 			let savedEmptyProfile = Profile.newEmpty()
-			let firstBDFS = savedEmptyProfile.factorSources.babylonDevice
+			let firstBDFS = savedEmptyProfile.factorSources.asIdentified().babylonDevice
 
 			let used = await withTestClients {
 				$0.secureStorageClient.containsMnemonicIdentifiedByFactorSourceID = { factorSourceID in

--- a/RadixWalletTests/ProfileTests/EntitiesHidingTests.swift
+++ b/RadixWalletTests/ProfileTests/EntitiesHidingTests.swift
@@ -108,13 +108,13 @@ final class EntitiesHidingTests: TestCase {
 		var sut = network
 		sut.hide(account: account0)
 
-		let authorizedDapp0 = sut.authorizedDapps[id: dApp0.id]!
-		let authorizedDapp1 = sut.authorizedDapps[id: dApp1.id]!
+		let authorizedDapp0 = sut.authorizedDapps.asIdentified()[id: dApp0.id]!
+		let authorizedDapp1 = sut.authorizedDapps.asIdentified()[id: dApp1.id]!
 
 		/// Assert that account0 is not present anymore, but account1 is still kept.
-		XCTAssertEqual(authorizedDapp0.referencesToAuthorizedPersonas[id: sharedPersona0.id]?.sharedAccounts?.ids, [account1.address])
-		XCTAssertEqual(authorizedDapp1.referencesToAuthorizedPersonas[id: sharedPersona0.id]?.sharedAccounts?.ids, [account1.address])
-		XCTAssertEqual(authorizedDapp1.referencesToAuthorizedPersonas[id: sharedPersona1.id]?.sharedAccounts?.ids, [account1.address])
+		XCTAssertEqual(authorizedDapp0.referencesToAuthorizedPersonas.asIdentified()[id: sharedPersona0.id]?.sharedAccounts?.ids, [account1.address])
+		XCTAssertEqual(authorizedDapp1.referencesToAuthorizedPersonas.asIdentified()[id: sharedPersona0.id]?.sharedAccounts?.ids, [account1.address])
+		XCTAssertEqual(authorizedDapp1.referencesToAuthorizedPersonas.asIdentified()[id: sharedPersona1.id]?.sharedAccounts?.ids, [account1.address])
 	}
 
 	func test_GIVEN_hasAuthorizedDappsWithOnePersona_WHEN_personaIsHidden_THEN_dappIsRemoved() {
@@ -122,7 +122,7 @@ final class EntitiesHidingTests: TestCase {
 		sut.hide(persona: persona0)
 
 		/// dApp0 references only persona0
-		XCTAssertNil(sut.authorizedDapps[id: dApp0.id])
+		XCTAssertNil(sut.authorizedDapps.asIdentified()[id: dApp0.id])
 	}
 
 	func test_GIVEN_hasAuthorizedDappsWithMoreThanOnePersona_WHEN_personaIsHidden_THEN_personaIsRemovedFromDapp() throws {

--- a/RadixWalletTests/TestExtensions/TestUtils.swift
+++ b/RadixWalletTests/TestExtensions/TestUtils.swift
@@ -80,13 +80,15 @@ extension Profile {
 				authenticationSigning: nil
 			)
 		)
-		var accounts = Accounts(
-			element: account
+
+		let network = ProfileNetwork(
+			id: networkID,
+			accounts: [account],
+			personas: [],
+			authorizedDapps: []
 		)
 
-		let network = ProfileNetwork(id: networkID, accounts: accounts, personas: [], authorizedDapps: [])
-
-		self.networks = .init(element: network)
+		self.networks = [network]
 	}
 
 	static func testValue(


### PR DESCRIPTION
Bumps Sargon to 0.7.7 with the changes introduced in https://github.com/radixdlt/sargon/pull/127

Which removed the `struct Accounts`, `struct Personas` etc from Sargon, and replaced with vanilla `Array<Account>` - freeing up the typenames `Accoounts`, `Personas` etc...

This PR introduces a set of typealiases:
```swift
public typealias Accounts = IdentifiedArrayOf<Account>
public typealias Personas = IdentifiedArrayOf<Persona>
...
```

and updates all the clients to returns those new types, e.g. `AccountsClient` returns `IdentifiedArrayOf<Account>` (`Accounts`).

We should try to always use the `IdentifiedArrayOf<T>` throughout the app, since it guarantees uniqueness. If we accidentally write back `profile.accounts = Array([acc1, acc1])`, a duplicate, **this will crash when UniFFI roundtripped**. It is a GOOD think we crash if duplicates are found so that we do not corrupt the profile.

Furthermore, Sargon will crash if we were to JSON deserialize json with duplicated accounts, personas etc.

Furthermore, Sargon will crash if `profile.factorSources` is empty, so we SHOULD Swift roundtrip through `NonEmpty` for all operations mutating `profile.factorSource` (which I do in this PR).