### PR TITLE
bump Sargon to 1.0.2

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -8614,7 +8614,7 @@
 			repositoryURL = "https://github.com/radixdlt/sargon";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.1;
+				version = 1.0.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/radixdlt/sargon",
       "state" : {
-        "revision" : "60006952864e2b4fb1e511a83844694819132d04",
-        "version" : "1.0.1"
+        "revision" : "6d6ffb4c8d79bc98e82139f7b82636ba6ff6f7c1",
+        "version" : "1.0.2"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "2481e39ea43e14556ca9628259fa6b377427730c",
-        "version" : "1.0.1"
+        "revision" : "d533cd18b0b456b106694a9899f917ee595f2666",
+        "version" : "1.0.2"
       }
     },
     {


### PR DESCRIPTION
Bump [Sargon to 1.0.2 which contains bug fix](https://github.com/radixdlt/sargon/pull/147), that fixes [this crash that Umair managed to cause using a non-sensical Transaction Manifest](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1716550883466509)