### PR TITLE
Center the Success state in the screen

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
@@ -44,7 +44,6 @@ extension Completion {
 						Spacer()
 
 						Image(asset: AssetResource.successCheckmark)
-							.padding(.top, .large1)
 
 						Text(viewStore.title)
 							.foregroundColor(.app.gray1)

--- a/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
@@ -41,6 +41,8 @@ extension Completion {
 					store.send(.view(.dismissTapped))
 				} content: {
 					VStack(spacing: .zero) {
+						Spacer()
+
 						Image(asset: AssetResource.successCheckmark)
 							.padding(.top, .large1)
 


### PR DESCRIPTION
Center the content.

Note that we have to make the Success slide up bigger always to account for the possible bottom message to return to the browser.

old:
<img width="406" alt="Screenshot 2024-06-28 at 14 07 18" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/31831ff5-6820-40c2-afd4-a4422c776064">

new: No message
<img width="404" alt="Screenshot 2024-06-28 at 14 08 42" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/048195a0-1273-47bc-98d8-980db231e3df">

new: Switch back message
<img width="414" alt="Screenshot 2024-06-28 at 14 09 04" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/4dec3961-9fa7-42b1-b2f2-91042a3c9fc7">
