### PR TITLE
[ABW-3407] Indicate Personas connected to a Mnemonic

### DIFF
--- a/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
+++ b/RadixWallet/Core/SharedModels/Entities/EntitiesControlledByFactorSource.swift
@@ -28,7 +28,7 @@ public struct EntitiesControlledByFactorSource: Sendable, Hashable, Identifiable
 }
 
 extension EntitiesControlledByFactorSource {
-	public struct AccountsControlledByKeysOnSameCurve: Equatable, Sendable {
+	public struct EntitiesControlledByKeysOnSameCurve: Equatable, Sendable {
 		public struct ID: Sendable, Hashable {
 			public let factorSourceID: FactorSourceIdFromHash
 			public let isOlympia: Bool
@@ -37,23 +37,26 @@ extension EntitiesControlledByFactorSource {
 		public let id: ID
 		public let accounts: IdentifiedArrayOf<Account>
 		public let hiddenAccounts: IdentifiedArrayOf<Account>
+		public let personas: [Persona]
 	}
 
-	public var olympia: AccountsControlledByKeysOnSameCurve? {
+	public var olympia: EntitiesControlledByKeysOnSameCurve? {
 		guard deviceFactorSource.supportsOlympia else { return nil }
-		return AccountsControlledByKeysOnSameCurve(
+		return EntitiesControlledByKeysOnSameCurve(
 			id: .init(factorSourceID: deviceFactorSource.id, isOlympia: true),
 			accounts: olympiaAccounts,
-			hiddenAccounts: olympiaAccountsHidden
+			hiddenAccounts: olympiaAccountsHidden,
+			personas: personas
 		)
 	}
 
-	public var babylon: AccountsControlledByKeysOnSameCurve? {
+	public var babylon: EntitiesControlledByKeysOnSameCurve? {
 		guard deviceFactorSource.isBDFS else { return nil }
-		return AccountsControlledByKeysOnSameCurve(
+		return EntitiesControlledByKeysOnSameCurve(
 			id: .init(factorSourceID: deviceFactorSource.id, isOlympia: false),
 			accounts: babylonAccounts,
-			hiddenAccounts: babylonAccountsHidden
+			hiddenAccounts: babylonAccountsHidden,
+			personas: personas
 		)
 	}
 

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+Reducer.swift
@@ -32,6 +32,7 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 		public var isMnemonicPresentInKeychain: Bool
 		public let accounts: IdentifiedArrayOf<Account>
 		public let hiddenAccountsCount: Int
+		public let personasCount: Int
 		public var mode: Mode
 
 		public enum Mode: Sendable, Hashable {
@@ -46,6 +47,7 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 			isMnemonicPresentInKeychain: Bool,
 			accounts: IdentifiedArrayOf<Account>,
 			hiddenAccountsCount: Int,
+			personasCount: Int,
 			mode: Mode
 		) {
 			self.id = id
@@ -53,22 +55,24 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 			self.isMnemonicPresentInKeychain = isMnemonicPresentInKeychain
 			self.accounts = accounts
 			self.hiddenAccountsCount = hiddenAccountsCount
+			self.personasCount = personasCount
 			self.mode = mode
 		}
 
 		public init(
-			accountsControlledByKeysOnSameCurve accountSet: EntitiesControlledByFactorSource.AccountsControlledByKeysOnSameCurve,
+			entitiesControlledByKeysOnSameCurve entitiesSet: EntitiesControlledByFactorSource.EntitiesControlledByKeysOnSameCurve,
 			problems: [SecurityProblem]
 		) {
-			let accounts = accountSet.accounts.elements + accountSet.hiddenAccounts.elements
-			let isMnemonicMarkedAsBackedUp = problems.isMnemonicMarkedAsBackedUp(accounts: accounts)
-			let isMnemonicPresentInKeychain = problems.isMnemonicPresentInKeychain(accounts: accounts)
+			let accounts = entitiesSet.accounts.elements + entitiesSet.hiddenAccounts.elements
+			let isMnemonicMarkedAsBackedUp = problems.isMnemonicMarkedAsBackedUp(accounts: accounts, personas: entitiesSet.personas)
+			let isMnemonicPresentInKeychain = problems.isMnemonicPresentInKeychain(accounts: accounts, personas: entitiesSet.personas)
 			self.init(
-				id: .singleCurve(accountSet.id.factorSourceID, isOlympia: accountSet.id.isOlympia),
+				id: .singleCurve(entitiesSet.id.factorSourceID, isOlympia: entitiesSet.id.isOlympia),
 				isMnemonicMarkedAsBackedUp: isMnemonicMarkedAsBackedUp,
 				isMnemonicPresentInKeychain: isMnemonicPresentInKeychain,
-				accounts: accountSet.accounts,
-				hiddenAccountsCount: accountSet.hiddenAccounts.count,
+				accounts: entitiesSet.accounts,
+				hiddenAccountsCount: entitiesSet.hiddenAccounts.count,
+				personasCount: entitiesSet.personas.count,
 				mode: isMnemonicPresentInKeychain ? .mnemonicCanBeDisplayed : .mnemonicNeedsImport
 			)
 		}
@@ -105,22 +109,24 @@ public struct DisplayEntitiesControlledByMnemonic: Sendable, FeatureReducer {
 }
 
 private extension [SecurityProblem] {
-	func isMnemonicMarkedAsBackedUp(accounts: [Account]) -> Bool {
+	func isMnemonicMarkedAsBackedUp(accounts: [Account], personas: [Persona]) -> Bool {
 		allSatisfy { problem in
 			switch problem {
 			case let .problem3(addresses):
-				addresses.problematicAccounts.isDisjoint(with: accounts.map(\.address))
+				addresses.problematicAccounts.isDisjoint(with: accounts.map(\.address)) &&
+					Set(addresses.personas).isDisjoint(with: personas.map(\.address))
 			default:
 				true
 			}
 		}
 	}
 
-	func isMnemonicPresentInKeychain(accounts: [Account]) -> Bool {
+	func isMnemonicPresentInKeychain(accounts: [Account], personas: [Persona]) -> Bool {
 		allSatisfy { problem in
 			switch problem {
 			case let .problem9(addresses):
-				addresses.problematicAccounts.isDisjoint(with: accounts.map(\.address))
+				addresses.problematicAccounts.isDisjoint(with: accounts.map(\.address)) &&
+					Set(addresses.personas).isDisjoint(with: personas.map(\.address))
 			default:
 				true
 			}

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -19,7 +19,8 @@ extension DisplayEntitiesControlledByMnemonic.State {
 			promptUserToBackUpMnemonic: mode == .mnemonicCanBeDisplayed && !isMnemonicMarkedAsBackedUp,
 			promptUserToImportMnemonic: mode == .mnemonicNeedsImport,
 			accounts: accounts.elements,
-			hiddenAccountsCount: hiddenAccountsCount
+			hiddenAccountsCount: hiddenAccountsCount,
+			personasCount: personasCount
 		)
 	}
 }
@@ -40,15 +41,23 @@ extension DisplayEntitiesControlledByMnemonic {
 				case scanning(selected: Bool)
 			}
 
-			public func connectedAccountsLabel(accounts: Int) -> String {
+			public func connectedAccountsLabel(accounts: Int, personas: Int) -> String {
 				switch type {
 				case .standard:
-					if accounts == 0 {
-						L10n.SeedPhrases.SeedPhrase.noConnectedAccountsReveal
-					} else if accounts == 1 {
-						L10n.SeedPhrases.SeedPhrase.oneConnectedAccountReveal
+					if personas == 0 {
+						if accounts == 0 {
+							L10n.SeedPhrases.SeedPhrase.noConnectedAccountsReveal
+						} else if accounts == 1 {
+							L10n.SeedPhrases.SeedPhrase.oneConnectedAccountReveal
+						} else {
+							L10n.SeedPhrases.SeedPhrase.multipleConnectedAccountsReveal(accounts)
+						}
 					} else {
-						L10n.SeedPhrases.SeedPhrase.multipleConnectedAccountsReveal(accounts)
+						if accounts == 1 {
+							L10n.DisplayMnemonics.ConnectedAccountsPersonasLabel.one(accounts)
+						} else {
+							L10n.DisplayMnemonics.ConnectedAccountsPersonasLabel.many(accounts)
+						}
 					}
 				case .scanning:
 					if accounts == 0 {
@@ -67,6 +76,7 @@ extension DisplayEntitiesControlledByMnemonic {
 		public let promptUserToImportMnemonic: Bool
 		public let accounts: [Account]
 		public let hiddenAccountsCount: Int
+		public let personasCount: Int
 
 		var totalAccountsCount: Int {
 			accounts.count + hiddenAccountsCount
@@ -158,7 +168,7 @@ extension DisplayEntitiesControlledByMnemonic {
 						.textStyle(.body1Header)
 						.foregroundColor(headingState.foregroundColor)
 
-					Text(headingState.connectedAccountsLabel(accounts: viewState.totalAccountsCount))
+					Text(headingState.connectedAccountsLabel(accounts: viewState.totalAccountsCount, personas: viewState.personasCount))
 						.textStyle(.body2Regular)
 						.foregroundColor(.app.gray2)
 				}

--- a/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
+++ b/RadixWallet/Features/DisplayEntitiesControlledByMnemonic/DisplayEntitiesControlledByMnemonic+View.swift
@@ -44,20 +44,12 @@ extension DisplayEntitiesControlledByMnemonic {
 			public func connectedAccountsLabel(accounts: Int, personas: Int) -> String {
 				switch type {
 				case .standard:
-					if personas == 0 {
-						if accounts == 0 {
-							L10n.SeedPhrases.SeedPhrase.noConnectedAccountsReveal
-						} else if accounts == 1 {
-							L10n.SeedPhrases.SeedPhrase.oneConnectedAccountReveal
-						} else {
-							L10n.SeedPhrases.SeedPhrase.multipleConnectedAccountsReveal(accounts)
-						}
-					} else {
-						if accounts == 1 {
-							L10n.DisplayMnemonics.ConnectedAccountsPersonasLabel.one(accounts)
-						} else {
-							L10n.DisplayMnemonics.ConnectedAccountsPersonasLabel.many(accounts)
-						}
+					switch (personas, accounts) {
+					case (0, 0): L10n.SeedPhrases.SeedPhrase.noConnectedAccountsReveal
+					case (0, 1): L10n.SeedPhrases.SeedPhrase.oneConnectedAccountReveal
+					case (0, _): L10n.SeedPhrases.SeedPhrase.multipleConnectedAccountsReveal(accounts)
+					case (_, 1): L10n.DisplayMnemonics.ConnectedAccountsPersonasLabel.one(accounts)
+					case (_, _): L10n.DisplayMnemonics.ConnectedAccountsPersonasLabel.many(accounts)
 					}
 				case .scanning:
 					if accounts == 0 {

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
@@ -50,6 +50,7 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 				isMnemonicPresentInKeychain: ents.isMnemonicPresentInKeychain,
 				accounts: accounts,
 				hiddenAccountsCount: hiddenAccountsCount,
+				personasCount: ents.personas.count,
 				mode: .displayAccountListOnly
 			)
 		}

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
@@ -196,7 +196,7 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 					.compactMap { $0 }
 					.map {
 						ComparableEntities(
-							state: .init(accountsControlledByKeysOnSameCurve: $0, problems: problems),
+							state: .init(entitiesControlledByKeysOnSameCurve: $0, problems: problems),
 							deviceFactorSource: ents.deviceFactorSource
 						)
 					}

--- a/RadixWallet/Features/SettingsFeature/Settings+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/Settings+Reducer.swift
@@ -218,7 +218,7 @@ extension Settings.State {
 			case .problem5, .problem6, .problem7:
 				!personas.isEmpty
 			case let .problem3(addresses), let .problem9(addresses):
-				// Note: we don't care about `addresses.problematicPersonas` as the state.personas will only have the visible ones.
+				// Note: we don't care about `addresses.hiddenPersonas` as the `state.personas` will only have the visible ones.
 				!Set(addresses.personas).isDisjoint(with: personas)
 			}
 		}

--- a/RadixWallet/Features/SettingsFeature/Troubleshooting/ManualAccountRecoveryScan/ManualAccountRecoverySeedPhrase+View.swift
+++ b/RadixWallet/Features/SettingsFeature/Troubleshooting/ManualAccountRecoveryScan/ManualAccountRecoverySeedPhrase+View.swift
@@ -142,7 +142,8 @@ private extension ManualAccountRecoverySeedPhrase.View {
 								return viewStore.isOlympia && curve == .secp256k1 || !viewStore.isOlympia && curve == .curve25519
 							}
 						},
-						hiddenAccountsCount: item.value.hiddenAccounts.count
+						hiddenAccountsCount: item.value.hiddenAccounts.count,
+						personasCount: item.value.personas.count
 					)
 				)
 				.padding(.medium3)


### PR DESCRIPTION
Jira ticket: [ABW-3407](https://radixdlt.atlassian.net/browse/ABW-3407)

## Description
On the `Seed Phrases` view, each row will now indicate if it has any (visible) personas connected to it. Also, it will prompt the user to import/back up a seed phrase if it doesn't have any connected accounts but has personas 

## Screenshot

| Screen 1 Before | Screen 1 After |
| - | - |
| ![b1](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/47385798-40b9-4140-ab9e-fe7570cf88fa) | ![a1](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/7fa2b8a0-4884-4b72-97ca-2e9809416a10) |
| ![b2](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/4750a35c-7d98-40dc-a281-23f05ed596fe) | ![a2](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/f4a209d3-c6b4-4510-8cb9-86ab493acb81) |






[ABW-3407]: https://radixdlt.atlassian.net/browse/ABW-3407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ