### PR TITLE
Show fiat worth error state when price retrieval fails.

### DIFF
--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+Live.swift
@@ -51,17 +51,17 @@ extension AccountPortfoliosClient: DependencyKey {
 		@Sendable
 		func applyTokenPrices(_ resources: [ResourceAddress], forceRefresh: Bool) async {
 			if !resources.isEmpty {
-				let prices = try? await tokenPricesClient.getTokenPrices(
-					.init(
-						tokens: Array(resources.uniqued()),
-						currency: state.selectedCurrency
-					),
-					forceRefresh
-				)
-
-				if let prices {
-					await state.setTokenPrices(prices)
+				let prices = await Result {
+					try await tokenPricesClient.getTokenPrices(
+						.init(
+							tokens: Array(resources.uniqued()),
+							currency: state.selectedCurrency
+						),
+						forceRefresh
+					)
 				}
+
+				await state.setTokenPrices(prices)
 			}
 		}
 
@@ -142,11 +142,12 @@ extension AccountPortfoliosClient: DependencyKey {
 			let account = try await onLedgerEntitiesClient.getAccount(accountAddress)
 			let portfolio = AccountPortfolio(account: account)
 
-			let currentResources = await state.tokenPrices.keys
-			await applyTokenPrices(
-				currentResources + account.resourcesWithPrices,
-				forceRefresh: forceRefresh
-			)
+			if case let .success(tokenPrices) = await state.tokenPrices {
+				await applyTokenPrices(
+					tokenPrices.keys + account.resourcesWithPrices,
+					forceRefresh: forceRefresh
+				)
+			}
 
 			await state.handlePortfolioUpdate(portfolio)
 			await fetchPoolAndStakeUnitsDetails(account.nonEmptyVaults, cachingStrategy: forceRefresh ? .forceUpdate : .useCache)

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
@@ -18,7 +18,7 @@ extension AccountPortfoliosClient {
 	actor State {
 		typealias TokenPrices = [ResourceAddress: Decimal192]
 		let portfoliosSubject: AsyncCurrentValueSubject<Loadable<[AccountAddress: AccountPortfolio]>> = .init(.loading)
-		var tokenPrices: TokenPrices = [:]
+		var tokenPrices: Result<TokenPrices, Error> = .success([:])
 
 		var selectedCurrency: FiatCurrency = .usd
 		var isCurrencyAmountVisible: Bool = true
@@ -74,7 +74,7 @@ extension AccountPortfoliosClient.State {
 		applyFiatCurrency(to: &portfolio)
 	}
 
-	func setTokenPrices(_ tokenPrices: TokenPrices) {
+	func setTokenPrices(_ tokenPrices: Result<TokenPrices, Error>) {
 		self.tokenPrices = tokenPrices
 		if var existingPortfolios = portfoliosSubject.value.values.wrappedValue.map({ Array($0) }) {
 			applyTokenPrices(to: &existingPortfolios)
@@ -129,26 +129,33 @@ extension AccountPortfoliosClient.State {
 extension AccountPortfoliosClient.State {
 	func calculateWorth(_ gateway: Gateway) -> (ResourceAddress, ResourceAmount) -> FiatWorth? {
 		{ resourceAddress, amount in
-			let price = {
-				#if DEBUG
-				if gateway != .mainnet {
-					if resourceAddress == .mainnetXRD {
-						return self.tokenPrices[resourceAddress]
-					} else {
-						return self.tokenPrices.values.randomElement()
-					}
-				} else {
-					return self.tokenPrices[resourceAddress]
+			let worth: FiatWorth.Worth? = {
+				guard case let .success(tokenPrices) = self.tokenPrices else {
+					return .unknown
 				}
-				#else
-				return self.tokenPrices[resourceAddress]
-				#endif
+
+				let price = {
+					#if DEBUG
+					if gateway != .mainnet {
+						if resourceAddress == .mainnetXRD {
+							return tokenPrices[resourceAddress]
+						} else {
+							return tokenPrices.values.randomElement()
+						}
+					} else {
+						return tokenPrices[resourceAddress]
+					}
+					#else
+					return tokenPrices[resourceAddress]
+					#endif
+				}()
+				return price.map { .known($0 * amount.nominalAmount) }
 			}()
 
-			return price.map {
+			return worth.map {
 				.init(
 					isVisible: self.isCurrencyAmountVisible,
-					worth: .known($0 * amount.nominalAmount),
+					worth: $0,
 					currency: self.selectedCurrency
 				)
 			}


### PR DESCRIPTION
Jira ticket: https://radixdlt.atlassian.net/browse/ABW-3336

## Description
Previously the Wallet considered that there is no token prices if the retrieval of these failed. With this PR the Wallet will show error state when the Wallet fails to fetch token prices.

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/7aca69f1-4d17-4f7d-b89c-9fd7ab14e835
