### PR TITLE
[ABW-3651] Fix RUID NFTs local id abbreviation

### DIFF
--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungibleAssetRow+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungibleAssetRow+View.swift
@@ -100,7 +100,7 @@ extension NonFungibleAssetList.Row.View {
 
 				HStack {
 					NFTIDView(
-						id: asset.id.nonFungibleLocalId.toUserFacingString(),
+						id: asset.id.nonFungibleLocalId.formatted(.default),
 						name: asset.data?.name,
 						thumbnail: asset.data?.keyImageURL
 					)

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungibleAssetRow+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungibleAssetRow+View.swift
@@ -100,7 +100,7 @@ extension NonFungibleAssetList.Row.View {
 
 				HStack {
 					NFTIDView(
-						id: asset.id.nonFungibleLocalId.formatted(.default),
+						id: asset.id.nonFungibleLocalId.formatted(),
 						name: asset.data?.name,
 						thumbnail: asset.data?.keyImageURL
 					)


### PR DESCRIPTION
Jira ticket: [ABW-3651](https://radixdlt.atlassian.net/browse/ABW-3651)

## Description
This PR fixes the abbreviation for NFT's localID of an RUID type.
Formatting is handled in [Sargon](https://github.com/radixdlt/sargon/blob/b0f6c8948eb17237414f1bd34ca776fec71a4858/src/profile/v100/address/non_fungible_local_id.rs#L61).

[ABW-3651]: https://radixdlt.atlassian.net/browse/ABW-3651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ