### PR TITLE
Fix bug where Security Problems where missing for hidden entities

### DIFF
--- a/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
+++ b/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
@@ -119,6 +119,6 @@ extension SecurityCenterClient {
 
 private extension ProblematicAddresses {
 	var isEmpty: Bool {
-		accounts.count + personas.count == 0
+		accounts.count + hiddenAccounts.count + personas.count == 0
 	}
 }


### PR DESCRIPTION
## Description
To reproduce this bug, just follow these steps:
- Reset Wallet
- Create new Account
- Hide such account
- Open Settings 

| Before | After |
| -- | -- |
| ![IMG_0046](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/ed3b048e-ca0e-4179-9c15-ba2a0afb5471) | ![IMG_0045](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/beb1ca23-63af-4920-aa6f-63cdd6724fe1) |




