### PR TITLE
Fix old QR code error message

### DIFF
--- a/RadixWallet/Features/NewConnectionFeature/Coordinator/NewConnection+Reducer.swift
+++ b/RadixWallet/Features/NewConnectionFeature/Coordinator/NewConnection+Reducer.swift
@@ -318,7 +318,7 @@ extension AlertState<NewConnection.Destination.Action.ErrorAlert> {
 				TextState(L10n.Common.dismiss)
 			}
 		} message: {
-			TextState(L10n.LinkedConnectors.incorrectQrMessage)
+			TextState(L10n.LinkedConnectors.oldQRErrorMessage)
 		}
 	}
 }


### PR DESCRIPTION
Fixes the error message that appears when scanning an old QR code.