### PR TITLE
[ABW-3477] WalletInteraction - Pre-select Persona

### DIFF
--- a/RadixWallet/Features/CreatePersona/Children/NewPersonaCompletion/NewPersonaCompletion+Reducer.swift
+++ b/RadixWallet/Features/CreatePersona/Children/NewPersonaCompletion/NewPersonaCompletion+Reducer.swift
@@ -34,7 +34,7 @@ public struct NewPersonaCompletion: Sendable, FeatureReducer {
 	}
 
 	public enum DelegateAction: Sendable, Equatable {
-		case completed
+		case completed(Persona)
 	}
 
 	public init() {}
@@ -42,7 +42,7 @@ public struct NewPersonaCompletion: Sendable, FeatureReducer {
 	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
 		case .goToDestination:
-			.send(.delegate(.completed))
+			.send(.delegate(.completed(state.persona)))
 		}
 	}
 }

--- a/RadixWallet/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+Reducer.swift
+++ b/RadixWallet/Features/CreatePersona/Coordinator/CreatePersonaCoordinator+Reducer.swift
@@ -95,7 +95,7 @@ public struct CreatePersonaCoordinator: Sendable, FeatureReducer {
 
 	public enum DelegateAction: Sendable, Equatable {
 		case dismissed
-		case completed
+		case completed(Persona)
 	}
 
 	public enum InternalAction: Sendable, Equatable {
@@ -152,9 +152,9 @@ extension CreatePersonaCoordinator {
 
 			return .send(.internal(.derivePublicKey))
 
-		case .path(.element(_, action: .step2_completion(.delegate(.completed)))):
+		case let .path(.element(_, action: .step2_completion(.delegate(.completed(persona))))):
 			return .run { send in
-				await send(.delegate(.completed))
+				await send(.delegate(.completed(persona)))
 				await dismiss()
 			}
 

--- a/RadixWallet/Features/DappInteractionFeature/Children/Login/Coordinator/Login.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Login/Coordinator/Login.swift
@@ -38,8 +38,11 @@ struct Login: Sendable, FeatureReducer {
 	}
 
 	enum InternalAction: Sendable, Equatable {
+		typealias SelectedPersonaID = IdentityAddress
+
 		case personasLoaded(
 			Personas,
+			SelectedPersonaID?,
 			AuthorizedDapp?,
 			AuthorizedPersonaSimple?
 		)
@@ -76,7 +79,7 @@ struct Login: Sendable, FeatureReducer {
 	func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
 		case .appeared:
-			return loadPersonas(state: &state).concatenate(with: determinePersonaPrimacy())
+			return loadPersonas(state: state).concatenate(with: determinePersonaPrimacy())
 
 		case let .selectedPersonaChanged(persona):
 			state.selectedPersona = persona
@@ -123,7 +126,7 @@ struct Login: Sendable, FeatureReducer {
 			state.personaPrimacy = personaPrimacy
 			return .none
 
-		case let .personasLoaded(personas, authorizedDapp, authorizedPersonaSimple):
+		case let .personasLoaded(personas, selectedPersonaID, authorizedDapp, authorizedPersonaSimple):
 			let lastLoggedInPersona: Persona? = if let authorizedPersonaSimple {
 				personas[id: authorizedPersonaSimple.identityAddress]
 			} else {
@@ -145,22 +148,29 @@ struct Login: Sendable, FeatureReducer {
 			}
 			state.authorizedDapp = authorizedDapp
 			state.authorizedPersona = authorizedPersonaSimple
+
+			if let selectedPersona = state.personas.first(where: { $0.id == selectedPersonaID }) {
+				state.selectedPersona = selectedPersona
+			} else if state.selectedPersona == nil {
+				state.selectedPersona = state.personas.first
+			}
+
 			return .none
 		}
 	}
 
 	func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
 		switch childAction {
-		case .createPersonaCoordinator(.presented(.delegate(.completed))):
+		case let .createPersonaCoordinator(.presented(.delegate(.completed(persona)))):
 			state.personaPrimacy = .notFirstOnCurrentNetwork
-			return loadPersonas(state: &state)
+			return loadPersonas(state: state, selectedPersonaID: persona.id)
 
 		default:
 			return .none
 		}
 	}
 
-	func loadPersonas(state: inout State) -> Effect<Action> {
+	func loadPersonas(state: State, selectedPersonaID: IdentityAddress? = nil) -> Effect<Action> {
 		.run { [dAppDefinitionAddress = state.dappMetadata.dAppDefinitionAddress] send in
 			let personas = try await personasClient.getPersonas()
 			let authorizedDapps = try await authorizedDappsClient.getAuthorizedDapps()
@@ -182,7 +192,7 @@ struct Login: Sendable, FeatureReducer {
 					}
 				}
 			}()
-			await send(.internal(.personasLoaded(personas, authorizedDapp, authorizedPersona)))
+			await send(.internal(.personasLoaded(personas, selectedPersonaID, authorizedDapp, authorizedPersona)))
 		}
 	}
 


### PR DESCRIPTION
Jira ticket: [ABW-3477](https://radixdlt.atlassian.net/browse/ABW-3477)

## Description
This PR updates the pre-selection logic on the Persona selection screen as follows:
- Pre-select the first Persona when the screen opens or if there isn't a selected Persona.
- Pre-select a newly created Persona if the user creates one within the flow.

## Demo
https://github.com/radixdlt/babylon-wallet-ios/assets/163979791/abdbdff1-c358-41f8-98d1-7b04ff5bac24



[ABW-3477]: https://radixdlt.atlassian.net/browse/ABW-3477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ