### PR TITLE
bump sargon to 0.7.18 (with RET / Scrypto bump)

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -8389,7 +8389,7 @@
 			repositoryURL = "https://github.com/radixdlt/sargon";
 			requirement = {
 				kind = exactVersion;
-				version = 0.7.16;
+				version = 0.7.18;
 			};
 		};
 		E6A0B0492BF23C7000617DAC /* XCRemoteSwiftPackageReference "swift-identified-collections" */ = {

--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c3bcd0ac778178b1f6d2fefec06dd7d0b6b38ec52e50ab67b977c895c445948",
+  "originHash" : "7d3590b225945abb1bc0ab6c684b005c28c64bdc204afcc2d34c3e379ef8a3c8",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/radixdlt/sargon",
       "state" : {
-        "revision" : "1e683c8271a270bf92734ad875655645c8a28dd3",
-        "version" : "0.7.16"
+        "revision" : "eb5998dc535a0770cbce8226355f0396f3aa62f4",
+        "version" : "0.7.18"
       }
     },
     {

--- a/RadixWalletTests/Clients/TransactionClientTests/TransactionClientTests.swift
+++ b/RadixWalletTests/Clients/TransactionClientTests/TransactionClientTests.swift
@@ -164,7 +164,7 @@ final class TransactionClientTests: TestCase {
 					transactionSigners: defaultSigners,
 					signingFactors: [.device: .init(rawValue: Set(defaultFactors))!],
 					signingPurpose: .signTransaction(.manifestFromDapp),
-					manifest: TransactionManifest(instructionsString: "", networkID: .mainnet)
+					manifest: TransactionManifest.sample
 				),
 				allFeePayerCandidates: .init(rawValue: .init(uncheckedUniqueElements: allFeePayerCandidates))!,
 				involvedEntities: .init(


### PR DESCRIPTION
Bump Sargon to version containing Bottlenose compatible RET / Scrypto