### PR TITLE
Bold dApp name in origin verification

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Children/DappOriginVerification/DappInteractionOriginVerification +View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/DappOriginVerification/DappInteractionOriginVerification +View.swift
@@ -39,7 +39,7 @@ extension DappInteractionOriginVerification {
 					.textStyle(.sheetTitle)
 					.padding(.bottom, .large2)
 
-				Text(L10n.MobileConnect.linkSubtitle(store.dAppMetadata.name))
+				Text(markdown: L10n.MobileConnect.linkSubtitle(store.dAppMetadata.name), italicsColor: .app.gray1)
 					.foregroundColor(.app.gray1)
 					.textStyle(.body1Link)
 			}


### PR DESCRIPTION
Make the dApp name bold.



<img width="338" alt="Screenshot 2024-06-28 at 18 15 49" src="https://github.com/radixdlt/babylon-wallet-ios/assets/118184705/ceae39af-5c4d-4937-a3dc-e42837a9555d">
