### PR TITLE
[ABW-3490] Security problems refresh bug

### DIFF
--- a/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
+++ b/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
@@ -66,11 +66,14 @@ extension SecurityCenterClient {
 				}
 
 				func hasProblem5() -> Bool {
-					if isCloudProfileSyncEnabled, let cloudBackup = backups.cloud {
-						cloudBackup.result.failed
-					} else {
-						false
+					guard isCloudProfileSyncEnabled else {
+						return false
 					}
+					guard let cloudBackup = backups.cloud else {
+						return true
+					}
+
+					return !cloudBackup.result.succeeded
 				}
 
 				func hasProblem6() -> Bool {


### PR DESCRIPTION
Jira ticket: [ABW-3490](https://radixdlt.atlassian.net/browse/ABW-3490)

## Description
Solves the UI glitch caused by `problem5` showing up and disappearing during an instant.

### Notes
To reproduce the case easily, you can lower the [retry backup interval](https://github.com/radixdlt/babylon-wallet-ios/blob/164a233d6b532d97cd5135d9607fe90ebd2830e0/RadixWallet/Clients/CloudBackupClient/CloudBackupClient%2BLive.swift#L200) to something like 5-10 seconds. Then, place the device in airplane mode and you will easily see the issue on any account at Home screen.

After doing so and adding some logs for the problems detected by the `SecurityCenterClient`, I could see the following 3 logs almost immediately every time the cloud backup was attempted:
```
[]
[]
[.problem5]
```

As you may see, the client is indicating two times there is no problem, before correctly indicating at last that wallet has `problem5`. 

The first empty result shows because when app tries to perform a new backup after a failing one, it [deletes](https://github.com/radixdlt/babylon-wallet-ios/blob/164a233d6b532d97cd5135d9607fe90ebd2830e0/RadixWallet/Clients/CloudBackupClient/CloudBackupClient%2BLive.swift#L167) the existing one on UserDefaults storage. Then, the `SecurityCenterClient` was considering this not a problem, when the fact is that if iCloud sync is enabled and there is no cloud backup, then we should consider we have a problem. This was fixed [here](https://github.com/radixdlt/babylon-wallet-ios/commit/4f1f3033263b8b7df4ffd69730600565d2ac2698#diff-8cd090629ee1d66f7c446ef5dcdaebd2e5bfe2e9fb7375f3f93748f81c32c679R73).

The second empty result comes because after failing to backup, while we attempt to perform a backup we set User Defaults to have a result `BackupResult.Result.started`. Until now, this wasn't considered a failing state. However it must also be considered a failing state to avoid the glitch while the operation takes place. It makes logical sense to be considered a failure state since we don't have a backup at such moment. This was fixed [here](https://github.com/radixdlt/babylon-wallet-ios/commit/4f1f3033263b8b7df4ffd69730600565d2ac2698#diff-8cd090629ee1d66f7c446ef5dcdaebd2e5bfe2e9fb7375f3f93748f81c32c679R76)


[ABW-3490]: https://radixdlt.atlassian.net/browse/ABW-3490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ