### PR TITLE
Top QR code width/height

### DIFF
--- a/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
+++ b/RadixWallet/Core/FeaturePrelude/AddressView/AddressDetails+View.swift
@@ -65,7 +65,6 @@ public extension AddressDetails {
 						.foregroundColor(.app.gray1)
 
 					qrCode
-						.padding(.horizontal, .large2)
 				}
 			}
 		}
@@ -75,9 +74,10 @@ public extension AddressDetails {
 				switch store.qrImage {
 				case let .success(value):
 					GeometryReader { proxy in
+						let size = min(proxy.size.height, proxy.size.width, 275)
 						Image(decorative: value, scale: 1)
 							.resizable()
-							.frame(width: proxy.size.height, height: proxy.size.height)
+							.frame(width: size, height: size)
 							.position(x: proxy.frame(in: .local).midX, y: proxy.frame(in: .local).midY)
 					}
 					.transition(.scale(scale: 0.95).combined(with: .opacity))


### PR DESCRIPTION
## Description
This PR tops the width/height used for the Address details QR code to be 275 or less.

## Screenshots

<img width=250 src=https://github.com/user-attachments/assets/0b1d2d5a-8e3f-4c62-baad-6c00e6f8fc2f> <img width=250 src=https://github.com/user-attachments/assets/3a82ac70-25ca-4c40-85a4-08ed7f4d35a1>
