### PR TITLE
Update Seed Phrases to use Security Client

### DIFF
--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Interface.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Interface.swift
@@ -13,7 +13,7 @@ public struct DeviceFactorSourceClient: Sendable {
 	public var controlledEntities: GetControlledEntities
 
 	/// The `Accounts` & `Personas` for which the wallet doesn't have its mnmemonic.
-	public var missingMnemonicEntities: MissingMnemonicEntities
+	public var mnemonicMissingEntities: MnemonicMissingEntities
 
 	/// The `Accounts` & `Personas` the user wouldn't be able to recover if they loose their phone,
 	/// since they haven't been backed up (seed phrase not written).
@@ -25,7 +25,7 @@ public struct DeviceFactorSourceClient: Sendable {
 		isAccountRecoveryNeeded: @escaping IsAccountRecoveryNeeded,
 		entitiesControlledByFactorSource: @escaping GetEntitiesControlledByFactorSource,
 		controlledEntities: @escaping GetControlledEntities,
-		missingMnemonicEntities: @escaping MissingMnemonicEntities,
+		mnemonicMissingEntities: @escaping MnemonicMissingEntities,
 		unrecoverableEntities: @escaping UnrecoverableEntities
 	) {
 		self.publicKeysFromOnDeviceHD = publicKeysFromOnDeviceHD
@@ -33,7 +33,7 @@ public struct DeviceFactorSourceClient: Sendable {
 		self.isAccountRecoveryNeeded = isAccountRecoveryNeeded
 		self.entitiesControlledByFactorSource = entitiesControlledByFactorSource
 		self.controlledEntities = controlledEntities
-		self.missingMnemonicEntities = missingMnemonicEntities
+		self.mnemonicMissingEntities = mnemonicMissingEntities
 		self.unrecoverableEntities = unrecoverableEntities
 	}
 }
@@ -46,7 +46,7 @@ extension DeviceFactorSourceClient {
 	public typealias PublicKeysFromOnDeviceHD = @Sendable (PublicKeysFromOnDeviceHDRequest) async throws -> [HierarchicalDeterministicPublicKey]
 	public typealias SignatureFromOnDeviceHD = @Sendable (SignatureFromOnDeviceHDRequest) async throws -> SignatureWithPublicKey
 	public typealias IsAccountRecoveryNeeded = @Sendable () async throws -> Bool
-	public typealias MissingMnemonicEntities = @Sendable () async throws -> (accounts: [AccountAddress], personas: [IdentityAddress])
+	public typealias MnemonicMissingEntities = @Sendable () async throws -> (accounts: [AccountAddress], personas: [IdentityAddress])
 	public typealias UnrecoverableEntities = @Sendable () async throws -> (accounts: [AccountAddress], personas: [IdentityAddress])
 }
 

--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Interface.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Interface.swift
@@ -12,8 +12,8 @@ public struct DeviceFactorSourceClient: Sendable {
 	/// Fetched accounts and personas on current network that are controlled by a device factor source, for every factor source in current profile
 	public var controlledEntities: GetControlledEntities
 
-	/// Checks if there is any account for which the wallet doesn't have its seed phrase.
-	public var isSeedPhraseNeededToRecoverAccounts: IsSeedPhraseNeededToRecoverAccounts
+	/// The `Accounts` & `Personas` for which the wallet doesn't have its mnmemonic.
+	public var missingMnemonicEntities: MissingMnemonicEntities
 
 	/// The `Accounts` & `Personas` the user wouldn't be able to recover if they loose their phone,
 	/// since they haven't been backed up (seed phrase not written).
@@ -25,7 +25,7 @@ public struct DeviceFactorSourceClient: Sendable {
 		isAccountRecoveryNeeded: @escaping IsAccountRecoveryNeeded,
 		entitiesControlledByFactorSource: @escaping GetEntitiesControlledByFactorSource,
 		controlledEntities: @escaping GetControlledEntities,
-		isSeedPhraseNeededToRecoverAccounts: @escaping IsSeedPhraseNeededToRecoverAccounts,
+		missingMnemonicEntities: @escaping MissingMnemonicEntities,
 		unrecoverableEntities: @escaping UnrecoverableEntities
 	) {
 		self.publicKeysFromOnDeviceHD = publicKeysFromOnDeviceHD
@@ -33,7 +33,7 @@ public struct DeviceFactorSourceClient: Sendable {
 		self.isAccountRecoveryNeeded = isAccountRecoveryNeeded
 		self.entitiesControlledByFactorSource = entitiesControlledByFactorSource
 		self.controlledEntities = controlledEntities
-		self.isSeedPhraseNeededToRecoverAccounts = isSeedPhraseNeededToRecoverAccounts
+		self.missingMnemonicEntities = missingMnemonicEntities
 		self.unrecoverableEntities = unrecoverableEntities
 	}
 }
@@ -46,7 +46,7 @@ extension DeviceFactorSourceClient {
 	public typealias PublicKeysFromOnDeviceHD = @Sendable (PublicKeysFromOnDeviceHDRequest) async throws -> [HierarchicalDeterministicPublicKey]
 	public typealias SignatureFromOnDeviceHD = @Sendable (SignatureFromOnDeviceHDRequest) async throws -> SignatureWithPublicKey
 	public typealias IsAccountRecoveryNeeded = @Sendable () async throws -> Bool
-	public typealias IsSeedPhraseNeededToRecoverAccounts = @Sendable () async throws -> Bool
+	public typealias MissingMnemonicEntities = @Sendable () async throws -> (accounts: [AccountAddress], personas: [IdentityAddress])
 	public typealias UnrecoverableEntities = @Sendable () async throws -> (accounts: [AccountAddress], personas: [IdentityAddress])
 }
 

--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
@@ -82,7 +82,9 @@ extension DeviceFactorSourceClient: DependencyKey {
 			for entity in entities {
 				if !entity.isMnemonicPresentInKeychain {
 					accounts.append(contentsOf: entity.accounts.map(\.address))
+					accounts.append(contentsOf: entity.hiddenAccounts.map(\.address))
 					personas.append(contentsOf: entity.personas.map(\.address))
+					personas.append(contentsOf: entity.hiddenPersonas.map(\.address))
 				}
 			}
 			return (accounts, personas)
@@ -98,7 +100,9 @@ extension DeviceFactorSourceClient: DependencyKey {
 			for entity in entities {
 				if !entity.isMnemonicMarkedAsBackedUp {
 					accounts.append(contentsOf: entity.accounts.map(\.address))
+					accounts.append(contentsOf: entity.hiddenAccounts.map(\.address))
 					personas.append(contentsOf: entity.personas.map(\.address))
+					personas.append(contentsOf: entity.hiddenPersonas.map(\.address))
 				}
 			}
 			return (accounts, personas)

--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Test.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Test.swift
@@ -16,7 +16,7 @@ extension DeviceFactorSourceClient: TestDependencyKey {
 		isAccountRecoveryNeeded: { false },
 		entitiesControlledByFactorSource: { _, _ in throw NoopError() },
 		controlledEntities: { _ in [] },
-		isSeedPhraseNeededToRecoverAccounts: { false },
+		missingMnemonicEntities: { (accounts: [], personas: []) },
 		unrecoverableEntities: { (accounts: [], personas: []) }
 	)
 
@@ -26,7 +26,7 @@ extension DeviceFactorSourceClient: TestDependencyKey {
 		isAccountRecoveryNeeded: unimplemented("\(Self.self).isAccountRecoveryNeeded"),
 		entitiesControlledByFactorSource: unimplemented("\(Self.self).entitiesControlledByFactorSource"),
 		controlledEntities: unimplemented("\(Self.self).controlledEntities"),
-		isSeedPhraseNeededToRecoverAccounts: unimplemented("\(Self.self).isSeedPhraseNeededToRecoverAccounts"),
+		missingMnemonicEntities: unimplemented("\(Self.self).missingMnemonicEntities"),
 		unrecoverableEntities: unimplemented("\(Self.self).unrecoverableEntities")
 	)
 }

--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Test.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Test.swift
@@ -16,7 +16,7 @@ extension DeviceFactorSourceClient: TestDependencyKey {
 		isAccountRecoveryNeeded: { false },
 		entitiesControlledByFactorSource: { _, _ in throw NoopError() },
 		controlledEntities: { _ in [] },
-		missingMnemonicEntities: { (accounts: [], personas: []) },
+		mnemonicMissingEntities: { (accounts: [], personas: []) },
 		unrecoverableEntities: { (accounts: [], personas: []) }
 	)
 
@@ -26,7 +26,7 @@ extension DeviceFactorSourceClient: TestDependencyKey {
 		isAccountRecoveryNeeded: unimplemented("\(Self.self).isAccountRecoveryNeeded"),
 		entitiesControlledByFactorSource: unimplemented("\(Self.self).entitiesControlledByFactorSource"),
 		controlledEntities: unimplemented("\(Self.self).controlledEntities"),
-		missingMnemonicEntities: unimplemented("\(Self.self).missingMnemonicEntities"),
+		mnemonicMissingEntities: unimplemented("\(Self.self).mnemonicMissingEntities"),
 		unrecoverableEntities: unimplemented("\(Self.self).unrecoverableEntities")
 	)
 }

--- a/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Interface.swift
+++ b/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Interface.swift
@@ -36,7 +36,7 @@ public enum SecurityProblem: Hashable, Sendable, Identifiable {
 	case problem7
 	/// User has gotten a new phone (and restored their wallet from backup) and the wallet sees that there are accounts without shields using a phone key,
 	/// meaning they can only be recovered with the seed phrase. (See problem 2) This would also be the state if a user disabled their PIN (and reenabled it), clearing phone keys.
-	case problem9
+	case problem9(accounts: [AccountAddress], personas: [IdentityAddress])
 
 	public var id: Int { number }
 

--- a/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
+++ b/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
@@ -85,7 +85,7 @@ extension SecurityCenterClient {
 					}
 
 					func hasProblem9() async -> (accounts: [AccountAddress], personas: [IdentityAddress])? {
-						guard let result = try? await deviceFactorSourceClient.missingMnemonicEntities(),
+						guard let result = try? await deviceFactorSourceClient.mnemonicMissingEntities(),
 						      result.accounts.count + result.personas.count > 0
 						else { return nil }
 						return result

--- a/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
+++ b/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
@@ -84,8 +84,11 @@ extension SecurityCenterClient {
 						!isCloudProfileSyncEnabled && manualBackup?.upToDate == false
 					}
 
-					func hasProblem9() async -> Bool {
-						await (try? deviceFactorSourceClient.isSeedPhraseNeededToRecoverAccounts()) ?? false
+					func hasProblem9() async -> (accounts: [AccountAddress], personas: [IdentityAddress])? {
+						guard let result = try? await deviceFactorSourceClient.missingMnemonicEntities(),
+						      result.accounts.count + result.personas.count > 0
+						else { return nil }
+						return result
 					}
 
 					var result: [SecurityProblem] = []
@@ -95,7 +98,9 @@ extension SecurityCenterClient {
 							result.append(.problem3(accounts: accounts, personas: personas))
 						}
 
-						if await hasProblem9() { result.append(.problem9) }
+						if let (accounts, personas) = await hasProblem9() {
+							result.append(.problem9(accounts: accounts, personas: personas))
+						}
 					}
 
 					if type == nil || type == .configurationBackup {

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -109,10 +109,10 @@ private extension [SecurityProblem] {
 		!contains(where: { item in
 			switch item {
 			case let .problem3(problematicAccounts, _):
-				guard let first = problematicAccounts.first else {
+				guard let first = accounts.first else {
 					return false
 				}
-				return accounts.contains(where: { $0.address.id == first.id })
+				return problematicAccounts.contains(where: { $0.id == first.address.id })
 			default:
 				return false
 			}
@@ -123,10 +123,10 @@ private extension [SecurityProblem] {
 		!contains(where: { item in
 			switch item {
 			case let .problem9(problematicAccounts, _):
-				guard let first = problematicAccounts.first else {
+				guard let first = accounts.first else {
 					return false
 				}
-				return accounts.contains(where: { $0.address.id == first.id })
+				return problematicAccounts.contains(where: { $0.id == first.address.id })
 			default:
 				return false
 			}

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -58,22 +58,6 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 
 		public init(
 			accountsControlledByKeysOnSameCurve accountSet: EntitiesControlledByFactorSource.AccountsControlledByKeysOnSameCurve,
-			isMnemonicMarkedAsBackedUp: Bool,
-			isMnemonicPresentInKeychain: Bool,
-			mode: Mode
-		) {
-			self.init(
-				id: .singleCurve(accountSet.id.factorSourceID, isOlympia: accountSet.id.isOlympia),
-				isMnemonicMarkedAsBackedUp: isMnemonicMarkedAsBackedUp,
-				isMnemonicPresentInKeychain: isMnemonicPresentInKeychain,
-				accounts: accountSet.accounts,
-				hasHiddenAccounts: !accountSet.hiddenAccounts.isEmpty,
-				mode: mode
-			)
-		}
-
-		public init(
-			accountsControlledByKeysOnSameCurve accountSet: EntitiesControlledByFactorSource.AccountsControlledByKeysOnSameCurve,
 			problems: [SecurityProblem]
 		) {
 			let accounts = accountSet.accounts.elements + accountSet.hiddenAccounts.elements

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -106,30 +106,24 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 
 private extension [SecurityProblem] {
 	func isMnemonicMarkedAsBackedUp(accounts: [Account]) -> Bool {
-		!contains(where: { item in
-			switch item {
+		allSatisfy { problem in
+			switch problem {
 			case let .problem3(problematicAccounts, _):
-				guard let first = accounts.first else {
-					return false
-				}
-				return problematicAccounts.contains(where: { $0.id == first.address.id })
+				Set(problematicAccounts).isDisjoint(with: accounts.map(\.address))
 			default:
-				return false
+				true
 			}
-		})
+		}
 	}
 
 	func isMnemonicPresentInKeychain(accounts: [Account]) -> Bool {
-		!contains(where: { item in
-			switch item {
+		allSatisfy { problem in
+			switch problem {
 			case let .problem9(problematicAccounts, _):
-				guard let first = accounts.first else {
-					return false
-				}
-				return problematicAccounts.contains(where: { $0.id == first.address.id })
+				Set(problematicAccounts).isDisjoint(with: accounts.map(\.address))
 			default:
-				return false
+				true
 			}
-		})
+		}
 	}
 }

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -71,6 +71,20 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 				mode: mode
 			)
 		}
+
+		public init(
+			accountsControlledByKeysOnSameCurve accountSet: EntitiesControlledByFactorSource.AccountsControlledByKeysOnSameCurve,
+			problems: [SecurityProblem]
+		) {
+			self.init(
+				id: .singleCurve(accountSet.id.factorSourceID, isOlympia: accountSet.id.isOlympia),
+				isMnemonicMarkedAsBackedUp: problems.isMnemonicMarkedAsBackedUp,
+				isMnemonicPresentInKeychain: problems.isMnemonicPresentInKeychain,
+				accounts: accountSet.accounts,
+				hasHiddenAccounts: !accountSet.hiddenAccounts.isEmpty,
+				mode: problems.mode
+			)
+		}
 	}
 
 	public enum ViewAction: Sendable, Equatable {
@@ -100,5 +114,29 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 				return .none
 			}
 		}
+	}
+}
+
+private extension [SecurityProblem] {
+	var isMnemonicMarkedAsBackedUp: Bool {
+		!contains(where: { item in
+			switch item {
+			case .problem3: true
+			default: false
+			}
+		})
+	}
+
+	var isMnemonicPresentInKeychain: Bool {
+		!contains(where: { item in
+			switch item {
+			case .problem9: true
+			default: false
+			}
+		})
+	}
+
+	var mode: DisplayEntitiesControlledByMnemonic.State.Mode {
+		isMnemonicPresentInKeychain ? .mnemonicCanBeDisplayed : .mnemonicNeedsImport
 	}
 }

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -31,7 +31,7 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 		public var isMnemonicMarkedAsBackedUp: Bool
 		public var isMnemonicPresentInKeychain: Bool
 		public let accounts: IdentifiedArrayOf<Account>
-		public let hasHiddenAccounts: Bool
+		public let hiddenAccountsCount: Int
 		public var mode: Mode
 
 		public enum Mode: Sendable, Hashable {
@@ -45,14 +45,14 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 			isMnemonicMarkedAsBackedUp: Bool,
 			isMnemonicPresentInKeychain: Bool,
 			accounts: IdentifiedArrayOf<Account>,
-			hasHiddenAccounts: Bool,
+			hiddenAccountsCount: Int,
 			mode: Mode
 		) {
 			self.id = id
 			self.isMnemonicMarkedAsBackedUp = isMnemonicMarkedAsBackedUp
 			self.isMnemonicPresentInKeychain = isMnemonicPresentInKeychain
 			self.accounts = accounts
-			self.hasHiddenAccounts = hasHiddenAccounts
+			self.hiddenAccountsCount = hiddenAccountsCount
 			self.mode = mode
 		}
 
@@ -68,7 +68,7 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 				isMnemonicMarkedAsBackedUp: isMnemonicMarkedAsBackedUp,
 				isMnemonicPresentInKeychain: isMnemonicPresentInKeychain,
 				accounts: accountSet.accounts,
-				hasHiddenAccounts: !accountSet.hiddenAccounts.isEmpty,
+				hiddenAccountsCount: accountSet.hiddenAccounts.count,
 				mode: isMnemonicPresentInKeychain ? .mnemonicCanBeDisplayed : .mnemonicNeedsImport
 			)
 		}

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -9,14 +9,12 @@ extension DisplayEntitiesControlledByMnemonic.State {
 				case .mnemonicCanBeDisplayed:
 					.init(
 						title: L10n.SeedPhrases.SeedPhrase.headingReveal,
-						imageAsset: AssetResource.signingKey,
 						type: .standard,
 						isError: false
 					)
 				case .mnemonicNeedsImport:
 					.init(
 						title: L10n.SecurityProblems.No9.seedPhrases,
-						imageAsset: AssetResource.error,
 						type: .standard,
 						isError: true
 					)
@@ -36,11 +34,10 @@ extension DisplayEntitiesControlledByMnemonic {
 	public struct ViewState: Equatable {
 		public struct HeadingState: Equatable {
 			public let title: String
-			public let imageAsset: ImageAsset
 			public let type: HeadingType
 			public let isError: Bool
 			var foregroundColor: Color {
-				isError ? .app.red1 : .black
+				isError ? .app.gray2 : .app.gray1
 			}
 
 			public enum HeadingType: Equatable {
@@ -121,7 +118,7 @@ extension DisplayEntitiesControlledByMnemonic {
 				if viewState.promptUserToBackUpMnemonic {
 					WarningErrorView(
 						text: L10n.SecurityProblems.No3.seedPhrases,
-						type: .error,
+						type: .warning,
 						useNarrowSpacing: true
 					)
 				}
@@ -144,7 +141,7 @@ extension DisplayEntitiesControlledByMnemonic {
 
 		private func heading(_ headingState: ViewState.HeadingState) -> some SwiftUI.View {
 			HStack {
-				Image(asset: headingState.imageAsset)
+				Image(.signingKey)
 					.resizable()
 					.renderingMode(.template)
 					.frame(.smallest)
@@ -164,7 +161,8 @@ extension DisplayEntitiesControlledByMnemonic {
 
 				switch headingState.type {
 				case .standard:
-					Image(asset: AssetResource.chevronRight)
+					Image(.chevronRight)
+						.foregroundColor(headingState.foregroundColor)
 				case let .scanning(isSelected):
 					RadioButton(appearance: .dark, state: isSelected ? .selected : .unselected)
 				}

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -15,7 +15,7 @@ extension DisplayEntitiesControlledByMnemonic.State {
 					)
 				case .mnemonicNeedsImport:
 					.init(
-						title: L10n.SeedPhrases.SeedPhrase.headingNeedsImport,
+						title: L10n.SecurityProblems.No9.seedPhrases,
 						imageAsset: AssetResource.error,
 						type: .standard,
 						isError: true
@@ -120,7 +120,7 @@ extension DisplayEntitiesControlledByMnemonic {
 
 				if viewState.promptUserToBackUpMnemonic {
 					WarningErrorView(
-						text: L10n.SeedPhrases.backupWarning,
+						text: L10n.SecurityProblems.No3.seedPhrases,
 						type: .error,
 						useNarrowSpacing: true
 					)

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -24,7 +24,7 @@ extension DisplayEntitiesControlledByMnemonic.State {
 			}(),
 			promptUserToBackUpMnemonic: mode == .mnemonicCanBeDisplayed && !isMnemonicMarkedAsBackedUp,
 			accounts: accounts.elements,
-			hasHiddenAccounts: hasHiddenAccounts
+			hiddenAccountsCount: hiddenAccountsCount
 		)
 	}
 }
@@ -70,7 +70,11 @@ extension DisplayEntitiesControlledByMnemonic {
 		public let headingState: HeadingState?
 		public let promptUserToBackUpMnemonic: Bool
 		public let accounts: [Account]
-		public let hasHiddenAccounts: Bool
+		public let hiddenAccountsCount: Int
+
+		var totalAccountsCount: Int {
+			accounts.count + hiddenAccountsCount
+		}
 	}
 }
 
@@ -130,7 +134,7 @@ extension DisplayEntitiesControlledByMnemonic {
 								.cornerRadius(.small1)
 						}
 					}
-				} else if viewState.hasHiddenAccounts {
+				} else if viewState.hiddenAccountsCount > 0 {
 					NoContentView(L10n.SeedPhrases.hiddenAccountsOnly)
 						.frame(maxWidth: .infinity)
 						.frame(height: .huge2)
@@ -152,7 +156,7 @@ extension DisplayEntitiesControlledByMnemonic {
 						.textStyle(.body1Header)
 						.foregroundColor(headingState.foregroundColor)
 
-					Text(headingState.connectedAccountsLabel(accounts: viewState.accounts.count))
+					Text(headingState.connectedAccountsLabel(accounts: viewState.totalAccountsCount))
 						.textStyle(.body2Regular)
 						.foregroundColor(.app.gray2)
 				}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
@@ -24,17 +24,22 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 			self.isMainBDFS = isMainBDFS
 			self.entitiesControlledByFactorSource = ents
 
-			let accounts: IdentifiedArrayOf<Account> = switch (ents.babylonAccounts.isEmpty, ents.olympiaAccounts.isEmpty) {
+			let accounts: IdentifiedArrayOf<Account>
+			let hiddenAccountsCount: Int
+			switch (ents.babylonAccounts.isEmpty, ents.olympiaAccounts.isEmpty) {
 			case (false, _):
 				// We prefer Babylon, always.
-				ents.babylonAccounts
+				accounts = ents.babylonAccounts
+				hiddenAccountsCount = ents.babylonAccountsHidden.count
 			case (true, false):
-				ents.olympiaAccounts
+				accounts = ents.olympiaAccounts
+				hiddenAccountsCount = ents.olympiaAccountsHidden.count
 			case (true, true):
 				// no accounts... still possible! i.e. Profile -> Create HARDWARE Account ->
 				// delete passcode -> import missing Mnemonic, which... does not control any
 				// accounts
-				[]
+				accounts = []
+				hiddenAccountsCount = 0
 			}
 
 			self.entities = .init(
@@ -44,7 +49,7 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 				isMnemonicMarkedAsBackedUp: ents.isMnemonicMarkedAsBackedUp,
 				isMnemonicPresentInKeychain: ents.isMnemonicPresentInKeychain,
 				accounts: accounts,
-				hasHiddenAccounts: !ents.hiddenAccounts.isEmpty,
+				hiddenAccountsCount: hiddenAccountsCount,
 				mode: .displayAccountListOnly
 			)
 		}

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
@@ -12,6 +12,8 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 		public var destination: Destination.State? = nil
 
 		public var deviceFactorSources: IdentifiedArrayOf<DisplayEntitiesControlledByMnemonic.State> = []
+		fileprivate var problems: [SecurityProblem] = []
+		fileprivate var entities: IdentifiedArrayOf<EntitiesControlledByFactorSource> = []
 
 		public init() {}
 	}
@@ -21,7 +23,9 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 	}
 
 	public enum InternalAction: Sendable, Equatable {
-		case loadedDeviceFactorSources(TaskResult<IdentifiedArrayOf<DisplayEntitiesControlledByMnemonic.State>>)
+		case setSecurityProblems([SecurityProblem])
+		case setEntities(TaskResult<IdentifiedArrayOf<EntitiesControlledByFactorSource>>)
+		case setDeviceFactorSources(IdentifiedArrayOf<DisplayEntitiesControlledByMnemonic.State>)
 	}
 
 	public enum ChildAction: Sendable, Equatable {
@@ -55,6 +59,7 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 	@Dependency(\.deviceFactorSourceClient) var deviceFactorSourceClient
 	@Dependency(\.keychainClient) var keychainClient
 	@Dependency(\.backupsClient) var backupsClient
+	@Dependency(\.securityCenterClient) var securityCenterClient
 
 	public init() {}
 
@@ -73,49 +78,28 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
 		case .onFirstTask:
-			.run { send in
-				let result = await TaskResult {
-					let entitiesForDeviceFactorSources = try await deviceFactorSourceClient.controlledEntities(
-						// `nil` means read profile in ProfileStore, instead of using an overriding profile
-						nil
-					)
-					let comparableEntities = entitiesForDeviceFactorSources.flatMap { ents in
-						[ents.babylon, ents.olympia]
-							.compactMap { $0 }
-							.map {
-								ComparableEntities(
-									state: .init(
-										accountsControlledByKeysOnSameCurve: $0,
-										isMnemonicMarkedAsBackedUp: ents.isMnemonicMarkedAsBackedUp,
-										isMnemonicPresentInKeychain: ents.isMnemonicPresentInKeychain,
-										mode: ents.isMnemonicPresentInKeychain ? .mnemonicCanBeDisplayed : .mnemonicNeedsImport
-									),
-									deviceFactorSource: ents.deviceFactorSource
-								)
-							}
-					}
-					return comparableEntities
-						.sorted()
-						.map(\.state)
-						.asIdentified()
-				}
-
-				await send(
-					.internal(.loadedDeviceFactorSources(result))
-				)
-			}
+			securityProblemsEffect()
+				.merge(with: entitiesEffect())
 		}
 	}
 
 	public func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
 		switch internalAction {
-		case let .loadedDeviceFactorSources(.success(deviceFactorSources)):
-			state.deviceFactorSources = deviceFactorSources
-			return .none
+		case let .setSecurityProblems(problems):
+			state.problems = problems
+			return deviceFactorSourcesEffect(state: state)
 
-		case let .loadedDeviceFactorSources(.failure(error)):
+		case let .setEntities(.success(entities)):
+			state.entities = entities
+			return deviceFactorSourcesEffect(state: state)
+
+		case let .setEntities(.failure(error)):
 			loggerGlobal.error("Failed to load device factor sources, error: \(error)")
 			errorQueue.schedule(error)
+			return .none
+
+		case let .setDeviceFactorSources(deviceFactorSources):
+			state.deviceFactorSources = deviceFactorSources
 			return .none
 		}
 	}
@@ -178,6 +162,47 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 			}
 		default:
 			return .none
+		}
+	}
+
+	private func securityProblemsEffect() -> Effect<Action> {
+		.run { send in
+			for try await problems in await securityCenterClient.problems(.securityFactors) {
+				guard !Task.isCancelled else { return }
+				await send(.internal(.setSecurityProblems(problems)))
+			}
+		}
+	}
+
+	private func entitiesEffect() -> Effect<Action> {
+		.run { send in
+			let result = await TaskResult {
+				try await deviceFactorSourceClient.controlledEntities(
+					// `nil` means read profile in ProfileStore, instead of using an overriding profile
+					nil
+				)
+			}
+			await send(.internal(.setEntities(result)))
+		}
+	}
+
+	private func deviceFactorSourcesEffect(state: State) -> Effect<Action> {
+		.run { [problems = state.problems, entities = state.entities] send in
+			let comparableEntities = entities.flatMap { ents in
+				[ents.babylon, ents.olympia]
+					.compactMap { $0 }
+					.map {
+						ComparableEntities(
+							state: .init(accountsControlledByKeysOnSameCurve: $0, problems: problems),
+							deviceFactorSource: ents.deviceFactorSource
+						)
+					}
+			}
+			let result = comparableEntities
+				.sorted()
+				.map(\.state)
+				.asIdentified()
+			await send(.internal(.setDeviceFactorSources(result)))
 		}
 	}
 }

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
@@ -12,8 +12,8 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 		public var destination: Destination.State? = nil
 
 		public var deviceFactorSources: IdentifiedArrayOf<DisplayEntitiesControlledByMnemonic.State> = []
-		fileprivate var problems: [SecurityProblem] = []
-		fileprivate var entities: IdentifiedArrayOf<EntitiesControlledByFactorSource> = []
+		fileprivate var problems: [SecurityProblem]?
+		fileprivate var entities: IdentifiedArrayOf<EntitiesControlledByFactorSource>?
 
 		public init() {}
 	}
@@ -187,7 +187,10 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 	}
 
 	private func deviceFactorSourcesEffect(state: State) -> Effect<Action> {
-		.run { [problems = state.problems, entities = state.entities] send in
+		guard let problems = state.problems, let entities = state.entities else {
+			return .none
+		}
+		return .run { send in
 			let comparableEntities = entities.flatMap { ents in
 				[ents.babylon, ents.olympia]
 					.compactMap { $0 }

--- a/RadixWallet/Features/SettingsFeature/Troubleshooting/ManualAccountRecoveryScan/ManualAccountRecoverySeedPhrase+View.swift
+++ b/RadixWallet/Features/SettingsFeature/Troubleshooting/ManualAccountRecoveryScan/ManualAccountRecoverySeedPhrase+View.swift
@@ -141,7 +141,7 @@ private extension ManualAccountRecoverySeedPhrase.View {
 								return viewStore.isOlympia && curve == .secp256k1 || !viewStore.isOlympia && curve == .curve25519
 							}
 						},
-						hasHiddenAccounts: !item.value.hiddenAccounts.isEmpty
+						hiddenAccountsCount: item.value.hiddenAccounts.count
 					)
 				)
 				.padding(.medium3)

--- a/RadixWallet/Features/SettingsFeature/Troubleshooting/ManualAccountRecoveryScan/ManualAccountRecoverySeedPhrase+View.swift
+++ b/RadixWallet/Features/SettingsFeature/Troubleshooting/ManualAccountRecoveryScan/ManualAccountRecoverySeedPhrase+View.swift
@@ -130,7 +130,6 @@ private extension ManualAccountRecoverySeedPhrase.View {
 					viewState: .init(
 						headingState: .init(
 							title: L10n.SeedPhrases.SeedPhrase.headingScan,
-							imageAsset: AssetResource.signingKey,
 							type: .scanning(selected: item.isSelected),
 							isError: false
 						),


### PR DESCRIPTION
## Changelog
- Uses `SecurityCeneterClient` to determine problems inside `DisplayMnemonics`
- Update UI to look as Aftab requested
- Consider hidden accounts for problems.

## Screenshots

| Screen 1 Before | Screen 1 After |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-05-28 at 16 15 51](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/e230390c-18c3-45bc-aefa-58ac5a1c9bb5) | ![problem3 after](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/cdbc8d6e-3318-4e17-a430-b99ca2408cf9) |
| ![problem9 before](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/c972a5c9-4b29-4114-b5da-872da490ce6a) | ![problem9 after](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/46412ef4-442a-4a50-bc1d-e658b1139f89) |



