### PR TITLE
Remove Home Card transition

### DIFF
--- a/RadixWallet/Features/CardCarousel/CardCarousel+View.swift
+++ b/RadixWallet/Features/CardCarousel/CardCarousel+View.swift
@@ -36,7 +36,6 @@ extension CardCarousel {
 					}
 					.tag(index)
 					.padding(.horizontal, margin - spacing)
-					.transition(.scale(scale: 0.8).combined(with: .opacity))
 				}
 			}
 			.tabViewStyle(.page(indexDisplayMode: .never))


### PR DESCRIPTION
## Description
Second part of https://github.com/radixdlt/babylon-wallet-ios/pull/1227. A UI [glitch](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1721827160507999) that only happens on his device and not consistently. 
The transition wasn't having any effect on the card any way (probably because the card is inside a `TabView` now?), so this doesn't change the current UX for currently working users, and hopefully stops the issue for those who show the glitch now.
