### PR TITLE
[ABW-3328] Fix NPSSurvey presentation bug

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor+ViewModifier.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor+ViewModifier.swift
@@ -26,36 +26,9 @@ extension DappInteractor {
 		func body(content: Content) -> some SwiftUI.View {
 			ZStack {
 				content
-				WithViewStore(store, observe: { $0.currentModal }) { viewStore in
-					IfLetStore(
-						store.scope(state: \.$currentModal, action: { .child(.modal($0)) }),
-						state: /DappInteractor.Modal.State.dappInteraction,
-						action: DappInteractor.Modal.Action.dappInteraction,
-						then: { DappInteractionCoordinator.View(store: $0) }
-					)
-					.transition(.move(edge: .bottom))
-					.animation(.linear, value: viewStore.state)
-				}
+				dappInteraction
 			}
-			.sheet(
-				store: store.scope(state: \.$currentModal, action: { .child(.modal($0)) }),
-				state: /DappInteractor.Modal.State.dappInteractionCompletion,
-				action: DappInteractor.Modal.Action.dappInteractionCompletion,
-				onDismiss: { store.send(.view(.completionDismissed)) },
-				content: { Completion.View(store: $0) }
-			)
-			.alert(
-				store: store.scope(
-					state: \.$invalidRequestAlert,
-					action: { .view(.invalidRequestAlert($0)) }
-				)
-			)
-			.alert(
-				store: store.scope(
-					state: \.$responseFailureAlert,
-					action: { .view(.responseFailureAlert($0)) }
-				)
-			)
+			.destinations(with: store)
 			.task {
 				await store.send(.view(.task)).finish()
 			}
@@ -66,6 +39,56 @@ extension DappInteractor {
 				store.send(.view(.moveToBackground))
 			}
 		}
+
+		@MainActor
+		private var dappInteraction: some SwiftUI.View {
+			WithViewStore(store, observe: { $0.destination }) { viewStore in
+				IfLetStore(
+					store.destination,
+					state: /DappInteractor.Destination.State.dappInteraction,
+					action: DappInteractor.Destination.Action.dappInteraction,
+					then: { DappInteractionCoordinator.View(store: $0) }
+				)
+				.transition(.move(edge: .bottom))
+				.animation(.linear, value: viewStore.state)
+			}
+		}
+	}
+}
+
+private extension StoreOf<DappInteractor> {
+	var destination: PresentationStoreOf<DappInteractor.Destination> {
+		func scopeState(state: State) -> PresentationState<DappInteractor.Destination.State> {
+			state.$destination
+		}
+		return scope(state: scopeState, action: Action.destination)
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<DappInteractor>) -> some View {
+		let destinationStore = store.destination
+		return dappInteractionCompletion(with: destinationStore, store: store)
+			.invalidRequestAlert(with: destinationStore)
+			.responseFailureAlert(with: destinationStore)
+	}
+
+	private func dappInteractionCompletion(with destinationStore: PresentationStoreOf<DappInteractor.Destination>, store: StoreOf<DappInteractor>) -> some View {
+		sheet(
+			store: destinationStore.scope(state: \.dappInteractionCompletion, action: \.dappInteractionCompletion),
+			onDismiss: { store.send(.view(.completionDismissed)) }
+		) {
+			Completion.View(store: $0)
+		}
+	}
+
+	private func invalidRequestAlert(with destinationStore: PresentationStoreOf<DappInteractor.Destination>) -> some View {
+		alert(store: destinationStore.scope(state: \.invalidRequest, action: \.invalidRequest))
+	}
+
+	private func responseFailureAlert(with destinationStore: PresentationStoreOf<DappInteractor.Destination>) -> some View {
+		alert(store: destinationStore.scope(state: \.responseFailure, action: \.responseFailure))
 	}
 }
 

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor+ViewModifier.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor+ViewModifier.swift
@@ -41,6 +41,7 @@ extension DappInteractor {
 				store: store.scope(state: \.$currentModal, action: { .child(.modal($0)) }),
 				state: /DappInteractor.Modal.State.dappInteractionCompletion,
 				action: DappInteractor.Modal.Action.dappInteractionCompletion,
+				onDismiss: { store.send(.view(.completionDismissed)) },
 				content: { Completion.View(store: $0) }
 			)
 			.alert(

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -19,6 +19,8 @@ struct DappInteractor: Sendable, FeatureReducer {
 
 		@PresentationState
 		public var destination: Destination.State?
+
+		fileprivate var shouldIncrementOnCompletionDismiss = false
 	}
 
 	enum ViewAction: Sendable, Equatable {
@@ -128,7 +130,9 @@ struct DappInteractor: Sendable, FeatureReducer {
 			}
 
 		case .completionDismissed:
-			npsSurveyClient.incrementTransactionCompleteCounter()
+			if state.shouldIncrementOnCompletionDismiss {
+				npsSurveyClient.incrementTransactionCompleteCounter()
+			}
 			return .none
 		}
 	}
@@ -209,6 +213,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 			return .none
 
 		case let .presentResponseSuccessView(dappMetadata, txID, p2pRoute):
+			state.shouldIncrementOnCompletionDismiss = txID != nil
 			state.destination = .dappInteractionCompletion(
 				.init(
 					txID: txID,

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -31,6 +31,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 		case task
 		case moveToBackground
 		case moveToForeground
+		case completionDismissed
 		case responseFailureAlert(PresentationAction<ResponseFailureAlertAction>)
 		case invalidRequestAlert(PresentationAction<InvalidRequestAlertAction>)
 
@@ -106,6 +107,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 	@Dependency(\.rolaClient) var rolaClient
 	@Dependency(\.appPreferencesClient) var appPreferencesClient
 	@Dependency(\.dappInteractionClient) var dappInteractionClient
+	@Dependency(\.npsSurveyClient) var npsSurveyClient
 
 	var body: some ReducerOf<Self> {
 		Reduce(core)
@@ -156,6 +158,10 @@ struct DappInteractor: Sendable, FeatureReducer {
 			return .run { _ in
 				_ = await radixConnectClient.loadP2PLinksAndConnectAll()
 			}
+
+		case .completionDismissed:
+			npsSurveyClient.incrementTransactionCompleteCounter()
+			return .none
 		}
 	}
 

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -18,13 +18,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 		var requestQueue: IdentifiedArrayOf<RequestEnvelope> = []
 
 		@PresentationState
-		var currentModal: Modal.State?
-
-		@PresentationState
-		var responseFailureAlert: AlertState<ViewAction.ResponseFailureAlertAction>?
-
-		@PresentationState
-		var invalidRequestAlert: AlertState<ViewAction.InvalidRequestAlertAction>?
+		public var destination: Destination.State?
 	}
 
 	enum ViewAction: Sendable, Equatable {
@@ -32,17 +26,6 @@ struct DappInteractor: Sendable, FeatureReducer {
 		case moveToBackground
 		case moveToForeground
 		case completionDismissed
-		case responseFailureAlert(PresentationAction<ResponseFailureAlertAction>)
-		case invalidRequestAlert(PresentationAction<InvalidRequestAlertAction>)
-
-		enum ResponseFailureAlertAction: Sendable, Hashable {
-			case cancelButtonTapped(RequestEnvelope)
-			case retryButtonTapped(WalletToDappInteractionResponse, for: RequestEnvelope, DappMetadata)
-		}
-
-		enum InvalidRequestAlertAction: Sendable, Hashable {
-			case ok(P2P.RTCOutgoingMessage.Response, origin: P2P.Route)
-		}
 	}
 
 	enum InternalAction: Sendable, Equatable {
@@ -74,26 +57,37 @@ struct DappInteractor: Sendable, FeatureReducer {
 		)
 	}
 
-	enum ChildAction: Sendable, Equatable {
-		case modal(PresentationAction<Modal.Action>)
-	}
-
-	struct Modal: Sendable, Reducer {
+	struct Destination: Sendable, DestinationReducer {
+		@CasePathable
 		enum State: Sendable, Hashable {
 			case dappInteraction(DappInteractionCoordinator.State)
 			case dappInteractionCompletion(Completion.State)
+			case responseFailure(AlertState<Action.ResponseFailure>)
+			case invalidRequest(AlertState<Action.InvalidRequest>)
 		}
 
+		@CasePathable
 		enum Action: Sendable, Equatable {
 			case dappInteraction(DappInteractionCoordinator.Action)
 			case dappInteractionCompletion(Completion.Action)
+			case responseFailure(ResponseFailure)
+			case invalidRequest(InvalidRequest)
+
+			enum ResponseFailure: Sendable, Hashable {
+				case cancelButtonTapped(RequestEnvelope)
+				case retryButtonTapped(WalletToDappInteractionResponse, for: RequestEnvelope, DappMetadata)
+			}
+
+			enum InvalidRequest: Sendable, Hashable {
+				case ok(P2P.RTCOutgoingMessage.Response, origin: P2P.Route)
+			}
 		}
 
 		var body: some ReducerOf<Self> {
-			Scope(state: /State.dappInteraction, action: /Action.dappInteraction) {
+			Scope(state: \.dappInteraction, action: \.dappInteraction) {
 				DappInteractionCoordinator()
 			}
-			Scope(state: /State.dappInteractionCompletion, action: /Action.dappInteractionCompletion) {
+			Scope(state: \.dappInteractionCompletion, action: \.dappInteractionCompletion) {
 				Completion()
 			}
 		}
@@ -111,43 +105,17 @@ struct DappInteractor: Sendable, FeatureReducer {
 
 	var body: some ReducerOf<Self> {
 		Reduce(core)
-			.ifLet(\.$currentModal, action: /Action.child .. ChildAction.modal) {
-				Modal()
+			.ifLet(destinationPath, action: /Action.destination) {
+				Destination()
 			}
-			.ifLet(\.$responseFailureAlert, action: /Action.view .. ViewAction.responseFailureAlert)
-			.ifLet(\.$invalidRequestAlert, action: /Action.view .. ViewAction.invalidRequestAlert)
 	}
+
+	private let destinationPath: WritableKeyPath<State, PresentationState<Destination.State>> = \.$destination
 
 	func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
 		case .task:
 			return handleIncomingRequests()
-
-		case let .responseFailureAlert(action):
-			switch action {
-			case .dismiss:
-				return .none
-			case let .presented(.cancelButtonTapped(request)):
-				dismissCurrentModalAndRequest(request, for: &state)
-				return .send(.internal(.presentQueuedRequestIfNeeded))
-			case let .presented(.retryButtonTapped(response, request, dappMetadata)):
-				return sendResponseToDappEffect(response, for: request, dappMetadata: dappMetadata)
-			}
-
-		case let .invalidRequestAlert(action):
-			switch action {
-			case .dismiss:
-				return .none
-			case let .presented(.ok(response, route)):
-				return .run { send in
-					do {
-						try await dappInteractionClient.completeInteraction(.response(response, origin: route))
-					} catch {
-						errorQueue.schedule(error)
-					}
-					await send(.internal(.presentQueuedRequestIfNeeded))
-				}
-			}
 
 		case .moveToBackground:
 			return .run { _ in
@@ -169,11 +137,11 @@ struct DappInteractor: Sendable, FeatureReducer {
 		switch internalAction {
 		case let .receivedRequestFromDapp(request):
 
-			switch state.currentModal {
+			switch state.destination {
 			case .some(.dappInteractionCompletion):
 				// FIXME: this is a temporary hack, to solve bug where incoming requests
 				// are ignored since completion is believed to be shown, but is not.
-				state.currentModal = nil
+				state.destination = nil
 			default: break
 			}
 
@@ -198,7 +166,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 			return .send(.internal(.presentResponseFailureAlert(response, for: request, metadata, reason: reason)))
 
 		case let .presentResponseFailureAlert(response, for: request, dappMetadata, reason):
-			state.responseFailureAlert = .init(
+			state.destination = .responseFailure(.init(
 				title: { TextState(L10n.Common.errorAlertTitle) },
 				actions: {
 					ButtonState(role: .cancel, action: .cancelButtonTapped(request)) {
@@ -215,7 +183,8 @@ struct DappInteractor: Sendable, FeatureReducer {
 					TextState(L10n.DAppRequest.ResponseFailureAlert.message)
 					#endif
 				}
-			)
+			))
+
 			return .none
 
 		case let .presentInvalidRequest(invalidRequest, reason, route, isDeveloperModeEnabled):
@@ -225,7 +194,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 				message: reason.responseMessage()
 			)
 
-			state.invalidRequestAlert = .init(
+			state.destination = .invalidRequest(.init(
 				title: { TextState(L10n.Error.DappRequest.invalidRequest) },
 				actions: {
 					ButtonState(
@@ -236,11 +205,11 @@ struct DappInteractor: Sendable, FeatureReducer {
 					}
 				},
 				message: { TextState(reason.alertMessage(isDeveloperModeEnabled)) }
-			)
+			))
 			return .none
 
 		case let .presentResponseSuccessView(dappMetadata, txID, p2pRoute):
-			state.currentModal = .dappInteractionCompletion(
+			state.destination = .dappInteractionCompletion(
 				.init(
 					txID: txID,
 					dappMetadata: dappMetadata,
@@ -251,10 +220,10 @@ struct DappInteractor: Sendable, FeatureReducer {
 		}
 	}
 
-	func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
-		switch childAction {
-		case let .modal(.presented(.dappInteraction(.delegate(delegateAction)))):
-			guard case let .dappInteraction(dappInteraction) = state.currentModal else {
+	func reduce(into state: inout State, presentedAction: Destination.Action) -> Effect<Action> {
+		switch presentedAction {
+		case let .dappInteraction(.delegate(delegateAction)):
+			guard case let .dappInteraction(dappInteraction) = state.destination else {
 				let message = "We should only get actions from this modal if it is showing"
 				assertionFailure(message)
 				loggerGlobal.error(.init(stringLiteral: message))
@@ -273,9 +242,31 @@ struct DappInteractor: Sendable, FeatureReducer {
 				return delayedMediumEffect(internal: .presentQueuedRequestIfNeeded)
 			}
 
-		case .modal(.presented(.dappInteractionCompletion(.delegate(.dismiss)))):
-			state.currentModal = nil
+		case .dappInteractionCompletion(.delegate(.dismiss)):
+			state.destination = nil
 			return delayedMediumEffect(internal: .presentQueuedRequestIfNeeded)
+
+		case let .responseFailure(action):
+			switch action {
+			case let .cancelButtonTapped(request):
+				dismissCurrentModalAndRequest(request, for: &state)
+				return .send(.internal(.presentQueuedRequestIfNeeded))
+			case let .retryButtonTapped(response, request, dappMetadata):
+				return sendResponseToDappEffect(response, for: request, dappMetadata: dappMetadata)
+			}
+
+		case let .invalidRequest(action):
+			switch action {
+			case let .ok(response, route):
+				return .run { send in
+					do {
+						try await dappInteractionClient.completeInteraction(.response(response, origin: route))
+					} catch {
+						errorQueue.schedule(error)
+					}
+					await send(.internal(.presentQueuedRequestIfNeeded))
+				}
+			}
 
 		default:
 			return .none
@@ -287,12 +278,12 @@ struct DappInteractor: Sendable, FeatureReducer {
 	) -> Effect<Action> {
 		guard
 			let next = state.requestQueue.first,
-			state.currentModal == nil
+			state.destination == nil
 		else {
 			return .none
 		}
 
-		state.currentModal = .dappInteraction(.init(request: next))
+		state.destination = .dappInteraction(.init(request: next))
 
 		return .none
 	}
@@ -349,7 +340,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 
 	func dismissCurrentModalAndRequest(_ request: RequestEnvelope, for state: inout State) {
 		state.requestQueue.remove(id: request.id)
-		state.currentModal = nil
+		state.destination = nil
 	}
 }
 

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
@@ -67,7 +67,6 @@ public struct SubmitTransaction: Sendable, FeatureReducer {
 	@Dependency(\.submitTXClient) var submitTXClient
 	@Dependency(\.errorQueue) var errorQueue
 	@Dependency(\.accountPortfoliosClient) var accountPortfoliosClient
-	@Dependency(\.npsSurveyClient) var npsSurveyClient
 
 	public init() {}
 
@@ -163,7 +162,6 @@ public struct SubmitTransaction: Sendable, FeatureReducer {
 	private func transactionCommittedSuccesfully(_ state: State) -> Effect<Action> {
 		// TODO: Could probably be moved in other place. TransactionClient? AccountPortfolio?
 		accountPortfoliosClient.updateAfterCommittedTransaction(state.notarizedTX.intent)
-		npsSurveyClient.incrementTransactionCompleteCounter()
 		return .send(.delegate(.committedSuccessfully(state.notarizedTX.txID)))
 	}
 }


### PR DESCRIPTION
Jira ticket: [ABW-3328](https://radixdlt.atlassian.net/browse/ABW-3328?atlOrigin=eyJpIjoiM2FlOWQwMWRlZDg0NDgxOGExZTA3MDE0OTlmZmFiYjYiLCJwIjoiaiJ9)

## Problem
Until now, `Home` was in charge of presenting the `NPSSurvey` view whenever the conditions were met (10th successful transaction or 3 months since last time shown). However, if the `DappInteractor` was currently presenting its flow on the root view, we could have an overlap of modal presentations. This causes unexpected behaviors on SwiftUI, by presenting only one of the two modals and leaving modal presentation broken during the app run. 

### Solution
Trigger the NPS Survey counter increment after completion is dismissed.

## How to test
You can either run on a fresh install and perform 10 transactions, or just update the logic under `NPSSurveyClient+Live`:
```Swift
static func shouldAskUserForFeedback(_ transactionCounter: Int, dateOfLastSubmittedNPSSurvey: Date?) -> Bool {
	return true
}
```

## Bug before & after
You can see on the first video how the completion view wasn't presented, while on the second video both views (NPSSurvey & Completion) are presented sequentially.

| Before | After |
| - | - |
| <video src=https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/ad202ace-b49a-4d08-ad39-ad8ae2f1a06f> | <video src=https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/78d77490-171e-4277-99d4-f666604e7426> |


[ABW-3328]: https://radixdlt.atlassian.net/browse/ABW-3328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ