### PR TITLE
Refine Backup Behaviour

### DIFF
--- a/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Interface.swift
+++ b/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Interface.swift
@@ -5,6 +5,7 @@ import os
 
 // MARK: - CloudBackupClient
 public struct CloudBackupClient: DependencyKey, Sendable {
+	public let isCloudProfileSyncEnabled: IsCloudProfileSyncEnabled
 	public let startAutomaticBackups: StartAutomaticBackups
 	public let migrateProfilesFromKeychain: MigrateProfilesFromKeychain
 	public let deleteProfileBackup: DeleteProfileBackup
@@ -15,6 +16,7 @@ public struct CloudBackupClient: DependencyKey, Sendable {
 	public let claimProfileOnICloud: ClaimProfileOnICloud
 
 	public init(
+		isCloudProfileSyncEnabled: @escaping IsCloudProfileSyncEnabled,
 		startAutomaticBackups: @escaping StartAutomaticBackups,
 		migrateProfilesFromKeychain: @escaping MigrateProfilesFromKeychain,
 		deleteProfileBackup: @escaping DeleteProfileBackup,
@@ -24,6 +26,7 @@ public struct CloudBackupClient: DependencyKey, Sendable {
 		loadProfileHeaders: @escaping LoadProfileHeaders,
 		claimProfileOnICloud: @escaping ClaimProfileOnICloud
 	) {
+		self.isCloudProfileSyncEnabled = isCloudProfileSyncEnabled
 		self.startAutomaticBackups = startAutomaticBackups
 		self.migrateProfilesFromKeychain = migrateProfilesFromKeychain
 		self.deleteProfileBackup = deleteProfileBackup
@@ -36,9 +39,10 @@ public struct CloudBackupClient: DependencyKey, Sendable {
 }
 
 extension CloudBackupClient {
+	public typealias IsCloudProfileSyncEnabled = @Sendable () async -> AnyAsyncSequence<Bool>
 	public typealias StartAutomaticBackups = @Sendable () async throws -> Void
 	public typealias MigrateProfilesFromKeychain = @Sendable () async throws -> [CKRecord]
-	public typealias DeleteProfileBackup = @Sendable (ProfileID) async throws -> Void
+	public typealias DeleteProfileBackup = @Sendable (ProfileID?) async throws -> Void
 	public typealias CheckAccountStatus = @Sendable () async throws -> CKAccountStatus
 	public typealias LastBackup = @Sendable (ProfileID) -> AnyAsyncSequence<BackupResult?>
 	public typealias LoadProfile = @Sendable (ProfileID) async throws -> BackedUpProfile

--- a/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Live.swift
+++ b/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Live.swift
@@ -167,13 +167,11 @@ extension CloudBackupClient {
 				try? userDefaults.removeLastCloudBackup(for: profile.id)
 			}
 
-			let isSyncEnabled = profile.appPreferences.security.isCloudProfileSyncEnabled
-			let needsBackingUp = isSyncEnabled && profile.header.isNonEmpty
+			guard profile.appPreferences.security.isCloudProfileSyncEnabled else { return }
 			let isBackedUp = backedUpHeader?.saveIdentifier == profile.header.saveIdentifier
-			let shouldBackUp = needsBackingUp && !isBackedUp
-			let shouldCheckIfClaimed = isSyncEnabled && timeToCheckIfClaimed
+			let shouldBackUp = profile.header.isNonEmpty && !isBackedUp
 
-			guard shouldBackUp || shouldCheckIfClaimed else { return }
+			guard shouldBackUp || timeToCheckIfClaimed else { return }
 
 			let shouldReclaim: Bool
 			if let backedUpID = backedUpHeader?.lastUsedOnDevice.id, await !profileStore.isThisDevice(deviceID: backedUpID) {

--- a/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Live.swift
+++ b/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Live.swift
@@ -156,11 +156,13 @@ extension CloudBackupClient {
 				try? userDefaults.removeLastCloudBackup(for: profile.id)
 			}
 
-			let needsBackUp = profile.appPreferences.security.isCloudProfileSyncEnabled && profile.header.isNonEmpty
+			let isSynced = profile.appPreferences.security.isCloudProfileSyncEnabled
+			let needsBackUp = isSynced && profile.header.isNonEmpty
 			let isBackedUp = backedUpHeader?.saveIdentifier == profile.header.saveIdentifier
 			let shouldBackUp = needsBackUp && !isBackedUp
+			let shouldCheckIfClaimed = isSynced && timeToCheckIfClaimed
 
-			guard shouldBackUp || timeToCheckIfClaimed else { return }
+			guard shouldBackUp || shouldCheckIfClaimed else { return }
 
 			let shouldReclaim: Bool
 			if let backedUpID = backedUpHeader?.lastUsedOnDevice.id, await !profileStore.isThisDevice(deviceID: backedUpID) {

--- a/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Test.swift
+++ b/RadixWallet/Clients/CloudBackupClient/CloudBackupClient+Test.swift
@@ -15,6 +15,7 @@ extension CloudBackupClient: TestDependencyKey {
 	public static let previewValue: Self = .noop
 
 	public static let noop = Self(
+		isCloudProfileSyncEnabled: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
 		startAutomaticBackups: {},
 		migrateProfilesFromKeychain: { throw NoopError() },
 		deleteProfileBackup: { _ in },
@@ -26,6 +27,7 @@ extension CloudBackupClient: TestDependencyKey {
 	)
 
 	public static let testValue = Self(
+		isCloudProfileSyncEnabled: unimplemented("\(Self.self).isCloudProfileSyncEnabled"),
 		startAutomaticBackups: unimplemented("\(Self.self).startAutomaticBackups"),
 		migrateProfilesFromKeychain: unimplemented("\(Self.self).migrateProfilesFromKeychain"),
 		deleteProfileBackup: unimplemented("\(Self.self).deleteProfileBackup"),

--- a/RadixWallet/Clients/TransportProfileClient/TransportProfileClient+Live.swift
+++ b/RadixWallet/Clients/TransportProfileClient/TransportProfileClient+Live.swift
@@ -14,7 +14,9 @@ extension TransportProfileClient: DependencyKey {
 				do {
 					var profile = profile
 					await profileStore.claimOwnership(of: &profile)
-					try await cloudBackupClient.claimProfileOnICloud(profile)
+					if profile.appSettings.security.isCloudProfileSyncEnabled {
+						try await cloudBackupClient.claimProfileOnICloud(profile)
+					}
 					try await profileStore.importProfile(profile)
 					userDefaults.setShowRelinkConnectorsAfterProfileRestore(containsP2PLinks)
 				} catch {

--- a/RadixWallet/Clients/TransportProfileClient/TransportProfileClient+Live.swift
+++ b/RadixWallet/Clients/TransportProfileClient/TransportProfileClient+Live.swift
@@ -14,8 +14,8 @@ extension TransportProfileClient: DependencyKey {
 				do {
 					var profile = profile
 					await profileStore.claimOwnership(of: &profile)
-					if profile.appSettings.security.isCloudProfileSyncEnabled {
-						try await cloudBackupClient.claimProfileOnICloud(profile)
+					if profile.appPreferences.security.isCloudProfileSyncEnabled {
+						try? await cloudBackupClient.claimProfileOnICloud(profile)
 					}
 					try await profileStore.importProfile(profile)
 					userDefaults.setShowRelinkConnectorsAfterProfileRestore(containsP2PLinks)

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+Reducer.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+Reducer.swift
@@ -254,7 +254,7 @@ public struct SelectBackup: Sendable, FeatureReducer {
 					reason = .accountTemporarilyUnavailable
 				case CKError.notAuthenticated:
 					reason = .notAuthenticated
-				case CKError.networkUnavailable:
+				case CKError.networkUnavailable, CKError.networkFailure:
 					reason = .networkUnavailable
 				default:
 					reason = .other

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+Reducer.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+Reducer.swift
@@ -1,3 +1,4 @@
+import CloudKit
 import ComposableArchitecture
 import SwiftUI
 
@@ -9,7 +10,14 @@ public struct SelectBackup: Sendable, FeatureReducer {
 			case migrating
 			case loading
 			case loaded
-			case failed
+			case failed(FailureReason)
+
+			public enum FailureReason: Sendable {
+				case networkUnavailable
+				case accountTemporarilyUnavailable
+				case notAuthenticated
+				case other
+			}
 		}
 
 		public var status: Status = .start
@@ -240,9 +248,21 @@ public struct SelectBackup: Sendable, FeatureReducer {
 
 				await send(.internal(.setStatus(.loaded)))
 			} catch {
-				errorQueue.schedule(error)
+				let reason: State.Status.FailureReason
+				switch error {
+				case CKError.accountTemporarilyUnavailable:
+					reason = .accountTemporarilyUnavailable
+				case CKError.notAuthenticated:
+					reason = .notAuthenticated
+				case CKError.networkUnavailable:
+					reason = .networkUnavailable
+				default:
+					reason = .other
+					errorQueue.schedule(error)
+				}
+
 				loggerGlobal.error("Failed to migrate or load backed up profiles, error: \(error)")
-				await send(.internal(.setStatus(.failed)))
+				await send(.internal(.setStatus(.failed(reason))))
 			}
 		}
 	}

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
@@ -70,8 +70,16 @@ extension SelectBackup.View {
 					ProgressView()
 				case .loaded:
 					backupsList(with: viewStore)
-				case .failed:
-					EmptyView()
+				case let .failed(reason):
+					let text = switch reason {
+					case .accountTemporarilyUnavailable, .notAuthenticated:
+						"Not logged in to iCloud" // FIXME: Strings
+					case .networkUnavailable:
+						"Network unavailable" // FIXME: Strings
+					case .other:
+						"Could not load list of backups" // FIXME: Strings
+					}
+					NoContentView(text)
 				}
 
 				VStack(alignment: .center, spacing: .small1) {

--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+View.swift
@@ -73,11 +73,11 @@ extension SelectBackup.View {
 				case let .failed(reason):
 					let text = switch reason {
 					case .accountTemporarilyUnavailable, .notAuthenticated:
-						"Not logged in to iCloud" // FIXME: Strings
+						L10n.IOSRecoverProfileBackup.notLoggedInToICloud
 					case .networkUnavailable:
-						"Network unavailable" // FIXME: Strings
+						L10n.IOSRecoverProfileBackup.networkUnavailable
 					case .other:
-						"Could not load list of backups" // FIXME: Strings
+						L10n.IOSRecoverProfileBackup.couldNotLoadBackups
 					}
 					NoContentView(text)
 				}


### PR DESCRIPTION
## Description
Pursuant to [this discussion](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1718896121997059), the restore from backup behaviour is fixed and refined by this PR:

1. If you restore a profile from disk which has iCloud sync turned off, we will no longer try to claim it on iCloud (bugfix)
2. If you restore a profile that has iCloud sync turned on and claiming on iCloud fails, we will continue to import (bugfix) but Security Center will show a problem
3. Prior to this, when loading the list of iCloud backups (or migrating keychain backups ahead of loading the list), if something goes wrong we now distinguish between three cases:

- Not logged in to iCloud, show "Not logged in to iCloud" in the list
- No internet, show "Network unavailable" in the list
- Other error (very rare), show "Could not load backups" in the list and the error in an alert

The strings were added [here](https://github.com/radixdlt/apps-localization-src/pull/413)

## How to test
(Using Pre-alpha 1.6.1 (1) for now, until this is merged)

1. Try to restore from a file that has iCloud sync disabled
2. Try to restore from a file while internet is off
3. Try to load the list of backups with internet off
4. Try to load the list of backups while logged out of iCloud
5. Try to load the list of backups with iCloud for Radix Wallet disabled

![image](https://github.com/radixdlt/babylon-wallet-ios/assets/123396602/a6d28715-6c41-4a61-9b9a-3e62c29464e4)
