### PR TITLE
Fix FactoryReset to not remove CloudKit related cache

### DIFF
--- a/RadixWallet/Clients/CacheClient/CacheClient+Interface.swift
+++ b/RadixWallet/Clients/CacheClient/CacheClient+Interface.swift
@@ -109,6 +109,8 @@ extension Address {
 
 extension CacheClient {
 	public enum Entry: Equatable {
+		static let root: String = "RadixWallet"
+
 		public init(address: some AddressProtocol) {
 			self = .onLedgerEntity(.init(address: address))
 		}
@@ -161,7 +163,7 @@ extension CacheClient {
 		case dateOfFirstTransaction(_ accountAddress: AccountAddress)
 
 		var filesystemFilePath: String {
-			switch self {
+			let path = switch self {
 			case let .onLedgerEntity(entity):
 				entity.filesystemFilePath
 			case let .networkName(url):
@@ -177,6 +179,8 @@ extension CacheClient {
 			case let .dateOfFirstTransaction(address):
 				"\(filesystemFolderPath)/account-\(address.address)"
 			}
+
+			return "\(Self.root)/\(path)"
 		}
 
 		var filesystemFolderPath: String {

--- a/RadixWallet/Clients/CacheClient/CacheClient+Live.swift
+++ b/RadixWallet/Clients/CacheClient/CacheClient+Live.swift
@@ -61,7 +61,7 @@ extension CacheClient: DependencyKey {
 			@Dependency(\.diskPersistenceClient) var diskPersistenceClient
 
 			do {
-				try diskPersistenceClient.removeAll()
+				try diskPersistenceClient.remove(Entry.root)
 				loggerGlobal.debug("💾 Data successfully cleared from disk")
 			} catch {
 				loggerGlobal.debug("💾❌ Could not clear cached data from disk: \(error.localizedDescription)")


### PR DESCRIPTION
Jira ticket: https://radixdlt.atlassian.net/browse/ABW-3342

## Description
Our CacheClient did create all of the cache folders/files at the root of `caches` directory, thus when it was needed to clear the cache on FactoryReset, the whole `caches` directory was cleared out.

CloudKit is using `caches` directory for its operations, and it would create specific folders for its operations. Thus when performing FactoryReset those were deleted - this caused the bug of not being able to see the Cloud backups when restoring from backup immediately after FactoryReset.

The error thrown by CloudKit was:
```
CKError 0x302a87e10: "Internal Error" (1/1000); "Moving downloaded asset failed"
```
Which correlates well with the CloudKit directories being removed from `caches` - CloudKit didn't know anymore where to store the temporary assets after downloading those from the container.

The fix is about moving all of the CacheClient's entries under one and the same folder, thus when doing factory reset and calling `cacheClient.removeAll()`, only the entries created by the CacheClient directly are removed.


## Video

https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/872963a4-59a0-4abe-8e31-4627ca415baf
