### PR TITLE
SecurityCenterClient improvements

### DIFF
--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Interface.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Interface.swift
@@ -42,7 +42,7 @@ extension DeviceFactorSourceClient {
 	public typealias PublicKeysFromOnDeviceHD = @Sendable (PublicKeysFromOnDeviceHDRequest) async throws -> [HierarchicalDeterministicPublicKey]
 	public typealias SignatureFromOnDeviceHD = @Sendable (SignatureFromOnDeviceHDRequest) async throws -> SignatureWithPublicKey
 	public typealias IsAccountRecoveryNeeded = @Sendable () async throws -> Bool
-	public typealias ProblematicEntities = @Sendable () async throws -> (mnemonicMissing: ProblematicAddresses, unrecoverable: ProblematicAddresses)
+	public typealias ProblematicEntities = @Sendable () async throws -> AnyAsyncSequence<(mnemonicMissing: ProblematicAddresses, unrecoverable: ProblematicAddresses)>
 }
 
 // MARK: - DiscrepancyUnsupportedCurve

--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Live.swift
@@ -5,7 +5,9 @@ struct FailedToFindFactorSource: Swift.Error {}
 extension DeviceFactorSourceClient: DependencyKey {
 	public typealias Value = Self
 
-	public static let liveValue: Self = {
+	public static let liveValue: Self = .liveValue()
+
+	public static func liveValue(profileStore: ProfileStore = .shared) -> DeviceFactorSourceClient {
 		@Dependency(\.secureStorageClient) var secureStorageClient
 		@Dependency(\.accountsClient) var accountsClient
 		@Dependency(\.personasClient) var personasClient
@@ -71,85 +73,70 @@ extension DeviceFactorSourceClient: DependencyKey {
 			)
 		}
 
-		let profileStore = ProfileStore.shared
+		let problematicEntities: @Sendable () async throws -> AnyAsyncSequence<(mnemonicMissing: ProblematicAddresses, unrecoverable: ProblematicAddresses)> = {
+			await combineLatest(factorSourcesClient.gustaf(), userDefaults.factorSourceIDOfBackedUpMnemonics(), profileStore.values()).map { factorSources, backedUpFactorSources, profile in
+				let mnemonicMissingFactorSources = factorSources
+					.filter(not(\.value))
+					.map(\.key)
 
-		@Sendable
-		func factorSourcesMnemonicPresence() async -> AnyAsyncSequence<[(FactorSourceIDFromHash, present: Bool)]> {
-			await combineLatest(profileStore.factorSourcesValues(), secureStorageClient.keychainChanged())
-				.map { factorSources, _ in
-					factorSources
-						.compactMap { $0.extract(DeviceFactorSource.self)?.id }
-						.map { id in
-							(id, secureStorageClient.containsMnemonicIdentifiedByFactorSourceID(id))
-						}
+				let mnemomincPresentFactorSources = factorSources
+					.filter(\.value)
+					.map(\.key)
+
+				let unrecoverableFactorSources = mnemomincPresentFactorSources
+					.filter { !backedUpFactorSources.contains($0) }
+
+				let network = try profile.network(id: profile.networkID)
+				let accounts = network.getAccounts()
+				let hiddenAccounts = network.getHiddenAccounts()
+				let personas = network.getPersonas()
+				let hiddenPersonas = network.getHiddenPersonas()
+
+				func mnemonicMissing(_ account: Account) -> Bool {
+					switch account.securityState {
+					case let .unsecured(value):
+						mnemonicMissingFactorSources.contains(value.transactionSigning.factorSourceId)
+					}
 				}
-				.eraseToAnyAsyncSequence()
-		}
 
-		let problematicEntities: @Sendable () async throws -> (mnemonicMissing: ProblematicAddresses, unrecoverable: ProblematicAddresses) = {
-			let factorSources = try await factorSourcesClient.getFactorSources(type: DeviceFactorSource.self)
-			let accounts = try await accountsClient.getAccountsOnCurrentNetwork().elements
-			let hiddenAccounts = try await accountsClient.getHiddenAccountsOnCurrentNetwork().elements
-			let personas = try await personasClient.getPersonas().elements
-			let hiddenPersonas = try await personasClient.getHiddenPersonasOnCurrentNetwork().elements
+				func mnemonicMissing(_ persona: Persona) -> Bool {
+					switch persona.securityState {
+					case let .unsecured(value):
+						mnemonicMissingFactorSources.contains(value.transactionSigning.factorSourceId)
+					}
+				}
 
-			let mnemonicMissingFactorSources = factorSources.filter {
-				!secureStorageClient.containsMnemonicIdentifiedByFactorSourceID($0.id)
-			}.map(\.id)
+				func unrecoverable(_ account: Account) -> Bool {
+					switch account.securityState {
+					case let .unsecured(value):
+						unrecoverableFactorSources.contains(value.transactionSigning.factorSourceId)
+					}
+				}
 
-			let mnemonicPresentFactorSources = factorSources.filter {
-				secureStorageClient.containsMnemonicIdentifiedByFactorSourceID($0.id)
+				func unrecoverable(_ persona: Persona) -> Bool {
+					switch persona.securityState {
+					case let .unsecured(value):
+						unrecoverableFactorSources.contains(value.transactionSigning.factorSourceId)
+					}
+				}
+
+				let mnemonicMissing = ProblematicAddresses(
+					accounts: accounts.filter(mnemonicMissing(_:)).map(\.address),
+					hiddenAccounts: hiddenAccounts.filter(mnemonicMissing(_:)).map(\.address),
+					personas: personas.filter(mnemonicMissing(_:)).map(\.address),
+					hiddenPersonas: hiddenPersonas.filter(mnemonicMissing(_:)).map(\.address)
+				)
+
+				let unrecoverable = ProblematicAddresses(
+					accounts: accounts.filter(unrecoverable(_:)).map(\.address),
+					hiddenAccounts: hiddenAccounts.filter(unrecoverable(_:)).map(\.address),
+					personas: personas.filter(unrecoverable(_:)).map(\.address),
+					hiddenPersonas: hiddenPersonas.filter(unrecoverable(_:)).map(\.address)
+				)
+
+				return (mnemonicMissing: mnemonicMissing, unrecoverable: unrecoverable)
 			}
-			.map(\.id)
-
-			let unrecoverableFactorSources = mnemonicPresentFactorSources
-				.filter {
-					!userDefaults.getFactorSourceIDOfBackedUpMnemonics().contains($0)
-				}
-
-			func mnemonicMissing(_ account: Account) -> Bool {
-				switch account.securityState {
-				case let .unsecured(value):
-					mnemonicMissingFactorSources.contains(value.transactionSigning.factorSourceId)
-				}
-			}
-
-			func mnemonicMissing(_ persona: Persona) -> Bool {
-				switch persona.securityState {
-				case let .unsecured(value):
-					mnemonicMissingFactorSources.contains(value.transactionSigning.factorSourceId)
-				}
-			}
-
-			func unrecoverable(_ account: Account) -> Bool {
-				switch account.securityState {
-				case let .unsecured(value):
-					unrecoverableFactorSources.contains(value.transactionSigning.factorSourceId)
-				}
-			}
-
-			func unrecoverable(_ persona: Persona) -> Bool {
-				switch persona.securityState {
-				case let .unsecured(value):
-					unrecoverableFactorSources.contains(value.transactionSigning.factorSourceId)
-				}
-			}
-
-			let mnemonicMissing = ProblematicAddresses(
-				accounts: accounts.filter(mnemonicMissing(_:)).map(\.address),
-				hiddenAccounts: hiddenAccounts.filter(mnemonicMissing(_:)).map(\.address),
-				personas: personas.filter(mnemonicMissing(_:)).map(\.address),
-				hiddenPersonas: hiddenPersonas.filter(mnemonicMissing(_:)).map(\.address)
-			)
-
-			let unrecoverable = ProblematicAddresses(
-				accounts: accounts.filter(unrecoverable(_:)).map(\.address),
-				hiddenAccounts: hiddenAccounts.filter(unrecoverable(_:)).map(\.address),
-				personas: personas.filter(unrecoverable(_:)).map(\.address),
-				hiddenPersonas: hiddenPersonas.filter(unrecoverable(_:)).map(\.address)
-			)
-
-			return (mnemonicMissing: mnemonicMissing, unrecoverable: unrecoverable)
+			.eraseToAnyAsyncSequence()
 		}
 
 		return Self(
@@ -214,5 +201,5 @@ extension DeviceFactorSourceClient: DependencyKey {
 			},
 			problematicEntities: problematicEntities
 		)
-	}()
+	}
 }

--- a/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Test.swift
+++ b/RadixWallet/Clients/DeviceFactorSourceClient/DeviceFactorSourceClient+Test.swift
@@ -16,7 +16,7 @@ extension DeviceFactorSourceClient: TestDependencyKey {
 		isAccountRecoveryNeeded: { false },
 		entitiesControlledByFactorSource: { _, _ in throw NoopError() },
 		controlledEntities: { _ in [] },
-		problematicEntities: { (mnemonicMissing: .empty, unrecoverable: .empty) }
+		problematicEntities: { throw NoopError() }
 	)
 
 	public static let testValue = Self(

--- a/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Interface.swift
+++ b/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Interface.swift
@@ -184,6 +184,10 @@ extension FactorSourcesClient {
 	) async throws -> IdentifiedArrayOf<Source> {
 		try await IdentifiedArrayOf(uniqueElements: getFactorSources().compactMap { $0.extract(Source.self) })
 	}
+
+	public func gustaf() -> AnyAsyncSequence<[FactorSourceIDFromHash: Bool]> {
+		fatalError()
+	}
 }
 
 // MARK: - UpdateFactorSourceLastUsedRequest

--- a/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Interface.swift
+++ b/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Interface.swift
@@ -5,6 +5,7 @@ import os
 
 // MARK: - SecurityCenterClient
 public struct SecurityCenterClient: DependencyKey, Sendable {
+	public let startMonitoring: StartMonitoringProblems
 	public let problems: Problems
 	public let lastManualBackup: LastManualBackup
 	public let lastCloudBackup: LastCloudBackup
@@ -12,6 +13,7 @@ public struct SecurityCenterClient: DependencyKey, Sendable {
 
 // MARK: SecurityCenterClient.Problems
 extension SecurityCenterClient {
+	public typealias StartMonitoringProblems = @Sendable () async throws -> Void
 	public typealias Problems = @Sendable (SecurityProblem.ProblemType?) async -> AnyAsyncSequence<[SecurityProblem]>
 	public typealias LastManualBackup = @Sendable () async -> AnyAsyncSequence<BackupStatus?>
 	public typealias LastCloudBackup = @Sendable () async -> AnyAsyncSequence<BackupStatus?>

--- a/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Test.swift
+++ b/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Test.swift
@@ -15,12 +15,14 @@ extension SecurityCenterClient: TestDependencyKey {
 	public static let previewValue: Self = .noop
 
 	public static let noop = Self(
+		startMonitoring: {},
 		problems: { _ in AsyncLazySequence([[]]).eraseToAnyAsyncSequence() },
 		lastManualBackup: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
 		lastCloudBackup: { AsyncLazySequence([]).eraseToAnyAsyncSequence() }
 	)
 
 	public static let testValue = Self(
+		startMonitoring: unimplemented("\(Self.self).startMonitoring"),
 		problems: unimplemented("\(Self.self).problems"),
 		lastManualBackup: unimplemented("\(Self.self).lastManualBackup"),
 		lastCloudBackup: unimplemented("\(Self.self).lastCloudBackup")

--- a/RadixWallet/Core/FeaturePrelude/UserDefaultsClient+AccountRecovery.swift
+++ b/RadixWallet/Core/FeaturePrelude/UserDefaultsClient+AccountRecovery.swift
@@ -12,4 +12,10 @@ extension UserDefaults.Dependency {
 	public func removeAllFactorSourceIDsOfBackedUpMnemonics() {
 		remove(.mnemonicsUserClaimsToHaveBackedUp)
 	}
+
+	public func factorSourceIDOfBackedUpMnemonics() -> AnyAsyncSequence<OrderedSet<FactorSourceIDFromHash>> {
+		codableValues(key: .mnemonicsUserClaimsToHaveBackedUp, codable: OrderedSet<FactorSourceIDFromHash>.self)
+			.map { (try? $0.get()) ?? [] }
+			.eraseToAnyAsyncSequence()
+	}
 }

--- a/RadixWallet/Features/MainFeature/Main+Reducer.swift
+++ b/RadixWallet/Features/MainFeature/Main+Reducer.swift
@@ -53,6 +53,7 @@ public struct Main: Sendable, FeatureReducer {
 	@Dependency(\.gatewaysClient) var gatewaysClient
 	@Dependency(\.personasClient) var personasClient
 	@Dependency(\.cloudBackupClient) var cloudBackupClient
+	@Dependency(\.securityCenterClient) var securityCenterClient
 
 	public init() {}
 
@@ -72,6 +73,7 @@ public struct Main: Sendable, FeatureReducer {
 		switch viewAction {
 		case .task:
 			startAutomaticBackupsEffect()
+				.merge(with: startMonitoringSecurityCenterEffect())
 				.merge(with: gatewayValuesEffect())
 		}
 	}
@@ -82,6 +84,16 @@ public struct Main: Sendable, FeatureReducer {
 				try await cloudBackupClient.startAutomaticBackups()
 			} catch {
 				loggerGlobal.notice("cloudBackupClient.startAutomaticBackups failed: \(error)")
+			}
+		}
+	}
+
+	private func startMonitoringSecurityCenterEffect() -> Effect<Action> {
+		.run { _ in
+			do {
+				try await securityCenterClient.startMonitoring()
+			} catch {
+				loggerGlobal.notice("securityCenterClient.startMonitoring failed: \(error)")
 			}
 		}
 	}


### PR DESCRIPTION
Use `AnyAsyncSequence` inside `SecurityCenterClient` so that checks take place only when a triggering change has fired.