### PR TITLE
Change type for Profile record on CloudKit

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -2182,6 +2182,7 @@
 		A41557522B7645E70040AD4E /* TransactionHistory+Reducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistory+Reducer.swift"; sourceTree = "<group>"; };
 		A41557542B7645F70040AD4E /* TransactionHistory+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistory+View.swift"; sourceTree = "<group>"; };
 		A41557562B7D4BF10040AD4E /* ResourceBalanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceBalanceView.swift; sourceTree = "<group>"; };
+		A415D5272C0E70DA00EAC126 /* RadixWalletBeta.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RadixWalletBeta.entitlements; sourceTree = "<group>"; };
 		A43F1E222BC72884001DD3FA /* AnyRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRange.swift; sourceTree = "<group>"; };
 		A43F1E252BC96F18001DD3FA /* SecurityCenter+Reducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecurityCenter+Reducer.swift"; sourceTree = "<group>"; };
 		A43F1E272BC96F27001DD3FA /* SecurityCenter+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecurityCenter+View.swift"; sourceTree = "<group>"; };
@@ -2503,6 +2504,7 @@
 		48CFBC512ADC106300E77A5C /* RadixWallet */ = {
 			isa = PBXGroup;
 			children = (
+				A415D5272C0E70DA00EAC126 /* RadixWalletBeta.entitlements */,
 				A468D7E02C00C43500AFED2E /* RadixWalletDebug-Alpha.entitlements */,
 				A468D7DF2BF743CF00AFED2E /* RadixWalletRelease.entitlements */,
 				A4A1379A2BE4630200D84B50 /* RadixWalletDebug-PreAlpha.entitlements */,
@@ -8322,6 +8324,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 48CFC6A02ADC110800E77A5C /* iOS-beta.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = RadixWallet/RadixWalletBeta.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Radix Wallet";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";

--- a/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Live.swift
+++ b/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Live.swift
@@ -92,7 +92,7 @@ extension CloudBackupClient {
 			let profile = try Profile(jsonString: json)
 			try FileManager.default.removeItem(at: fileURL)
 
-			guard try getProfileHeader(record) == profile.header else {
+			guard try getProfileHeader(record).isEquivalent(to: profile.header) else {
 				throw HeaderAndMetadataMismatchError()
 			}
 
@@ -228,6 +228,30 @@ private extension Profile.Header {
 	var isNonEmpty: Bool {
 		contentHint.numberOfAccountsOnAllNetworksInTotal + contentHint.numberOfPersonasOnAllNetworksInTotal > 0
 	}
+
+	func isEquivalent(to other: Self) -> Bool {
+		snapshotVersion.rawValue == other.snapshotVersion.rawValue &&
+			creatingDevice.isEquivalent(to: other.creatingDevice) &&
+			lastUsedOnDevice.isEquivalent(to: other.lastUsedOnDevice) &&
+			lastModified.isEquivalent(to: other.lastModified) &&
+			contentHint.numberOfAccountsOnAllNetworksInTotal == other.contentHint.numberOfAccountsOnAllNetworksInTotal &&
+			contentHint.numberOfPersonasOnAllNetworksInTotal == other.contentHint.numberOfPersonasOnAllNetworksInTotal &&
+			contentHint.numberOfNetworks == other.contentHint.numberOfNetworks
+	}
+}
+
+private extension DeviceInfo {
+	func isEquivalent(to other: Self) -> Bool {
+		id.uuidString == other.id.uuidString &&
+			date.isEquivalent(to: other.date) &&
+			description == other.description
+	}
+}
+
+private extension Date {
+	func isEquivalent(to other: Self) -> Bool {
+		abs(timeIntervalSince(other)) < 0.001
+	}
 }
 
 extension CloudBackupClient {
@@ -275,20 +299,14 @@ extension CloudBackupClient {
 	private static func setProfileHeader(_ header: Profile.Header, on record: CKRecord) {
 		record[.snapshotVersion] = header.snapshotVersion.rawValue
 		record[.creatingDeviceID] = header.creatingDevice.id.uuidString
-		record[.creatingDeviceDate] = header.creatingDevice.date.roundedToMS
+		record[.creatingDeviceDate] = header.creatingDevice.date
 		record[.creatingDeviceDescription] = header.creatingDevice.description
 		record[.lastUsedOnDeviceID] = header.lastUsedOnDevice.id.uuidString
-		record[.lastUsedOnDeviceDate] = header.lastUsedOnDevice.date.roundedToMS
+		record[.lastUsedOnDeviceDate] = header.lastUsedOnDevice.date
 		record[.lastUsedOnDeviceDescription] = header.lastUsedOnDevice.description
-		record[.lastModified] = header.lastModified.roundedToMS
+		record[.lastModified] = header.lastModified
 		record[.numberOfAccounts] = header.contentHint.numberOfAccountsOnAllNetworksInTotal
 		record[.numberOfPersonas] = header.contentHint.numberOfPersonasOnAllNetworksInTotal
 		record[.numberOfNetworks] = header.contentHint.numberOfNetworks
-	}
-}
-
-private extension Date {
-	var roundedToMS: Date {
-		Date(timeIntervalSince1970: 0.001 * (1000 * timeIntervalSince1970).rounded())
 	}
 }

--- a/RadixWallet/RadixWalletBeta.entitlements
+++ b/RadixWallet/RadixWalletBeta.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.radixpublishing.radixwallet.ios.beta</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
The old record type we used has gotten polluted with incorrect field names, so this PR introduces a new type, `ProfileV2`.