### PR TITLE
[ABW-3618] Account address overlay missing X button

### DIFF
--- a/RadixWallet/Core/DesignSystem/Components/CloseButton.swift
+++ b/RadixWallet/Core/DesignSystem/Components/CloseButton.swift
@@ -30,6 +30,7 @@ public struct CloseButton: View {
 			Image(.close)
 				.resizable()
 				.frame(kind.size)
+				.foregroundColor(nil)
 				.tint(kind.tint)
 				.padding(kind.padding)
 		}


### PR DESCRIPTION
Jira ticket: [ABW-3618](https://radixdlt.atlassian.net/browse/ABW-3618)

## Description
Fixes the missing X button for the Account address overlay by setting `foregroundColor` to `nil` to remove any custom foreground color set on `AddressView`.

## Screenshot

| Screen 1 Before | Screen 1 After |
| - | - |
|  ![Simulator Screenshot - iPhone 15 Pro - 2024-07-18 at 13 14 23](https://github.com/user-attachments/assets/c0e33c8e-bba5-4928-89bb-f7b96402f179)|  ![Simulator Screenshot - iPhone 15 Pro - 2024-07-18 at 13 15 05](https://github.com/user-attachments/assets/cc2851c9-bbdb-4d34-a177-92f57ab0a3c4)|