### PR TITLE
Fix P2P links loading

### DIFF
--- a/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Live.swift
+++ b/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Live.swift
@@ -44,7 +44,7 @@ private extension SecureStorageClient {
 	@Sendable func updatingP2PLinks<T>(
 		_ mutateP2PLinks: @Sendable (inout P2PLinks) throws -> T
 	) throws -> T {
-		var copy = try loadP2PLinks() ?? []
+		var copy = (try? loadP2PLinks()) ?? []
 		let result = try mutateP2PLinks(&copy)
 		try saveP2PLinks(copy)
 		return result


### PR DESCRIPTION
Fix for those devices that have created P2P links from `pre-alpha 1.6.0 (3)` build.
Solution is to ignore `loadP2PLinks` decoding error when updating P2P links.