### PR TITLE
[ABW-3575] Dismiss signing sheet only when rejecting transaction on Ledger

### DIFF
--- a/RadixWallet/Clients/LedgerHardwareWalletClient/LedgerHardwareWalletClient+Live.swift
+++ b/RadixWallet/Clients/LedgerHardwareWalletClient/LedgerHardwareWalletClient+Live.swift
@@ -48,7 +48,7 @@ extension LedgerHardwareWalletClient: DependencyKey {
 					loggerGlobal.warning("Error from CE? \(errorFromConnectorExtension)")
 
 					switch errorFromConnectorExtension.code {
-					case .generic: break
+					case .generic, .userRejectedSigningOfTransaction: break
 					case .blindSigningNotEnabledButRequired:
 						overlayWindowClient.scheduleAlertAndIgnoreAction(
 							.init(
@@ -136,8 +136,8 @@ extension LedgerHardwareWalletClient: DependencyKey {
 				}
 			},
 			signTransaction: { request in
-				let hashedMsg = try request.transactionIntent.hash()
-				let compiledTransactionIntent = try request.transactionIntent.compile()
+				let hashedMsg = request.transactionIntent.hash()
+				let compiledTransactionIntent = request.transactionIntent.compile()
 				return try await sign(
 					signers: request.signers,
 					expectedHashedMessage: hashedMsg.hash.data

--- a/RadixWallet/Core/SharedModels/P2P/ConnectorExtension/P2P+ConnectorExtension+Response.swift
+++ b/RadixWallet/Core/SharedModels/P2P/ConnectorExtension/P2P+ConnectorExtension+Response.swift
@@ -33,9 +33,11 @@ extension P2P.ConnectorExtension.Response.LedgerHardwareWallet {
 		public enum Reason: Int, Sendable, Hashable, Decodable {
 			case generic = 0
 			case blindSigningNotEnabledButRequired = 1
+			case userRejectedSigningOfTransaction = 2
+
 			public var userFacingErrorDescription: String {
 				switch self {
-				case .generic:
+				case .generic, .userRejectedSigningOfTransaction:
 					L10n.Error.TransactionFailure.unknown
 				case .blindSigningNotEnabledButRequired:
 					L10n.Error.TransactionFailure.blindSigningNotEnabledButRequired


### PR DESCRIPTION
Jira ticket: [ABW-3575](https://radixdlt.atlassian.net/browse/ABW-3575)

## Description
When signing a transaction with a Ledger device, we will only dismiss the signing sheet when error was due to user rejecting  transaction on the Ledger device.

## Video


https://github.com/user-attachments/assets/020ad787-ac50-4a7f-a80f-f1b70ebf9970

