### PR TITLE
Address Details + NFT Name UI fixes

### DIFF
--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
@@ -74,10 +74,14 @@ public extension AddressDetails {
 			Group {
 				switch store.qrImage {
 				case let .success(value):
-					Image(decorative: value, scale: 1)
-						.resizable()
-						.aspectRatio(1, contentMode: .fit)
-						.transition(.scale(scale: 0.95).combined(with: .opacity))
+					GeometryReader { proxy in
+						Image(decorative: value, scale: 1)
+							.resizable()
+							.frame(width: proxy.size.height, height: proxy.size.height)
+							.frame(maxWidth: .infinity)
+							.transition(.scale(scale: 0.95).combined(with: .opacity))
+					}
+
 				case .failure:
 					Text(L10n.AddressDetails.qrCodeFailure)
 						.textStyle(.body1HighImportance)

--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
@@ -81,7 +81,6 @@ public extension AddressDetails {
 							.frame(maxWidth: .infinity)
 							.transition(.scale(scale: 0.95).combined(with: .opacity))
 					}
-
 				case .failure:
 					Text(L10n.AddressDetails.qrCodeFailure)
 						.textStyle(.body1HighImportance)

--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
@@ -220,15 +220,6 @@ private extension AddressDetails.View {
 }
 
 private extension AddressDetails.State {
-	var showQrCode: Bool {
-		switch address {
-		case .account:
-			true
-		default:
-			false
-		}
-	}
-
 	var showVerifyOnLedger: Bool {
 		switch address {
 		case let .account(_, isLedgerHWAccount):

--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails.swift
@@ -129,6 +129,9 @@ public struct AddressDetails: Sendable, FeatureReducer {
 	}
 
 	private func loadQrCodeEffect(state: inout State) -> Effect<Action> {
+		guard state.showQrCode else {
+			return .none
+		}
 		state.qrImage = .loading
 		let content = QR.addressPrefix + state.address.address
 		return .run { send in
@@ -141,6 +144,17 @@ public struct AddressDetails: Sendable, FeatureReducer {
 }
 
 // MARK: - Helpers
+
+extension AddressDetails.State {
+	var showQrCode: Bool {
+		switch address {
+		case .account:
+			true
+		default:
+			false
+		}
+	}
+}
 
 private extension OnLedgerEntity.Resource {
 	var resourceTitle: String? {

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
@@ -14,7 +14,7 @@ extension NonFungibleTokenDetails.State {
 				resourceAddress: resourceAddress,
 				isXRD: false,
 				validatorAddress: nil,
-				resourceName: resourceDetails.metadata.title,
+				resourceName: resourceDetails.metadata.name,
 				currentSupply: resourceDetails.totalSupply.map { $0?.formatted() },
 				arbitraryDataFields: resourceDetails.metadata.arbitraryItems.asDataFields,
 				behaviors: resourceDetails.behaviors,


### PR DESCRIPTION
Jira ticket: [ABW-3484](https://radixdlt.atlassian.net/browse/ABW-3484)
Jira ticket: [ABW-3487](https://radixdlt.atlassian.net/browse/ABW-3487)

## Description
This PR solves some small UI bugs reported.

### Notes
Regarding bug [3484](https://radixdlt.atlassian.net/browse/ABW-3484), the solution isn't perfect. This is, if user drags the modal to the top (and hence extend its height), the QR code will still resize while dragging. This is because we want the QR code to take all the available size, and if you increase the modal size then so does the image size. The only way to have it not doing this would be to either:
- prevent the user from dragging the modal => worse UX
- make the QR image size static => we would need to either make the view scrollable, or the QR code smaller enough to fit in every screen regardless of the address length

I think the current situation is good enough and better than before this change, but will leave some videos for comparisson.

| Before | After |
| -- | -- |
| <video src=https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/56715141-9b66-4f0f-ab60-858746f45ceb> | <video src=https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/cfeb82ea-e6e9-433c-a788-4df45d3ec495>
 |






[ABW-3484]: https://radixdlt.atlassian.net/browse/ABW-3484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-3487]: https://radixdlt.atlassian.net/browse/ABW-3487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ