### PR TITLE
[ABW-3484] Position QR image correctly

### DIFF
--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
@@ -78,9 +78,9 @@ public extension AddressDetails {
 						Image(decorative: value, scale: 1)
 							.resizable()
 							.frame(width: proxy.size.height, height: proxy.size.height)
-							.frame(maxWidth: .infinity)
-							.transition(.scale(scale: 0.95).combined(with: .opacity))
+							.position(x: proxy.frame(in: .local).midX, y: proxy.frame(in: .local).midY)
 					}
+					.transition(.scale(scale: 0.95).combined(with: .opacity))
 				case .failure:
 					Text(L10n.AddressDetails.qrCodeFailure)
 						.textStyle(.body1HighImportance)


### PR DESCRIPTION
Jira ticket: [ABW-3484](https://radixdlt.atlassian.net/browse/ABW-3484)

## Description
FIxes the position on some devices like iPhone 11 Pro.

## Screenshot

| Screen 1 Before | Screen 1 After |
| - | - |
| ![Simulator Screenshot - iPhone 11 Pro - 2024-07-10 at 16 30 11](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/e0d7e9b1-4132-4a8e-ac4f-74d7f1a7bce0) | ![Simulator Screenshot - iPhone 11 Pro - 2024-07-10 at 16 30 47](https://github.com/radixdlt/babylon-wallet-ios/assets/164921079/d94cb595-e928-4392-b3e4-c3b227f2e1bf) |





[ABW-3484]: https://radixdlt.atlassian.net/browse/ABW-3484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ