### PR TITLE
[CAP-36] Accounts sharing fix

### DIFF
--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Live.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Live.swift
@@ -14,7 +14,7 @@ extension RadixConnectClient {
 		Task {
 			for try await accounts in await accountsClient.accountsOnCurrentNetwork() {
 				guard !Task.isCancelled else { return }
-				try await sendAccountListMessage(accounts: accounts)
+				try? await sendAccountListMessage(accounts: accounts)
 			}
 		}
 
@@ -32,10 +32,10 @@ extension RadixConnectClient {
 		@Sendable
 		func sendAccountListMessageAfterConnect() {
 			Task {
-				let accounts = try await accountsClient.getAccountsOnCurrentNetwork()
+				guard let accounts = try? await accountsClient.getAccountsOnCurrentNetwork() else { return }
 				// FIXME: Investigate why this delay is needed. [Slack discussion](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1715583069664349)
 				try? await Task.sleep(for: .milliseconds(500))
-				try await sendAccountListMessage(accounts: accounts)
+				try? await sendAccountListMessage(accounts: accounts)
 			}
 		}
 


### PR DESCRIPTION
Fixes the scenarios when `sendAccountListMessage` throws an error and stops the execution of the loop.