### PR TITLE
[ABW-3273] Update time format for stake claims

### DIFF
--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
@@ -169,9 +169,17 @@ extension OnLedgerEntitiesClient.StakeClaim {
 		guard let reamainingEpochsUntilClaim, isUnstaking else {
 			return nil
 		}
-		return L10n.AssetDetails.Staking.readyToClaimInMinutes(
-			reamainingEpochsUntilClaim * epochDurationInMinutes
-		)
+		typealias S = L10n.AssetDetails.Staking
+		let remainingMinutes = reamainingEpochsUntilClaim * epochDurationInMinutes
+		let remainingHours = remainingMinutes / 60
+		let remainingDays = remainingHours / 24
+		if remainingDays > 0 {
+			return remainingDays == 1 ? S.readyToClaimInDay : S.readyToClaimInDays(remainingDays)
+		} else if remainingHours > 0 {
+			return remainingHours == 1 ? S.readyToClaimInHour : S.readyToClaimInHours(remainingHours)
+		} else {
+			return remainingMinutes == 1 ? S.readyToClaimInMinute : S.readyToClaimInMinutes(remainingMinutes)
+		}
 	}
 }
 


### PR DESCRIPTION
Jira ticket: [ABW-3273](https://radixdlt.atlassian.net/browse/ABW-3273)

## Description
Updates the time format used for stake claims to be more precise.

### Notes
Cannot test it on stokenet (as claims last less than 5 minutes), but hardcoded a few epoch values to take the following screenshots.
<img src=https://github.com/user-attachments/assets/19696244-a656-48f0-adb9-d07b206eac0a width=250> <img src=https://github.com/user-attachments/assets/9a75d2f6-c06d-4258-b759-e1f3c658df60 width=250> <img src=https://github.com/user-attachments/assets/9d28170c-05e5-47a8-920f-1d69d4d5c041 width=250>


[ABW-3273]: https://radixdlt.atlassian.net/browse/ABW-3273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ