### PR TITLE
[ABW-3539] UI Adjustments - Account permission

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Children/AccountPermission/AccountPermission+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/AccountPermission/AccountPermission+View.swift
@@ -44,7 +44,7 @@ extension AccountPermission {
 			) { viewStore in
 				GeometryReader { geometry in
 					ScrollView {
-						VStack(spacing: .large1) {
+						VStack(spacing: .zero) {
 							DappHeader(
 								thumbnail: viewStore.thumbnail,
 								title: viewStore.title,
@@ -58,13 +58,14 @@ extension AccountPermission {
 									.padding(.medium1)
 							}
 							.padding(.horizontal, .medium2)
+							.padding(.top, .large1)
 
 							Text(L10n.DAppRequest.AccountPermission.updateInSettingsExplanation)
 								.foregroundColor(.app.gray2)
 								.textStyle(.body1Regular)
 								.multilineTextAlignment(.center)
 								.padding(.horizontal, .medium2)
-								.padding(.top, .large1)
+								.padding(.top, .medium1)
 
 							Spacer()
 						}

--- a/RadixWallet/Features/DappInteractionFeature/Children/AccountPermission/AccountPermission+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/AccountPermission/AccountPermission+View.swift
@@ -44,7 +44,7 @@ extension AccountPermission {
 			) { viewStore in
 				GeometryReader { geometry in
 					ScrollView {
-						VStack(spacing: .medium2) {
+						VStack(spacing: .large1) {
 							DappHeader(
 								thumbnail: viewStore.thumbnail,
 								title: viewStore.title,
@@ -59,13 +59,12 @@ extension AccountPermission {
 							}
 							.padding(.horizontal, .medium2)
 
-							Spacer()
-
 							Text(L10n.DAppRequest.AccountPermission.updateInSettingsExplanation)
 								.foregroundColor(.app.gray2)
 								.textStyle(.body1Regular)
 								.multilineTextAlignment(.center)
 								.padding(.horizontal, .medium2)
+								.padding(.top, .large1)
 
 							Spacer()
 						}


### PR DESCRIPTION
Jira ticket: [ABW-3539](https://radixdlt.atlassian.net/browse/ABW-3539)

## Description
Updates padding for Account Permission screen.
Account cards updates for `AccountPermissionChooseAccounts` are handled [here](https://github.com/radixdlt/babylon-wallet-ios/pull/1216).

## Screenshot

| Screen 1 Before | Screen 1 After |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-07-17 at 17 45 33](https://github.com/user-attachments/assets/2b8f2857-ede9-4569-be52-8c07012fd311) | ![Simulator Screenshot - iPhone 15 Pro - 2024-07-17 at 17 39 31](https://github.com/user-attachments/assets/944c0351-0872-438c-a6bb-08655a4657b7) |

[ABW-3539]: https://radixdlt.atlassian.net/browse/ABW-3539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ