### PR TITLE
[BUG FIX] User locked in MARS failing flow

### DIFF
--- a/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
+++ b/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
@@ -124,8 +124,7 @@ public struct AccountRecoveryScanCoordinator: Sendable, FeatureReducer {
 				return .none
 			}
 
-		case .accountRecoveryScanInProgress(.delegate(.failed)),
-		     .accountRecoveryScanInProgress(.delegate(.close)):
+		case .accountRecoveryScanInProgress(.delegate(.close)):
 			return .send(.delegate(.dismissed))
 
 		case .selectInactiveAccountsToAdd(.delegate(.goBack)):


### PR DESCRIPTION
Bug reported by Umair in [Slack](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1715600665660489)

## Description
This solves a bug where user would be locked (and forced to kill the app) when performing a Manual Account Recovery Scan with the seed phrase missing.

## Videos
| Before | After |
| - | - |
| https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/61a1ee87-e6c5-474e-9d98-9260866f80eb |  https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/2ad0b471-4668-4c31-b268-66fb9334bf16 |

## Notes
The ideal behavior would be the sheet being closed when the `Ok` button is tapped on the alert. However, this would include a huge refactor since such alert is presented from the `SecureStorageClient` (using the `OverlayWindowClient`) and not from the View involved. 
