### PR TITLE
[ABW-3630] Fix NFTs collection background refresh

### DIFF
--- a/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/AssetsView+Reducer.swift
@@ -154,8 +154,9 @@ public struct AssetsView: Sendable, FeatureReducer {
 			state.isLoadingResources = false
 			state.isRefreshing = false
 			portfolio.account = portfolio.account.nonEmptyVaults
-			updateFromPortfolio(state: &state, from: portfolio)
-			return .none
+			let nftRowsToRefresh = updateFromPortfolio(state: &state, from: portfolio)
+
+			return !nftRowsToRefresh.isEmpty ? .send(.child(.nonFungibleTokenList(.internal(.refreshRows(nftRowsToRefresh))))) : .none
 		}
 	}
 

--- a/RadixWallet/Features/AssetsFeature/AssetsView+Update.swift
+++ b/RadixWallet/Features/AssetsFeature/AssetsView+Update.swift
@@ -38,13 +38,11 @@ extension AssetsView {
 			)
 		}
 		let nftRowsToRefresh: [ResourceAddress] = portfolio.account.nonFungibleResources.compactMap { resource in
-			guard let row = state.resources.nonFungibleTokenList?.rows.first(where: {
+			state.resources.nonFungibleTokenList?.rows.first {
 				$0.id == resource.resourceAddress &&
 					$0.resource.nonFungibleIdsCount != resource.nonFungibleIdsCount &&
 					$0.isExpanded
-			}) else { return nil }
-
-			return row.id
+			}?.id
 		}
 
 		let fungibleTokenList: FungibleAssetList.State? = {

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
@@ -59,6 +59,7 @@ extension NonFungibleAssetList {
 			}
 
 			case tokensLoaded(TaskResult<TokensLoadResult>)
+			case refreshResources
 		}
 
 		@Dependency(\.onLedgerEntitiesClient) var onLedgerEntitiesClient
@@ -131,6 +132,9 @@ extension NonFungibleAssetList {
 					state.isLoadingResources = false
 				}
 				return .none
+
+			case .refreshResources:
+				return loadResources(&state, pageIndex: 0)
 			}
 		}
 

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/NonFungibleAssetList+Reducer.swift
@@ -10,6 +10,10 @@ public struct NonFungibleAssetList: Sendable, FeatureReducer {
 		case asset(NonFungibleAssetList.Row.State.ID, NonFungibleAssetList.Row.Action)
 	}
 
+	public enum InternalAction: Sendable, Equatable {
+		case refreshRows([ResourceAddress])
+	}
+
 	public enum DelegateAction: Sendable, Equatable {
 		case selected(OnLedgerEntity.OwnedNonFungibleResource, token: OnLedgerEntity.NonFungibleToken)
 	}
@@ -34,6 +38,13 @@ public struct NonFungibleAssetList: Sendable, FeatureReducer {
 
 		case .asset:
 			return .none
+		}
+	}
+
+	public func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
+		switch internalAction {
+		case let .refreshRows(rows):
+			.merge(rows.map { .send(.child(.asset($0, .internal(.refreshResources)))) })
 		}
 	}
 }


### PR DESCRIPTION
Jira ticket: [ABW-3630](https://radixdlt.atlassian.net/browse/ABW-3630)

## Description
Fixes an issue where an expanded collection is not updated if it changes after a direct transfer or background refresh.
The solution is to update the collection when the portfolio is updated, but only if the collection is expanded and the `nonFungibleIdsCount` has changed. This ensures the update occurs only when necessary to avoid resetting pagination.

## Video

https://github.com/user-attachments/assets/55351d48-f065-4140-95df-cef99af813c1



[ABW-3630]: https://radixdlt.atlassian.net/browse/ABW-3630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ