### PR TITLE
Retroactively Update Backup Log

### DIFF
--- a/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
+++ b/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
@@ -421,7 +421,6 @@ extension FactorSourceKind: Comparable {
 		case .offDeviceMnemonic: 1
 		case .securityQuestions: 2
 		case .trustedContact: 3
-
 		// we want to sign with device last, since it would allow for us to stop using
 		// ephemeral notary and allow us to implement a AutoPurgingMnemonicCache which
 		// deletes items after 1 sec, thus `device` must come last.

--- a/RadixWallet/Clients/TransactionClient/Models/TransactionFailure.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionFailure.swift
@@ -47,6 +47,7 @@ extension TransactionFailure {
 			case .failedToSignIntentWithAccountSigners, .failedToSignSignedCompiledIntentWithNotarySigner, .failedToConvertNotarySignature, .failedToConvertAccountSignatures:
 				(errorKind: .failedToSignTransaction, message: nil)
 			}
+
 		case .failedToSubmit:
 			(errorKind: .failedToSubmitTransaction, message: nil)
 

--- a/RadixWallet/Clients/UserDefaults+Dependency+Extension/UserDefaults+Dependency+Extension.swift
+++ b/RadixWallet/Clients/UserDefaults+Dependency+Extension/UserDefaults+Dependency+Extension.swift
@@ -165,13 +165,12 @@ extension UserDefaults.Dependency {
 		try save(codable: backups, forKey: .lastCloudBackups)
 	}
 
-	public func setLastCloudBackup(_ result: BackupResult.Result, of profile: Profile) throws {
+	public func setLastCloudBackup(_ result: BackupResult.Result, of header: Profile.Header, at date: Date = .now) throws {
 		var backups: [UUID: BackupResult] = getLastCloudBackups
-		let now = Date.now
-		let lastSuccess = result == .success ? now : backups[profile.id]?.lastSuccess
-		backups[profile.id] = .init(
-			date: now,
-			saveIdentifier: profile.header.saveIdentifier,
+		let lastSuccess = result == .success ? date : backups[header.id]?.lastSuccess
+		backups[header.id] = .init(
+			date: date,
+			saveIdentifier: header.saveIdentifier,
 			result: result,
 			lastSuccess: lastSuccess
 		)

--- a/RadixWallet/Core/DesignSystem/Components/Thumbnails.swift
+++ b/RadixWallet/Core/DesignSystem/Components/Thumbnails.swift
@@ -255,7 +255,6 @@ public struct LoadableImage<Placeholder: View>: View {
 		case .shimmer:
 			Color.app.gray4
 				.shimmer(active: true, config: .accountResourcesLoading)
-
 		case let .color(color):
 			color
 		case let .asset(imageAsset):

--- a/RadixWallet/Core/SharedModels/P2P/Application/IncomingMessage/P2P+RTCIncomingMessage.swift
+++ b/RadixWallet/Core/SharedModels/P2P/Application/IncomingMessage/P2P+RTCIncomingMessage.swift
@@ -52,6 +52,7 @@ extension P2P.RTCIncomingMessageContainer {
 		case let (.failure(lhsFailure), .failure(rhsFailure)):
 			// FIXME: strongly type messages? to an Error type which is Hashable?
 			return String(describing: lhsFailure) == String(describing: rhsFailure)
+
 		case let (.success(lhsSuccess), .success(rhsSuccess)):
 			return lhsSuccess == rhsSuccess
 

--- a/RadixWallet/Core/SharedModels/P2P/ConnectorExtension/P2P+ConnectorExtension+Response.swift
+++ b/RadixWallet/Core/SharedModels/P2P/ConnectorExtension/P2P+ConnectorExtension+Response.swift
@@ -163,7 +163,6 @@ extension P2P.ConnectorExtension.Response.LedgerHardwareWallet {
 			self.response = try decodeResponse {
 				Success.signChallenge($0)
 			}
-
 		case .deriveAndDisplayAddress:
 			self.response = try decodeResponse {
 				Success.deriveAndDisplayAddress($0)

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
@@ -219,6 +219,7 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 		case let .canCreateAuthSigningKey(canCreateAuthSigningKey):
 			state.canCreateAuthSigningKey = canCreateAuthSigningKey
 			return .none
+
 		case let .canTurnIntoDappDefAccountType(canTurnIntoDappDefAccountType):
 			state.canTurnIntoDappDefinitionAccountType = canTurnIntoDappDefAccountType
 			return .none

--- a/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
+++ b/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
@@ -132,6 +132,7 @@ public struct AccountRecoveryScanCoordinator: Sendable, FeatureReducer {
 			let childState = state.backTo ?? AccountRecoveryScanCoordinator.State.accountRecoveryScanInProgressState(purpose: state.purpose)
 			state.root = .accountRecoveryScanInProgress(childState)
 			return .none
+
 		case let .selectInactiveAccountsToAdd(.delegate(.finished(selectedInactive, active))):
 			return completed(purpose: state.purpose, active: active, inactive: selectedInactive)
 

--- a/RadixWallet/Features/AppFeature/App+Reducer.swift
+++ b/RadixWallet/Features/AppFeature/App+Reducer.swift
@@ -96,6 +96,7 @@ public struct App: Sendable, FeatureReducer {
 			} else {
 				goToMain(state: &state)
 			}
+
 		default:
 			.none
 		}

--- a/RadixWallet/Features/AssetTransferFeature/AssetTransfer+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/AssetTransfer+Reducer.swift
@@ -268,7 +268,6 @@ func needsSignatureForDepositting(
 		return false
 	case (.acceptAll, .deny):
 		return true
-
 	// Accept Known
 	case (.acceptKnown, .allow):
 		return false
@@ -283,7 +282,6 @@ func needsSignatureForDepositting(
 		return !hasResource
 	case (.acceptKnown, .deny):
 		return true
-
 	// DenyAll
 	case (.denyAll, .none):
 		return true

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
@@ -315,7 +315,6 @@ private extension GatewayAPI.ProgrammaticScryptoSborValue {
 		switch self {
 		case .array, .map, .mapEntry, .tuple:
 			.complex
-
 		case let .bool(content):
 			.primitive(String(content.value))
 		case let .bytes(content):

--- a/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Models.swift
+++ b/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Models.swift
@@ -52,7 +52,6 @@ extension CreateAccountConfig {
 				navigationButtonCTA: .goBackToChooseAccounts,
 				specificNetworkID: nil
 			)
-
 		case .newAccountFromHome:
 			self.init(
 				isFirstAccount: false,

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -839,6 +839,7 @@ extension DappInteractionFlow.Path.State {
 		switch anyItem {
 		case .remote(.auth(.usePersona)):
 			return nil
+
 		case let .remote(.auth(.login(loginRequest))):
 			self.state = .login(.init(
 				dappMetadata: dappMetadata,

--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionModels.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionModels.swift
@@ -127,7 +127,6 @@ extension P2P.Dapp.Request {
 				3
 			case .oneTimePersonaData:
 				4
-
 			// transactions
 			case .send:
 				0

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -120,6 +120,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 		switch viewAction {
 		case .task:
 			return handleIncomingRequests()
+
 		case let .responseFailureAlert(action):
 			switch action {
 			case .dismiss:
@@ -150,6 +151,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 			return .run { _ in
 				await radixConnectClient.disconnectAll()
 			}
+
 		case .moveToForeground:
 			return .run { _ in
 				_ = await radixConnectClient.loadP2PLinksAndConnectAll()

--- a/RadixWallet/Features/DappsAndPersonas/AuthorizedDApps/AuthorizedDApps.swift
+++ b/RadixWallet/Features/DappsAndPersonas/AuthorizedDApps/AuthorizedDApps.swift
@@ -113,9 +113,11 @@ public struct AuthorizedDappsFeature: Sendable, FeatureReducer {
 		case let .loadedDapps(.failure(error)):
 			errorQueue.schedule(error)
 			return .none
+
 		case let .presentDappDetails(presentedDappState):
 			state.destination = .presentedDapp(presentedDappState)
 			return .none
+
 		case let .loadedThumbnail(thumbnail, dApp: id):
 			state.thumbnails[id] = thumbnail
 			return .none

--- a/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home.swift
@@ -183,6 +183,7 @@ public struct Home: Sendable, FeatureReducer {
 				))
 			)
 			return .none
+
 		case .pullToRefreshStarted:
 			let accountAddresses = state.accounts.map(\.address)
 			return .run { _ in
@@ -190,6 +191,7 @@ public struct Home: Sendable, FeatureReducer {
 			} catch: { error, _ in
 				errorQueue.schedule(error)
 			}
+
 		case .radixBannerButtonTapped:
 			return .run { _ in
 				await openURL(Home.radixBannerURL)
@@ -247,11 +249,13 @@ public struct Home: Sendable, FeatureReducer {
 			}
 			#endif
 			return .none
+
 		case let .shouldShowNPSSurvey(shouldShow):
 			if shouldShow {
 				state.addDestination(.npsSurvey(.init()))
 			}
 			return .none
+
 		case let .accountsFiatWorthLoaded(fiatWorths):
 			state.accountRows.mutateAll {
 				if let fiatWorth = fiatWorths[$0.id] {
@@ -260,6 +264,7 @@ public struct Home: Sendable, FeatureReducer {
 			}
 			state.totalFiatWorth = state.accountRows.map(\.totalFiatWorth).reduce(+) ?? .loading
 			return .none
+
 		case .showLinkConnectorIfNeeded:
 			let purpose: NewConnectionApproval.State.Purpose? = if userDefaults.showRelinkConnectorsAfterProfileRestore {
 				.approveRelinkAfterProfileRestore

--- a/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord.swift
@@ -157,6 +157,7 @@ public struct ImportMnemonicWord: Sendable, FeatureReducer {
 				candidate,
 				fromPartial: state.value.text
 			)))
+
 		case let .textFieldFocused(field):
 			state.focusedField = field
 			return field == nil ? .send(.delegate(.lostFocus(displayText: state.value.text))) : .none

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/ImportSeedPhrasesFlow/ImportMnemonicControllingAccounts.swift
@@ -124,6 +124,7 @@ public struct ImportMnemonicControllingAccounts: Sendable, FeatureReducer {
 		switch viewAction {
 		case .appeared:
 			return .none
+
 		case .inputMnemonicButtonTapped:
 			state.destination = .importMnemonic(.init(
 				warning: L10n.RevealSeedPhrase.warning,

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/RecoverWalletWithoutProfile/Coordinator/RecoverWalletWithoutProfileCoordinator+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/RecoverWalletWithoutProfile/Coordinator/RecoverWalletWithoutProfileCoordinator+View.swift
@@ -46,7 +46,6 @@ public extension RecoverWalletWithoutProfileCoordinator {
 						action: RecoverWalletWithoutProfileCoordinator.Path.Action.importMnemonic,
 						then: { ImportMnemonic.View(store: $0) }
 					)
-
 				case .recoveryComplete:
 					CaseLet(
 						/RecoverWalletWithoutProfileCoordinator.Path.State.recoveryComplete,

--- a/RadixWallet/Features/ProfileBackupsFeature/Shared/EncryptOrDecryptProfile+Reducer.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/Shared/EncryptOrDecryptProfile+Reducer.swift
@@ -120,6 +120,7 @@ public struct EncryptOrDecryptProfile: Sendable, FeatureReducer {
 
 				case .encryptSpecific:
 					break
+
 				case .decrypt:
 					break
 				}

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugUserDefaultsContents/DebugUserDefaultsContents.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugUserDefaultsContents/DebugUserDefaultsContents.swift
@@ -96,13 +96,10 @@ extension UserDefaults.Dependency.Key {
 			return [value]
 		case .epochForWhenLastUsedByAccountAddress:
 			return userDefaults.loadEpochForWhenLastUsedByAccountAddress().epochForAccounts.map { "epoch: \($0.epoch) account: \($0.accountAddress)" }
-
 		case .hideMigrateOlympiaButton:
 			return [userDefaults.hideMigrateOlympiaButton].map(String.init(describing:))
-
 		case .showRadixBanner:
 			return [userDefaults.showRadixBanner].map(String.init(describing:))
-
 		case .mnemonicsUserClaimsToHaveBackedUp:
 			return userDefaults.getFactorSourceIDOfBackedUpMnemonics().map(String.init(describing:))
 		case .transactionsCompletedCounter:

--- a/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
+++ b/RadixWallet/Features/SettingsFeature/DisplayMnemonics/Coordinator/DisplayMnemonics.swift
@@ -159,6 +159,7 @@ public struct DisplayMnemonics: Sendable, FeatureReducer {
 
 				return .none
 			}
+
 		default:
 			return .none
 		}

--- a/RadixWallet/Features/Signing/Coordinator/Signing.swift
+++ b/RadixWallet/Features/Signing/Coordinator/Signing.swift
@@ -111,6 +111,7 @@ public struct Signing: Sendable, FeatureReducer {
 			loggerGlobal.error("Failed to notarize transaction, error: \(error)")
 			errorQueue.schedule(error)
 			return .none
+
 		case let .notarizeResult(.success(notarized)):
 			switch state.signingPurposeWithPayload {
 			case .signAuth:
@@ -135,6 +136,7 @@ public struct Signing: Sendable, FeatureReducer {
 
 		case .signWithFactorSource(.delegate(.cancel)):
 			return .send(.delegate(.cancelSigning))
+
 		default:
 			return .none
 		}

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
@@ -106,7 +106,6 @@ public struct SubmitTransaction: Sendable, FeatureReducer {
 			}
 
 			return .send(.delegate(.manuallyDismiss))
-
 		case .dismissTransactionAlert(.presented(.confirm)):
 			return .concatenate(.cancel(id: CancellableId.transactionStatus), .send(.delegate(.manuallyDismiss)))
 		case .dismissTransactionAlert(.presented(.cancel)):

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
@@ -61,6 +61,7 @@ extension TransactionReview {
 		switch summary.detailedManifestClass {
 		case nil:
 			return nil
+
 		case .general, .transfer:
 			if summary.detailedManifestClass == .general {
 				guard !summary.deposits.isEmpty || !summary.withdrawals.isEmpty else { return nil }

--- a/RadixWallet/RadixConnect/RadixConnect/RTC/SignalingClient/IncomingMessage/IncomingMessage+Decoding.swift
+++ b/RadixWallet/RadixConnect/RadixConnect/RTC/SignalingClient/IncomingMessage/IncomingMessage+Decoding.swift
@@ -49,7 +49,6 @@ extension SignalingClient.IncomingMessage: Decodable {
 			let message = try container.decode(SignalingClient.ClientMessage.self, forKey: .message)
 			let remoteClientId = try container.decode(RemoteClientID.self, forKey: .remoteClientId)
 			self = .fromRemoteClient(.init(remoteClientId: remoteClientId, message: message))
-
 		case .remoteClientJustConnected:
 			let clientId = try container.decode(RemoteClientID.self, forKey: .remoteClientId)
 			self = .fromSignalingServer(.notification(.remoteClientJustConnected(clientId)))
@@ -59,7 +58,6 @@ extension SignalingClient.IncomingMessage: Decodable {
 		case .remoteClientDisconnected:
 			let clientId = try container.decode(RemoteClientID.self, forKey: .remoteClientId)
 			self = .fromSignalingServer(.notification(.remoteClientDisconnected(clientId)))
-
 		case .missingRemoteClientError:
 			let requestId = try container.decode(SignalingClient.ClientMessage.RequestID.self, forKey: .requestId)
 
@@ -70,7 +68,6 @@ extension SignalingClient.IncomingMessage: Decodable {
 					)
 				)
 			)
-
 		case .validationError:
 			let error = try container.decode(JSONValue.self, forKey: .error)
 			let requestId = try container.decode(SignalingClient.ClientMessage.RequestID.self, forKey: .requestId)


### PR DESCRIPTION
## Description
Instead of only updating the locally stored log of old backups when the user has backups turned on and we discover that no backup is present, this PR will make it so that we always update the log. This ensures that we don't show the `Out-of-date backup still present on iCloud` warning if the user manually deletes iCloud content from settings.

## How to test
- Turn of Automatic backups
- Note that `Out-of-date backup still present on iCloud` is visible
- Manually delete iCloud contents from settings
- Note that the warning goes away

## Video
The scenario from How to test:

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/24f82413-01ef-4c65-9b9a-8fc66618fc2e

What happens if you delete the backup from within the app

https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/84417444-655f-46e3-82bf-688fd3faa542


## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
