### PR TITLE
Display an abstracted message for Sargon errors

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -8635,7 +8635,7 @@
 			repositoryURL = "https://github.com/radixdlt/sargon";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.7;
+				version = 1.0.16;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/radixdlt/sargon",
       "state" : {
-        "revision" : "37221d388f75bdf4ce2ef9d2e4ed6fa686072969",
-        "version" : "1.0.7"
+        "revision" : "637c150e61f56271281485565ed6f9f1f1ed7b48",
+        "version" : "1.0.16"
       }
     },
     {

--- a/RadixWallet/Clients/ContactSupportClient/ContactSupportClient+Live.swift
+++ b/RadixWallet/Clients/ContactSupportClient/ContactSupportClient+Live.swift
@@ -17,9 +17,12 @@ extension ContactSupportClient: DependencyKey {
 		}
 
 		return .init(
-			openEmail: {
+			openEmail: { additionalBodyInfo in
 				let uiApplicaition = await UIApplication.shared
-				let body = await buildBody()
+				var body = await buildBody()
+				if let additionalBodyInfo {
+					body.append("\n\(additionalBodyInfo)")
+				}
 
 				for app in EmailApp.allCases {
 					if let url = app.build(body: body), await uiApplicaition.canOpenURL(url) {

--- a/RadixWallet/Clients/ContactSupportClient/ContactSupportClient+Live.swift
+++ b/RadixWallet/Clients/ContactSupportClient/ContactSupportClient+Live.swift
@@ -8,21 +8,18 @@ extension ContactSupportClient: DependencyKey {
 		@Dependency(\.bundleInfo) var bundleInfo
 
 		@Sendable
-		func buildBody() async -> String {
+		func buildBody(additionalInfo: String?) async -> String {
 			let version = bundleInfo.shortVersion
 			let model = await device.localizedModel
 			let systemVersion = await device.systemVersion
 
-			return "\n\nApp version: \(version)\nDevice: \(model)\nSystem version: \(systemVersion)"
+			return "\n\nApp version: \(version)\nDevice: \(model)\nSystem version: \(systemVersion)\n\(additionalInfo ?? "")"
 		}
 
 		return .init(
 			openEmail: { additionalBodyInfo in
 				let uiApplicaition = await UIApplication.shared
-				var body = await buildBody()
-				if let additionalBodyInfo {
-					body.append("\n\(additionalBodyInfo)")
-				}
+				let body = await buildBody(additionalInfo: additionalBodyInfo)
 
 				for app in EmailApp.allCases {
 					if let url = app.build(body: body), await uiApplicaition.canOpenURL(url) {

--- a/RadixWallet/Clients/ContactSupportClient/ContactSupportClient.swift
+++ b/RadixWallet/Clients/ContactSupportClient/ContactSupportClient.swift
@@ -11,7 +11,7 @@ struct ContactSupportClient: Sendable {
 
 // MARK: ContactSupportClient.OpenEmail
 extension ContactSupportClient {
-	typealias OpenEmail = @Sendable () async -> Void
+	typealias OpenEmail = @Sendable (_ additionalBodyInfo: String?) async -> Void
 }
 
 extension DependencyValues {

--- a/RadixWallet/Clients/OverlayWindowClient/OverlayWindowClient+Interface.swift
+++ b/RadixWallet/Clients/OverlayWindowClient/OverlayWindowClient+Interface.swift
@@ -71,10 +71,11 @@ extension OverlayWindowClient {
 extension OverlayWindowClient {
 	public enum Item: Sendable, Hashable {
 		public typealias AlertState = ComposableArchitecture.AlertState<AlertAction>
-		public enum AlertAction: Sendable, Equatable {
+		public enum AlertAction: Sendable, Hashable {
 			case primaryButtonTapped
 			case secondaryButtonTapped
 			case dismissed
+			case emailSupport(additionalInfo: String)
 		}
 
 		public struct HUD: Sendable, Hashable, Identifiable {

--- a/RadixWallet/Clients/OverlayWindowClient/OverlayWindowClient+Live.swift
+++ b/RadixWallet/Clients/OverlayWindowClient/OverlayWindowClient+Live.swift
@@ -19,10 +19,11 @@ extension OverlayWindowClient: DependencyKey {
 				return Item.alert(.init(
 					title: { TextState(L10n.Common.errorAlertTitle) },
 					actions: {
-						return [
+						let buttons: [ButtonState<OverlayWindowClient.Item.AlertAction>] = [
 							.init(role: .cancel, action: .dismissed, label: { TextState(L10n.Common.cancel) }),
 							.init(action: .emailSupport(additionalInfo: error.localizedDescription), label: { TextState(L10n.Error.emailSupportButtonTitle) }),
 						]
+						return buttons
 					},
 					message: { TextState(message) }
 				))

--- a/RadixWallet/Clients/OverlayWindowClient/OverlayWindowClient+Live.swift
+++ b/RadixWallet/Clients/OverlayWindowClient/OverlayWindowClient+Live.swift
@@ -10,10 +10,28 @@ extension OverlayWindowClient: DependencyKey {
 		@Dependency(\.pasteboardClient) var pasteBoardClient
 
 		errorQueue.errors().map { error in
-			Item.alert(.init(
-				title: { TextState(L10n.Common.errorAlertTitle) },
-				message: { TextState(error.localizedDescription) }
-			))
+			if let sargonError = error as? SargonError {
+				#if DEBUG
+				let message = error.localizedDescription
+				#else
+				let message = L10n.Error.emailSupportMessage(sargonError.errorCode)
+				#endif
+				return Item.alert(.init(
+					title: { TextState(L10n.Common.errorAlertTitle) },
+					actions: {
+						return [
+							.init(role: .cancel, action: .dismissed, label: { TextState(L10n.Common.cancel) }),
+							.init(action: .emailSupport(additionalInfo: error.localizedDescription), label: { TextState(L10n.Error.emailSupportButtonTitle) }),
+						]
+					},
+					message: { TextState(message) }
+				))
+			} else {
+				return Item.alert(.init(
+					title: { TextState(L10n.Common.errorAlertTitle) },
+					message: { TextState(error.localizedDescription) }
+				))
+			}
 		}
 		.subscribe(items)
 

--- a/RadixWallet/Core/Resources/Generated/L10n.generated.swift
+++ b/RadixWallet/Core/Resources/Generated/L10n.generated.swift
@@ -1527,6 +1527,13 @@ public enum L10n {
     }
   }
   public enum Error {
+    /// Email Support
+    public static let emailSupportButtonTitle = L10n.tr("Localizable", "error_emailSupportButtonTitle", fallback: "Email Support")
+    /// Please email support to automatically provide debugging info, and get assistance.
+    /// Code: %@
+    public static func emailSupportMessage(_ p1: Any) -> String {
+      return L10n.tr("Localizable", "error_emailSupportMessage", String(describing: p1), fallback: "Please email support to automatically provide debugging info, and get assistance.\nCode: %@")
+    }
     public enum AccountLabel {
       /// Account label required
       public static let missing = L10n.tr("Localizable", "error_accountLabel_missing", fallback: "Account label required")

--- a/RadixWallet/Features/AppFeature/Overlay/Overlay+Reducer.swift
+++ b/RadixWallet/Features/AppFeature/Overlay/Overlay+Reducer.swift
@@ -49,6 +49,7 @@ struct OverlayReducer: Sendable, FeatureReducer {
 
 	@Dependency(\.overlayWindowClient) var overlayWindowClient
 	@Dependency(\.continuousClock) var clock
+	@Dependency(\.contactSupportClient) var contactSupport
 
 	var body: some ReducerOf<Self> {
 		Reduce(core)
@@ -85,6 +86,12 @@ struct OverlayReducer: Sendable, FeatureReducer {
 		case let .alert(action):
 			if case let .alert(state) = state.itemsQueue.first {
 				overlayWindowClient.sendAlertAction(action, state.id)
+			}
+			if case let .emailSupport(additionalInfo) = action {
+				return .run { _ in
+					await contactSupport.openEmail(additionalInfo)
+				}
+				.concatenate(with: dismiss(&state))
 			}
 			return dismiss(&state)
 

--- a/RadixWallet/Features/SettingsFeature/Troubleshooting/Troubleshooting.swift
+++ b/RadixWallet/Features/SettingsFeature/Troubleshooting/Troubleshooting.swift
@@ -83,7 +83,7 @@ public struct Troubleshooting: Sendable, FeatureReducer {
 
 		case .contactSupportButtonTapped:
 			return .run { _ in
-				await contactSupport.openEmail()
+				await contactSupport.openEmail(nil)
 			}
 
 		case .discordButtonTapped:

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -698,7 +698,7 @@ extension TransactionReview {
 			)
 		}
 
-		return manifest.modify(addGuarantees: state.allGuarantees)
+		return try manifest.modify(addGuarantees: state.allGuarantees)
 	}
 
 	func determineFeePayer(_ state: State, reviewedTransaction: ReviewedTransaction) -> Effect<Action> {


### PR DESCRIPTION
Jira ticket: [ABW-3454](https://radixdlt.atlassian.net/browse/ABW-3454)

Relates to [#168](https://github.com/radixdlt/sargon/pull/168)

## Description
- Display an abstracted message for Sargon errors with the option to email support and include more debugging info
- For debug mode, show an error code and the detailed error message from Sargon instead of the abstracted message

### Notes
If you want to simulate this error from Sargon, you can scan this invalid QR code:

<img width="192" alt="Screenshot 2024-06-20 at 15 50 42" src="https://github.com/radixdlt/babylon-wallet-ios/assets/163979791/bb3ef328-a042-4178-b0ec-a3d4d8b97170">

## Screenshot

| Release example | Debug example |
| - | - |
| ![IMG_0014](https://github.com/radixdlt/babylon-wallet-ios/assets/163979791/82dfbe75-f073-4bc6-ab39-2f3bd9e3f3de) |  ![IMG_0013](https://github.com/radixdlt/babylon-wallet-ios/assets/163979791/6a4724c9-c346-4dd0-9dd7-974ebac1b68f) |

| Email body |
| - |
| ![IMG_0015](https://github.com/radixdlt/babylon-wallet-ios/assets/163979791/73b3d5ac-2d6a-472c-b620-ee8874ae0cfa)|

[ABW-3454]: https://radixdlt.atlassian.net/browse/ABW-3454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ