### PR TITLE
[ABW-3503] Wallet Interaction Success screen dismissal behaviour

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -143,9 +143,9 @@ struct DappInteractor: Sendable, FeatureReducer {
 
 			switch state.destination {
 			case .some(.dappInteractionCompletion):
-				// FIXME: this is a temporary hack, to solve bug where incoming requests
-				// are ignored since completion is believed to be shown, but is not.
-				state.destination = nil
+				if state.requestQueue.isEmpty {
+					state.destination = nil
+				}
 			default: break
 			}
 


### PR DESCRIPTION
Jira ticket: [ABW-3503](https://radixdlt.atlassian.net/browse/ABW-3503)

## Description
Fixes the Wallet Interaction Success screen dismissal behaviour to be automatically dismissed if it is being shown when a new request is received and there are no other requests in the queue.