### PR TITLE
[ABW-3350] Fix account details not loading resources

### DIFF
--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
@@ -58,7 +58,7 @@ extension AccountPortfoliosClient.State {
 	}
 
 	private func setOrUpdateAccountPortfolios(_ portfolios: [AccountPortfoliosClient.AccountPortfolio]) {
-		var newValue: [AccountAddress: AccountPortfoliosClient.AccountPortfolio] = [:]
+		var newValue: [AccountAddress: AccountPortfoliosClient.AccountPortfolio] = portfoliosSubject.value.wrappedValue ?? [:]
 		for portfolio in portfolios {
 			newValue[portfolio.account.address] = portfolio
 		}


### PR DESCRIPTION
Jira ticket: [ABW-3350](https://radixdlt.atlassian.net/browse/ABW-3350)

## Description
Fixes the issue causing account details to be stuck in infinite loading.

### Notes
When a single portfolio was updated, `setOrUpdateAccountPortfolios` deleted all others values from `portfoliosSubject`.

[ABW-3350]: https://radixdlt.atlassian.net/browse/ABW-3350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ