### PR TITLE
[ABW-3635] FIx Text with markdown

### DIFF
--- a/RadixWallet/Core/FeaturePrelude/Extensions/AttributedString+Extra.swift
+++ b/RadixWallet/Core/FeaturePrelude/Extensions/AttributedString+Extra.swift
@@ -1,7 +1,7 @@
 extension Text {
-	/// Shows a markdown string, where any italics sections are shown in the provided color
-	public init(markdown: String, emphasizedColor: Color) {
-		let attributed = AttributedString(markdown: markdown, replaceEmphasizedWith: emphasizedColor)
+	/// Shows a markdown string, where any italics/bold sections are shown in the provided color and font.
+	public init(markdown: String, emphasizedColor: Color, emphasizedFont: SwiftUI.Font? = nil) {
+		let attributed = AttributedString(markdown: markdown, replaceEmphasizedWith: emphasizedColor, font: emphasizedFont)
 		self.init(attributed)
 	}
 }
@@ -11,14 +11,14 @@ extension AttributedString {
 		self = update(AttributedString(string)) { $0.foregroundColor = foregroundColor }
 	}
 
-	public init(markdown: some StringProtocol, replaceEmphasizedWith emphasizedColor: Color) {
+	public init(markdown: some StringProtocol, replaceEmphasizedWith color: Color, font: SwiftUI.Font?) {
 		let string = String(markdown)
 		guard let attributed = try? AttributedString(markdown: string) else {
 			self.init(string)
 			return
 		}
 
-		let replacement = AttributeContainer.foregroundColor(emphasizedColor)
+		let replacement = AttributeContainer.emphasized(color: color, font: font)
 		self = attributed
 			.replacingAttributes(.emphasized, with: replacement)
 			.replacingAttributes(.stronglyEmphasized, with: replacement)
@@ -35,8 +35,9 @@ extension AttributeContainer {
 		return result
 	}
 
-	public static func foregroundColor(_ color: Color) -> AttributeContainer {
+	public static func emphasized(color: Color, font: SwiftUI.Font?) -> AttributeContainer {
 		var result = AttributeContainer()
+		result.font = font
 		result.foregroundColor = color
 		return result
 	}

--- a/RadixWallet/Features/DappInteractionFeature/Children/DappOriginVerification/DappInteractionOriginVerification+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/DappOriginVerification/DappInteractionOriginVerification+View.swift
@@ -39,7 +39,7 @@ extension DappInteractionOriginVerification {
 					.textStyle(.sheetTitle)
 					.padding(.bottom, .large2)
 
-				Text(markdown: L10n.MobileConnect.linkSubtitle(store.dAppMetadata.name), emphasizedColor: .app.gray1)
+				Text(markdown: L10n.MobileConnect.linkSubtitle(store.dAppMetadata.name), emphasizedColor: .app.gray1, emphasizedFont: .app.body1Header)
 					.foregroundColor(.app.gray1)
 					.textStyle(.body1Link)
 			}

--- a/RadixWallet/Features/ScanQR/Children/ScanQR/ScanQR+View.swift
+++ b/RadixWallet/Features/ScanQR/Children/ScanQR/ScanQR+View.swift
@@ -74,7 +74,7 @@ extension ScanQR.View {
 				ForEach(Array(disclosure.items.enumerated()), id: \.0) { index, message in
 					HStack(alignment: .top, spacing: .small3) {
 						Text("\(index + 1).")
-						Text(markdown: message, emphasizedColor: .app.gray1)
+						Text(markdown: message, emphasizedColor: .app.gray1, emphasizedFont: .app.body2HighImportance)
 					}
 					.multilineTextAlignment(.leading)
 					.font(.app.body2Regular)


### PR DESCRIPTION
Jira ticket: [ABW-3635](https://radixdlt.atlassian.net/browse/ABW-3635)

## Description
Allows the `Text` init for markdown to set a custom font for the emphasized parts.

## Screenshots
The following 3 screens are the ones using markdown for a Text. The [first](https://zpl.io/404lWY8) one uses the same font for emphasized part than common, while [second](https://zpl.io/noMqM9A) and [third](https://zpl.io/wyqYOjd) set a different font for the emphasized part.

| DappHeader | Link Connector | Origin verification |
| - | - | - |
| <img src=https://github.com/user-attachments/assets/0ea22aba-ce91-4895-9af1-8cf428c34839 width=200> | <img src=https://github.com/user-attachments/assets/ff4d5d0b-05af-48cf-8bd1-18c9dcd10c10 width=200> |  <img src=https://github.com/user-attachments/assets/e38e9275-8d3a-40b2-a06a-35013b41b2a6 width=200> |



[ABW-3635]: https://radixdlt.atlassian.net/browse/ABW-3635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ