### PR TITLE
bump Sargon to 1.0.1

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -7071,7 +7071,6 @@
 				48CFC2F82ADC10D900E77A5C /* InfoOfNewPersona+View.swift in Sources */,
 				48CFC3EC2ADC10D900E77A5C /* DataChannelMessage.swift in Sources */,
 				48CFC3FF2ADC10D900E77A5C /* RTCPeerConnectionAsyncDelegate.swift in Sources */,
-				48CFC5D72ADC10DA00E77A5C /* NavigationBarTitleColor.swift in Sources */,
 				83EE5EE32BE3C16F00B1531D /* AccountDepositPreValidationResourceBadge.swift in Sources */,
 				48CFC5B62ADC10DA00E77A5C /* CloseButton.swift in Sources */,
 				A462B5832B83671100C26D20 /* ValidatorCollectionItemEffectiveFeeFactor.swift in Sources */,
@@ -8607,7 +8606,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-identified-collections";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.1;
+				version = 1.0.2;
 			};
 		};
 		E7AE2D072BF7855500830BAA /* XCRemoteSwiftPackageReference "sargon" */ = {
@@ -8615,7 +8614,7 @@
 			repositoryURL = "https://github.com/radixdlt/sargon";
 			requirement = {
 				kind = exactVersion;
-				version = 0.7.19;
+				version = 1.0.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4eb650ade57061cd1cf989ce8f615547774e9303f591ff57a76f3f2c04cdbd07",
+  "originHash" : "7d3590b225945abb1bc0ab6c684b005c28c64bdc204afcc2d34c3e379ef8a3c8",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/radixdlt/sargon",
       "state" : {
-        "revision" : "30cfe39a9e108ac2e9c7a4f01fb917ba131869a1",
-        "version" : "0.7.19"
+        "revision" : "60006952864e2b4fb1e511a83844694819132d04",
+        "version" : "1.0.1"
       }
     },
     {

--- a/RadixWallet/Features/ProfileBackupsFeature/Shared/ExportableProfileFile.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/Shared/ExportableProfileFile.swift
@@ -44,7 +44,7 @@ extension ExportableProfileFile {
 	}
 
 	public init(data: Data) throws {
-		switch Profile.analyzeFile(contents: data) {
+		switch Profile.analyzeContents(data: data) {
 		case .encryptedProfile:
 			self = .encrypted(data)
 		case .notProfile:

--- a/RadixWallet/WalletApp.swift
+++ b/RadixWallet/WalletApp.swift
@@ -6,6 +6,15 @@ import SwiftUI
 struct WalletApp: SwiftUI.App {
 	@UIApplicationDelegateAdaptor var delegate: AppDelegate
 
+	init() {
+		#if DEBUG
+		// MUST NOT be called twice (panics...)
+		// MUST NOT be enabled in PROD (not ensured that secrets are omitted)
+		// This is VERY VERY verbose, so mosly useful for debugging.
+		enableLoggingFromRust()
+		#endif
+	}
+
 	var body: some SwiftUI.Scene {
 		WindowGroup {
 			if !_XCTIsTesting {


### PR DESCRIPTION
# Sargon 1.0.1 
This contains the 10x speedup to JSON Decoding and analysis of Profile
Contents and encryption/decryption, part of https://github.com/radixdlt/sargon/pull/144

>[!NOTE]
> Deprecations: I've deprecated the `Data` based API's or Profile in Swift Sargon since they are just convenience methods/functions which wrap `String.init:data:encoding)` and `String.data:encoding` utf8 roundtrips. So whenever we CAN we SHOULD use JSON `String` based API's directly, for maximum performance (i.e. when we add Persona avatars to Profile and it is several megabytes we might save some milliseconds avoiding unnessary `utf8` conversions).

> [!TIP]
> Enable Rust logging by default - it is **VERY verbose** you might wanna comment it out from WalletApp.swift

![image](https://github.com/radixdlt/babylon-wallet-ios/assets/116169792/5ed64173-7809-438c-b529-2dc529e46be2)