### PR TITLE
[ABW-3650] Security state incorrectly updating

### DIFF
--- a/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
+++ b/RadixWallet/Clients/SecurityCenterClient/SecurityCenterClient+Live.swift
@@ -38,6 +38,10 @@ extension SecurityCenterClient {
 		func cloudBackups() async -> AnyAsyncSequence<BackupStatus?> {
 			let profileID = await profileStore.profile.id
 			let backups = userDefaults.lastCloudBackupValues(for: profileID)
+				.filter { backup in
+					backup?.isFinal ?? true
+				}
+				.eraseToAnyAsyncSequence()
 			return await statusValues(results: backups)
 		}
 
@@ -72,8 +76,7 @@ extension SecurityCenterClient {
 					guard let cloudBackup = backups.cloud else {
 						return true
 					}
-
-					return !cloudBackup.result.succeeded
+					return cloudBackup.result.failed
 				}
 
 				func hasProblem6() -> Bool {

--- a/RadixWallet/Clients/UserDefaults+Dependency+Extension/UserDefaults+Dependency+Extension.swift
+++ b/RadixWallet/Clients/UserDefaults+Dependency+Extension/UserDefaults+Dependency+Extension.swift
@@ -259,6 +259,13 @@ public struct BackupResult: Hashable, Codable, Sendable {
 		}
 	}
 
+	public var isFinal: Bool {
+		switch result {
+		case .started: false
+		case .failure, .success: true
+		}
+	}
+
 	public enum Result: Hashable, Codable, Sendable {
 		case started(Date)
 		case success


### PR DESCRIPTION
Jira ticket: [ABW-3650](https://radixdlt.atlassian.net/browse/ABW-3650)

## Description
This PR solves an issue where a security problem would up for an instant when toggling the balances visibility. 

### Notes
This issue was introduced when we fixed another similar on https://github.com/radixdlt/babylon-wallet-ios/pull/1207. Basically, we were considering `.started` backups as failures, which helped solved the previous situation. 
However, we shouldn't consider `.started` backups as failures when the last backup was a `.success`: they should only be considered failures when the previous one was a `.failure`. Therefore, the solution is to just ignore `.started` backups for this check.

### Before vs After
| Before | After |
| -- | -- |
| <video src=https://github.com/user-attachments/assets/12eaf8f7-953f-4d6f-9ad3-37969571862e> | <video src=https://github.com/user-attachments/assets/46fbdb0a-7813-48bb-a34f-fac5edb4f4db> |


[ABW-3650]: https://radixdlt.atlassian.net/browse/ABW-3650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ