### PR TITLE
[ABW-3456] Fix the decoding issue for `Profile.Header`

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -1160,6 +1160,7 @@
 		E6FA984B2B04B9AC00748F20 /* ConfirmSkippingBDFS.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA98492B04B9AC00748F20 /* ConfirmSkippingBDFS.swift */; };
 		E6FA984E2B04E3D500748F20 /* NoContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA984D2B04E3D500748F20 /* NoContentView.swift */; };
 		E713204C2BCD372600AE6B3C /* UnknownCaseDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E713204B2BCD372600AE6B3C /* UnknownCaseDecodable.swift */; };
+		E76645A42C23138300065D9A /* Throwable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E76645A32C23138300065D9A /* Throwable.swift */; };
 		E7A5AC962C09F447006CB6EC /* ResetWalletClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A5AC952C09F447006CB6EC /* ResetWalletClient+Interface.swift */; };
 		E7A5AC982C09F44C006CB6EC /* ResetWalletClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A5AC972C09F44C006CB6EC /* ResetWalletClient+Live.swift */; };
 		E7A5AC9A2C09F453006CB6EC /* ResetWalletClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A5AC992C09F453006CB6EC /* ResetWalletClient+Test.swift */; };
@@ -2308,6 +2309,7 @@
 		E6FA98492B04B9AC00748F20 /* ConfirmSkippingBDFS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmSkippingBDFS.swift; sourceTree = "<group>"; };
 		E6FA984D2B04E3D500748F20 /* NoContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoContentView.swift; sourceTree = "<group>"; };
 		E713204B2BCD372600AE6B3C /* UnknownCaseDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownCaseDecodable.swift; sourceTree = "<group>"; };
+		E76645A32C23138300065D9A /* Throwable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throwable.swift; sourceTree = "<group>"; };
 		E7A5AC952C09F447006CB6EC /* ResetWalletClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResetWalletClient+Interface.swift"; sourceTree = "<group>"; };
 		E7A5AC972C09F44C006CB6EC /* ResetWalletClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResetWalletClient+Live.swift"; sourceTree = "<group>"; };
 		E7A5AC992C09F453006CB6EC /* ResetWalletClient+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResetWalletClient+Test.swift"; sourceTree = "<group>"; };
@@ -4141,6 +4143,7 @@
 				48CFBF502ADC10D900E77A5C /* Validation */,
 				830EA9E42AEB9088004C8051 /* DefaultValueDecodable.swift */,
 				E713204B2BCD372600AE6B3C /* UnknownCaseDecodable.swift */,
+				E76645A32C23138300065D9A /* Throwable.swift */,
 			);
 			path = Prelude;
 			sourceTree = "<group>";
@@ -6869,6 +6872,7 @@
 				48CFC42E2ADC10DA00E77A5C /* KeyPath+Sendable.swift in Sources */,
 				48D5F3982BD8DE0A000DE964 /* DebugInspectProfile.swift in Sources */,
 				48CFC2872ADC10D900E77A5C /* MinimumPercentageStepper+View.swift in Sources */,
+				E76645A42C23138300065D9A /* Throwable.swift in Sources */,
 				48CFC2A12ADC10D900E77A5C /* PersonaFeature.swift in Sources */,
 				48CFC4162ADC10DA00E77A5C /* PasteboardClient+Test.swift in Sources */,
 				48CFC34E2ADC10D900E77A5C /* Login+View.swift in Sources */,

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -95,9 +95,11 @@ extension SecureStorageClient: DependencyKey {
 			try keychainClient
 				.getDataWithoutAuth(forKey: profileHeaderListKeychainKey)
 				.map {
-					try jsonDecoder().decode([Profile.Header].self, from: $0)
+					try jsonDecoder().decode([Throwable<Profile.Header>].self, from: $0)
 				}
-				.flatMap(Profile.HeaderList.init)
+				.flatMap {
+					.init($0.compactMap { try? $0.result.get() })
+				}
 		}
 
 		@Sendable func saveProfileHeaderList(_ headers: Profile.HeaderList) throws {

--- a/RadixWallet/Prelude/Throwable.swift
+++ b/RadixWallet/Prelude/Throwable.swift
@@ -1,0 +1,7 @@
+struct Throwable<T: Decodable>: Decodable {
+	let result: Result<T, Error>
+
+	init(from decoder: Decoder) throws {
+		result = Result(catching: { try T(from: decoder) })
+	}
+}


### PR DESCRIPTION
Jira ticket: [ABW-3456](https://radixdlt.atlassian.net/browse/ABW-3456)

## Description
This PR fixes the issue that occurs when we try to decode an invalid profile header. The solution is to filter out the invalid ones.

[ABW-3456]: https://radixdlt.atlassian.net/browse/ABW-3456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ