### PR TITLE
[CAP-36] Migration messages presentation fix

### DIFF
--- a/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
@@ -179,7 +179,7 @@ public struct Home: Sendable, FeatureReducer {
 			.merge(with: loadNPSSurveyStatus())
 			.merge(with: loadAccountResources())
 			.merge(with: loadFiatValues())
-			.merge(with: .send(.internal(.showLinkConnectorIfNeeded)))
+			.merge(with: delayedMediumEffect(for: .internal(.showLinkConnectorIfNeeded)))
 
 		case .createAccountButtonTapped:
 			state.destination = .createAccount(

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicsFlowCoordinator.swift
@@ -260,9 +260,6 @@ public struct ImportMnemonicsFlowCoordinator: Sendable, FeatureReducer {
 					try await factorSourcesClient.saveNewMainBDFS(newMainBDFS)
 				}
 
-				/// A small delay is needed after dismissal in order to not break Home screen modal presentations
-				try? await Task.sleep(for: .milliseconds(250))
-
 				return await send(.delegate(.finishedImportingMnemonics(
 					skipped: skipped,
 					imported: imported,


### PR DESCRIPTION
Jira ticket: [ABW-3349](https://radixdlt.atlassian.net/browse/ABW-3349)

## Description
Fixes the issue when the P2P links migration message didn't display after importing a profile from a local file.
Removed the delay added in `ImportMnemonicsFlowCoordinator` and added a `delayedMediumEffect` in `Home` to ensure all possible flows are covered.

[ABW-3349]: https://radixdlt.atlassian.net/browse/ABW-3349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ