### PR TITLE
[ABW-3868] Disable home card animation

### DIFF
--- a/RadixWallet/Features/CardCarousel/CardCarousel+View.swift
+++ b/RadixWallet/Features/CardCarousel/CardCarousel+View.swift
@@ -40,7 +40,6 @@ extension CardCarousel {
 				}
 			}
 			.tabViewStyle(.page(indexDisplayMode: .never))
-			.animation(.default, value: store.cards)
 		}
 
 		@ViewBuilder


### PR DESCRIPTION
Jira ticket: [ABW-3868](https://radixdlt.atlassian.net/browse/ABW-3638)

## Description
Removes the Home cards animation to avoid weird bug reported in issue.

### Notes
Umair mentioned this cannot be consistently reproduced, and in my case I could never reproduce it. Before removing the animation, I've manually modified the code so that the `HomeCardsObserver` would send a cards update every 3 seconds with the same set of cards (in case there was some weird issue in Sargon code that would cause that). Even with that, the animation only happened on first load, as expected, and not every time the cards were set. Therefore, my conclusion is that this is a weird Swift bug and safest thing to do is remove the animation.
