### PR TITLE
[ABW-3637] Do not preselect account on Transfer + AppTextField fix

### DIFF
--- a/RadixWallet/Core/DesignSystem/Components/AppTextField.swift
+++ b/RadixWallet/Core/DesignSystem/Components/AppTextField.swift
@@ -105,7 +105,7 @@ public struct AppTextField<FocusValue: Hashable, Accessory: View, InnerAccessory
 						VStack(alignment: .leading, spacing: 0) {
 							Text(primaryHeading.text)
 								.textStyle(primaryHeading.isProminent ? .body1HighImportance : .body2Regular)
-								.foregroundColor(primaryHeading.isProminent && isEnabled ? accentColor(isFocused: false) : .app.gray2)
+								.foregroundColor(primaryHeading.isProminent && isEnabled ? accentColor(isFocused: true) : .app.gray2)
 								.multilineTextAlignment(.leading)
 							if let subHeading {
 								Text(subHeading)

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/TransferAccountList+Reducer.swift
@@ -234,7 +234,7 @@ extension TransferAccountList {
 		let chooseAccount: ChooseReceivingAccount.State = .init(
 			networkID: state.fromAccount.networkID,
 			chooseAccounts: .init(
-				selectionRequirement: .exactly(1),
+				context: .assetTransfer,
 				filteredAccounts: filteredAccounts,
 				// Create account is very buggy when started from AssetTransfer, disable it for now.
 				canCreateNewAccount: false

--- a/RadixWallet/Features/ChooseAccounts/ChooseAccounts+Reducer.swift
+++ b/RadixWallet/Features/ChooseAccounts/ChooseAccounts+Reducer.swift
@@ -1,10 +1,10 @@
 import ComposableArchitecture
 import SwiftUI
 
-// MARK: - _ChooseAccounts
+// MARK: - ChooseAccounts
 public struct ChooseAccounts: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
-		public let selectionRequirement: SelectionRequirement
+		public let context: Context
 		public let filteredAccounts: [AccountAddress]
 		public var availableAccounts: IdentifiedArrayOf<Account>
 		public var selectedAccounts: [ChooseAccountsRow.State]?
@@ -13,14 +13,23 @@ public struct ChooseAccounts: Sendable, FeatureReducer {
 		@PresentationState
 		var destination: Destination.State? = nil
 
+		var selectionRequirement: SelectionRequirement {
+			switch context {
+			case .assetTransfer:
+				.exactly(1)
+			case let .permission(selectionRequirement):
+				selectionRequirement
+			}
+		}
+
 		public init(
-			selectionRequirement: SelectionRequirement,
+			context: Context,
 			filteredAccounts: [AccountAddress] = [],
 			availableAccounts: IdentifiedArrayOf<Account> = [],
 			selectedAccounts: [ChooseAccountsRow.State]? = nil,
 			canCreateNewAccount: Bool = true
 		) {
-			self.selectionRequirement = selectionRequirement
+			self.context = context
 			self.filteredAccounts = filteredAccounts
 			self.availableAccounts = availableAccounts
 			self.selectedAccounts = selectedAccounts
@@ -117,5 +126,13 @@ public struct ChooseAccounts: Sendable, FeatureReducer {
 			}
 			await send(.internal(.loadAccountsResult(result)))
 		}
+	}
+}
+
+// MARK: - ChooseAccounts.State.Context
+extension ChooseAccounts.State {
+	public enum Context: Sendable, Hashable {
+		case assetTransfer
+		case permission(SelectionRequirement)
 	}
 }

--- a/RadixWallet/Features/ChooseAccounts/ChooseAccounts+View.swift
+++ b/RadixWallet/Features/ChooseAccounts/ChooseAccounts+View.swift
@@ -22,9 +22,10 @@ extension ChooseAccounts {
 			self.canCreateNewAccount = state.canCreateNewAccount
 
 			// If the dApp is asking for exactly(1) account and user has only one account, pre-select it
-			if let account = availableAccounts.first,
+			if case .permission = state.context,
+			   selectionRequirement == .exactly(1),
 			   availableAccounts.count == 1,
-			   selectionRequirement == .exactly(1)
+			   let account = availableAccounts.first
 			{
 				self.selectedAccounts = [account]
 			} else {

--- a/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+Reducer.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+Reducer.swift
@@ -45,7 +45,7 @@ struct AccountPermissionChooseAccounts: Sendable, FeatureReducer {
 				challenge: challenge,
 				accessKind: accessKind,
 				dappMetadata: dappMetadata,
-				chooseAccounts: .init(selectionRequirement: .init(numberOfAccounts))
+				chooseAccounts: .init(context: .permission(.init(numberOfAccounts)))
 			)
 		}
 	}

--- a/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/AccountPermissionChooseAccounts/AccountPermissionChooseAccounts+View.swift
@@ -131,7 +131,7 @@ extension AccountPermissionChooseAccounts.State {
 		accessKind: .ongoing,
 		dappMetadata: .previewValue,
 		chooseAccounts: .init(
-			selectionRequirement: .exactly(1),
+			context: .assetTransfer,
 			availableAccounts: .init(
 				uniqueElements: [
 					.previewValue0,


### PR DESCRIPTION
Jira tickets: 
[ABW-3637](https://radixdlt.atlassian.net/browse/ABW-3637)
[ABW-3633](https://radixdlt.atlassian.net/browse/ABW-3633)

## Description
This PR solves:
- bug where users wouldn't be able to scan an account if they had 2 accounts added
- fix UI bug on AppTextField

## Before vs after

| Before | After |
| -- | -- |
| <video src=https://github.com/user-attachments/assets/43113e1f-b1b6-4630-b969-80ecbaede2f2> | <video src=https://github.com/user-attachments/assets/78556133-8ca3-40de-9ac2-c24374e2fb44> |
| <img src=https://github.com/user-attachments/assets/96ec78b7-2d5d-47dc-bf0f-80ae84c59c5d width=250> | <img src=https://github.com/user-attachments/assets/5bc50bb4-6b8c-4c8b-b63e-8ecb63c6c890 width=250> |


[ABW-3637]: https://radixdlt.atlassian.net/browse/ABW-3637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-3633]: https://radixdlt.atlassian.net/browse/ABW-3633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ