### PR TITLE
[ABW-3432] Sort Fee Payer accounts as in Home

### DIFF
--- a/RadixWallet/Features/TransactionReviewFeature/SelectFeePayer/SelectFeePayer+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SelectFeePayer/SelectFeePayer+View.swift
@@ -56,27 +56,33 @@ extension SelectFeePayer {
 						.padding(.horizontal, .large3)
 						.padding(.bottom, .small1)
 
-					ScrollView {
-						loadable(viewStore.feePayerCandidates) {
-							ProgressView()
-						} successContent: { candidates in
-							VStack(spacing: .small1) {
-								Selection(
-									viewStore.binding(
-										get: \.selectedPayer,
-										send: { .selectedPayer($0) }
-									),
-									from: candidates
-								) { item in
-									SelectAccountToPayForFeeRow.View(
-										viewState: .init(candidate: item.value),
-										isSelected: item.isSelected,
-										action: item.action
-									)
+					ScrollViewReader { proxy in
+						ScrollView {
+							loadable(viewStore.feePayerCandidates) {
+								ProgressView()
+							} successContent: { candidates in
+								VStack(spacing: .small1) {
+									Selection(
+										viewStore.binding(
+											get: \.selectedPayer,
+											send: { .selectedPayer($0) }
+										),
+										from: candidates
+									) { item in
+										SelectAccountToPayForFeeRow.View(
+											viewState: .init(candidate: item.value),
+											isSelected: item.isSelected,
+											action: item.action
+										)
+										.id(item.value.id)
+									}
+								}
+								.padding(.horizontal, .medium1)
+								.padding(.bottom, .medium2)
+								.onFirstAppear {
+									proxy.scrollTo(viewStore.selectedPayer?.id, anchor: .center)
 								}
 							}
-							.padding(.horizontal, .medium1)
-							.padding(.bottom, .medium2)
 						}
 					}
 					.refreshable { @MainActor in


### PR DESCRIPTION
Jira ticket: [ABW-3432](https://radixdlt.atlassian.net/browse/ABW-3432)

## Description
- When selecting a fee payer account, show them in the same order as they are shown on Home
- Scroll to the preselected account so that it always shows up when opening the view.


## Videos

| Before | After |
| - | - |
| <video src=https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/e620f010-92a2-45c6-ae19-2abd37553657> | <video src=https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/1e96d6e1-59cb-4e16-a9c4-9ff44160a8bc> |









[ABW-3432]: https://radixdlt.atlassian.net/browse/ABW-3432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ