### PR TITLE
[ABW-3333] Update action handling on Security Center

### DIFF
--- a/RadixWallet/Features/SecurityCenterFeature/SecurityCenter+Reducer.swift
+++ b/RadixWallet/Features/SecurityCenterFeature/SecurityCenter+Reducer.swift
@@ -19,12 +19,14 @@ public struct SecurityCenter: Sendable, FeatureReducer {
 		public enum State: Sendable, Hashable {
 			case configurationBackup(ConfigurationBackup.State)
 			case securityFactors(SecurityFactors.State)
+			case displayMnemonics(DisplayMnemonics.State)
 		}
 
 		@CasePathable
 		public enum Action: Sendable, Equatable {
 			case configurationBackup(ConfigurationBackup.Action)
 			case securityFactors(SecurityFactors.Action)
+			case displayMnemonics(DisplayMnemonics.Action)
 		}
 
 		public var body: some ReducerOf<Self> {
@@ -33,6 +35,9 @@ public struct SecurityCenter: Sendable, FeatureReducer {
 			}
 			Scope(state: \.securityFactors, action: \.securityFactors) {
 				SecurityFactors()
+			}
+			Scope(state: \.displayMnemonics, action: \.displayMnemonics) {
+				DisplayMnemonics()
 			}
 		}
 	}
@@ -64,11 +69,16 @@ public struct SecurityCenter: Sendable, FeatureReducer {
 			return securityProblemsEffect()
 
 		case let .problemTapped(problem):
-			switch problem.type {
-			case .securityFactors:
-				state.destination = .securityFactors(.init())
-			case .configurationBackup:
+			switch problem {
+			case .problem3:
+				state.destination = .displayMnemonics(.init())
+
+			case .problem5, .problem6, .problem7:
 				state.destination = .configurationBackup(.init())
+
+			case .problem9:
+				// TODO: go to ImportMnemonicFlowCoordinator
+				break
 			}
 			return .none
 

--- a/RadixWallet/Features/SecurityCenterFeature/SecurityCenter+Reducer.swift
+++ b/RadixWallet/Features/SecurityCenterFeature/SecurityCenter+Reducer.swift
@@ -20,6 +20,7 @@ public struct SecurityCenter: Sendable, FeatureReducer {
 			case configurationBackup(ConfigurationBackup.State)
 			case securityFactors(SecurityFactors.State)
 			case displayMnemonics(DisplayMnemonics.State)
+			case importMnemonics(ImportMnemonicsFlowCoordinator.State)
 		}
 
 		@CasePathable
@@ -27,6 +28,7 @@ public struct SecurityCenter: Sendable, FeatureReducer {
 			case configurationBackup(ConfigurationBackup.Action)
 			case securityFactors(SecurityFactors.Action)
 			case displayMnemonics(DisplayMnemonics.Action)
+			case importMnemonics(ImportMnemonicsFlowCoordinator.Action)
 		}
 
 		public var body: some ReducerOf<Self> {
@@ -38,6 +40,9 @@ public struct SecurityCenter: Sendable, FeatureReducer {
 			}
 			Scope(state: \.displayMnemonics, action: \.displayMnemonics) {
 				DisplayMnemonics()
+			}
+			Scope(state: /State.importMnemonics, action: /Action.importMnemonics) {
+				ImportMnemonicsFlowCoordinator()
 			}
 		}
 	}
@@ -77,8 +82,7 @@ public struct SecurityCenter: Sendable, FeatureReducer {
 				state.destination = .configurationBackup(.init())
 
 			case .problem9:
-				// TODO: go to ImportMnemonicFlowCoordinator
-				break
+				state.destination = .importMnemonics(.init())
 			}
 			return .none
 
@@ -99,6 +103,17 @@ public struct SecurityCenter: Sendable, FeatureReducer {
 		switch internalAction {
 		case let .setProblems(problems):
 			state.problems = problems
+			return .none
+		}
+	}
+
+	public func reduce(into state: inout State, presentedAction: Destination.Action) -> Effect<Action> {
+		switch presentedAction {
+		case .importMnemonics(.delegate(.finishedEarly)),
+		     .importMnemonics(.delegate(.finishedImportingMnemonics)):
+			state.destination = nil
+			return .none
+		default:
 			return .none
 		}
 	}

--- a/RadixWallet/Features/SecurityCenterFeature/SecurityCenter+View.swift
+++ b/RadixWallet/Features/SecurityCenterFeature/SecurityCenter+View.swift
@@ -209,6 +209,7 @@ private extension View {
 		let destinationStore = store.destination
 		return configurationBackup(with: destinationStore)
 			.securityFactors(with: destinationStore)
+			.displayMnemonics(with: destinationStore)
 	}
 
 	private func configurationBackup(with destinationStore: PresentationStoreOf<SecurityCenter.Destination>) -> some View {
@@ -220,6 +221,12 @@ private extension View {
 	private func securityFactors(with destinationStore: PresentationStoreOf<SecurityCenter.Destination>) -> some View {
 		navigationDestination(store: destinationStore.scope(state: \.securityFactors, action: \.securityFactors)) {
 			SecurityFactors.View(store: $0)
+		}
+	}
+
+	private func displayMnemonics(with destinationStore: PresentationStoreOf<SecurityCenter.Destination>) -> some View {
+		navigationDestination(store: destinationStore.scope(state: \.displayMnemonics, action: \.displayMnemonics)) {
+			DisplayMnemonics.View(store: $0)
 		}
 	}
 }

--- a/RadixWallet/Features/SecurityCenterFeature/SecurityCenter+View.swift
+++ b/RadixWallet/Features/SecurityCenterFeature/SecurityCenter+View.swift
@@ -210,6 +210,7 @@ private extension View {
 		return configurationBackup(with: destinationStore)
 			.securityFactors(with: destinationStore)
 			.displayMnemonics(with: destinationStore)
+			.importMnemonics(with: destinationStore)
 	}
 
 	private func configurationBackup(with destinationStore: PresentationStoreOf<SecurityCenter.Destination>) -> some View {
@@ -228,5 +229,14 @@ private extension View {
 		navigationDestination(store: destinationStore.scope(state: \.displayMnemonics, action: \.displayMnemonics)) {
 			DisplayMnemonics.View(store: $0)
 		}
+	}
+
+	private func importMnemonics(with destinationStore: PresentationStoreOf<SecurityCenter.Destination>) -> some View {
+		sheet(
+			store: destinationStore,
+			state: /SecurityCenter.Destination.State.importMnemonics,
+			action: SecurityCenter.Destination.Action.importMnemonics,
+			content: { ImportMnemonicsFlowCoordinator.View(store: $0) }
+		)
 	}
 }


### PR DESCRIPTION
Jira ticket: [ABW-3333](https://radixdlt.atlassian.net/browse/ABW-3333)

## Description
This PR updates the action performed when tapping on each problem on `Security Center` view, following what's defined on [Confluence](https://radixdlt.atlassian.net/wiki/spaces/AT/pages/3392569357/Security-related+Problem+States+in+the+Wallet). 

The issue was just about `.problem9`, but I've included changes for `.problem3` as well. The remaining ones (`.problem5`, `.problem6` & `.problem7`) keep the existing behavior which is navigate to `Configuration Backup` view.

## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/fedfb4e6-18c4-49aa-b514-b53ca0c279b8



[ABW-3333]: https://radixdlt.atlassian.net/browse/ABW-3333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ