### PR TITLE
[ABW-3634] Fix bug where Account Details wouldn't show Verify Address on Ledger

### DIFF
--- a/RadixWallet/Clients/AccountsClient/AccountsClient+Interface.swift
+++ b/RadixWallet/Clients/AccountsClient/AccountsClient+Interface.swift
@@ -139,4 +139,13 @@ extension AccountsClient {
 	public func saveVirtualAccount(_ account: Account) async throws {
 		try await saveVirtualAccounts([account])
 	}
+
+	public func isLedgerHWAccount(_ address: AccountAddress) async -> Bool {
+		do {
+			let account = try await getAccountByAddress(address)
+			return account.isLedgerControlled
+		} catch {
+			return false
+		}
+	}
 }

--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
@@ -221,14 +221,3 @@ private extension AddressDetails.View {
 		return .init(result)
 	}
 }
-
-private extension AddressDetails.State {
-	var showVerifyOnLedger: Bool {
-		switch address {
-		case let .account(_, isLedgerHWAccount):
-			isLedgerHWAccount
-		default:
-			false
-		}
-	}
-}

--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails.swift
@@ -9,6 +9,7 @@ public struct AddressDetails: Sendable, FeatureReducer {
 		var showEnlarged = false
 
 		var showShare = false
+		var showVerifyOnLedger = false
 
 		public init(address: LedgerIdentifiable.Address) {
 			self.address = address
@@ -31,6 +32,7 @@ public struct AddressDetails: Sendable, FeatureReducer {
 	public enum InternalAction: Sendable, Equatable {
 		case loadedTitle(TaskResult<String?>)
 		case loadedQrImage(TaskResult<CGImage>)
+		case loadedShowVerifyOnLedger(Bool)
 	}
 
 	@Dependency(\.accountsClient) var accountsClient
@@ -48,6 +50,7 @@ public struct AddressDetails: Sendable, FeatureReducer {
 		case .task:
 			return loadTitleEffect(state: &state)
 				.merge(with: loadQrCodeEffect(state: &state))
+				.merge(with: loadShowVerifyOnLedgerEffect(state: state))
 		case .copyButtonTapped:
 			pasteboardClient.copyString(state.address.address)
 			return .none
@@ -97,6 +100,9 @@ public struct AddressDetails: Sendable, FeatureReducer {
 		case let .loadedQrImage(.failure(error)):
 			state.qrImage = .failure(error)
 			return .none
+		case let .loadedShowVerifyOnLedger(value):
+			state.showVerifyOnLedger = value
+			return .none
 		}
 	}
 
@@ -139,6 +145,22 @@ public struct AddressDetails: Sendable, FeatureReducer {
 				try await qrGeneratorClient.generate(.init(content: content))
 			}
 			await send(.internal(.loadedQrImage(result)))
+		}
+	}
+
+	private func loadShowVerifyOnLedgerEffect(state: State) -> Effect<Action> {
+		switch state.address {
+		case let .account(address, isLedgerHWAccount):
+			if let isLedgerHWAccount {
+				.send(.internal(.loadedShowVerifyOnLedger(isLedgerHWAccount)))
+			} else {
+				.run { send in
+					let showVerifyOnLedger = await accountsClient.isLedgerHWAccount(address)
+					await send(.internal(.loadedShowVerifyOnLedger(showVerifyOnLedger)))
+				}
+			}
+		default:
+			.send(.internal(.loadedShowVerifyOnLedger(false)))
 		}
 	}
 }

--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressView.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressView.swift
@@ -141,7 +141,7 @@ private extension AddressView {
 #if DEBUG
 struct AddressView_Previews: PreviewProvider {
 	static var previews: some View {
-		AddressView(.address(.account(try! .init(validatingAddress: "account_tdx_b_1p8ahenyznrqy2w0tyg00r82rwuxys6z8kmrhh37c7maqpydx7p"))))
+		AddressView(.address(.account(try! .init(validatingAddress: "account_tdx_b_1p8ahenyznrqy2w0tyg00r82rwuxys6z8kmrhh37c7maqpydx7p"), isLedgerHWAccount: false)))
 	}
 }
 #endif

--- a/RadixWallet/Core/SharedModels/LedgerIdentifiable.swift
+++ b/RadixWallet/Core/SharedModels/LedgerIdentifiable.swift
@@ -33,7 +33,9 @@ public enum LedgerIdentifiable: Sendable {
 // MARK: LedgerIdentifiable.Address
 extension LedgerIdentifiable {
 	public enum Address: Hashable, Sendable, Identifiable {
-		case account(AccountAddress, isLedgerHWAccount: Bool = false)
+		/// `isLedgerHWAccount` indicates if the account is controlled by a Ledger device.
+		/// if the value is nil, it means we don't know.
+		case account(AccountAddress, isLedgerHWAccount: Bool?)
 		case package(PackageAddress)
 		case resource(ResourceAddress)
 		case resourcePool(PoolAddress)

--- a/RadixWallet/Core/SharedModels/LedgerIdentifiable.swift
+++ b/RadixWallet/Core/SharedModels/LedgerIdentifiable.swift
@@ -34,7 +34,9 @@ public enum LedgerIdentifiable: Sendable {
 extension LedgerIdentifiable {
 	public enum Address: Hashable, Sendable, Identifiable {
 		/// `isLedgerHWAccount` indicates if the account is controlled by a Ledger device.
-		/// if the value is nil, it means we don't know.
+		/// - `true`: we know the account is controlled by a Ledger device
+		/// - `false`: either the account isn't controller by a Ledger device or it is an external account and we don't care.
+		/// - `nil`: we don't know if the account is controller by a Ledger device, we should check if needed.
 		case account(AccountAddress, isLedgerHWAccount: Bool?)
 		case package(PackageAddress)
 		case resource(ResourceAddress)

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/ReceivingAccount+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/ReceivingAccount+Reducer.swift
@@ -86,9 +86,9 @@ extension AccountOrAddressOf {
 	var identifer: LedgerIdentifiable {
 		switch self {
 		case let .profileAccount(value: account):
-			.address(.account(account.address))
+			.address(.account(account.address, isLedgerHWAccount: account.isLedgerControlled))
 		case let .addressOfExternalAccount(address):
-			.address(.account(address))
+			.address(.account(address, isLedgerHWAccount: false))
 		}
 	}
 

--- a/RadixWallet/Features/CreateAccount/Children/NewAccountCompletion/NewAccountCompletion+View.swift
+++ b/RadixWallet/Features/CreateAccount/Children/NewAccountCompletion/NewAccountCompletion+View.swift
@@ -16,6 +16,7 @@ extension NewAccountCompletion {
 		let subtitle: String
 
 		let accountAddress: AccountAddress
+		let isLedgerController: Bool
 		let appearanceID: AppearanceID
 
 		init(state: NewAccountCompletion.State) {
@@ -31,8 +32,8 @@ extension NewAccountCompletion {
 			}
 
 			self.isFirstOnNetwork = state.isFirstOnNetwork
-
 			self.accountAddress = state.account.address
+			self.isLedgerController = state.account.isLedgerControlled
 			self.appearanceID = state.account.appearanceID
 			self.explanation = L10n.CreateAccount.Completion.explanation
 
@@ -106,7 +107,7 @@ private extension NewAccountCompletion.View {
 					.textStyle(.body1Header)
 					.multilineTextAlignment(.center)
 
-				AddressView(.address(.account(viewStore.accountAddress)), isTappable: false)
+				AddressView(.address(.account(viewStore.accountAddress, isLedgerHWAccount: viewStore.isLedgerController)), isTappable: false)
 					.foregroundColor(.app.whiteTransparent)
 					.textStyle(.body2HighImportance)
 			}

--- a/RadixWallet/Features/CreateAccount/Children/NewAccountCompletion/NewAccountCompletion+View.swift
+++ b/RadixWallet/Features/CreateAccount/Children/NewAccountCompletion/NewAccountCompletion+View.swift
@@ -16,7 +16,7 @@ extension NewAccountCompletion {
 		let subtitle: String
 
 		let accountAddress: AccountAddress
-		let isLedgerController: Bool
+		let isLedgerControlled: Bool
 		let appearanceID: AppearanceID
 
 		init(state: NewAccountCompletion.State) {
@@ -33,7 +33,7 @@ extension NewAccountCompletion {
 
 			self.isFirstOnNetwork = state.isFirstOnNetwork
 			self.accountAddress = state.account.address
-			self.isLedgerController = state.account.isLedgerControlled
+			self.isLedgerControlled = state.account.isLedgerControlled
 			self.appearanceID = state.account.appearanceID
 			self.explanation = L10n.CreateAccount.Completion.explanation
 
@@ -107,7 +107,7 @@ private extension NewAccountCompletion.View {
 					.textStyle(.body1Header)
 					.multilineTextAlignment(.center)
 
-				AddressView(.address(.account(viewStore.accountAddress, isLedgerHWAccount: viewStore.isLedgerController)), isTappable: false)
+				AddressView(.address(.account(viewStore.accountAddress, isLedgerHWAccount: viewStore.isLedgerControlled)), isTappable: false)
 					.foregroundColor(.app.whiteTransparent)
 					.textStyle(.body2HighImportance)
 			}

--- a/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/DappDetails/DappDetails+View.swift
@@ -174,7 +174,7 @@ extension DappDetails.View {
 						Spacer(minLength: 0)
 
 						AddressView(
-							.address(.account(viewStore.address)),
+							.address(.account(viewStore.address, isLedgerHWAccount: false)),
 							imageColor: .app.gray2
 						)
 						.foregroundColor(.app.gray1)

--- a/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
@@ -199,7 +199,7 @@ extension PersonaDetails.View {
 						ForEach(viewStore.sharingAccounts) { account in
 							SmallAccountCard(
 								account.label.rawValue,
-								identifiable: .address(.account(account.address)),
+								identifiable: .address(.account(account.address, isLedgerHWAccount: nil)),
 								gradient: .init(account.appearanceId)
 							)
 							.cornerRadius(.small1)

--- a/RadixWallet/Features/SettingsFeature/Troubleshooting/ImportFromOlympiaLegacyWallet/Children/Completion/CompletionMigrateOlympiaAccountsToBabylon+View.swift
+++ b/RadixWallet/Features/SettingsFeature/Troubleshooting/ImportFromOlympiaLegacyWallet/Children/Completion/CompletionMigrateOlympiaAccountsToBabylon+View.swift
@@ -123,7 +123,7 @@ extension CompletionMigrateOlympiaAccountsToBabylon {
 					Text(name)
 						.textStyle(.body1Header)
 				}
-				AddressView(.address(.account(account.address)))
+				AddressView(.address(.account(account.address, isLedgerHWAccount: nil)))
 					.opacity(0.8)
 			}
 			.foregroundColor(.app.white)

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewAccount/TransactionReviewAccount+View.swift
@@ -166,7 +166,7 @@ extension SmallAccountCard where Accessory == EmptyView {
 		case let .external(accountAddress, _):
 			self.init(
 				L10n.TransactionReview.externalAccountName,
-				identifiable: .address(.account(accountAddress)),
+				identifiable: .address(.account(accountAddress, isLedgerHWAccount: false)),
 				gradient: .init(colors: [.app.gray2]),
 				verticalPadding: .small1
 			)


### PR DESCRIPTION
Jira ticket: [ABW-3634](https://radixdlt.atlassian.net/browse/ABW-3634)

## Description
Manually check whether an `AccountForDisplay` is controller by a Ledger device, instead of assuming it isn't.

## Before vs After
| Screen 1 Before | Screen 1 After |
| - | - |
| <video src=https://github.com/user-attachments/assets/0f48e878-8b2e-4005-a7be-e31c4ff9994a> | <video src=https://github.com/user-attachments/assets/71c634e9-f926-4b80-b96c-ae6e43116598> |
