### PR TITLE
Handle Success screen dismissal by swipe down

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -248,8 +248,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 			}
 
 		case .dappInteractionCompletion(.delegate(.dismiss)):
-			state.destination = nil
-			return delayedMediumEffect(internal: .presentQueuedRequestIfNeeded)
+			return onCompletionScreenDismissed(&state)
 
 		case let .responseFailure(action):
 			switch action {
@@ -275,6 +274,15 @@ struct DappInteractor: Sendable, FeatureReducer {
 
 		default:
 			return .none
+		}
+	}
+
+	func reduceDismissedDestination(into state: inout State) -> Effect<Action> {
+		switch state.destination {
+		case .dappInteractionCompletion:
+			onCompletionScreenDismissed(&state)
+		default:
+			.none
 		}
 	}
 
@@ -346,6 +354,11 @@ struct DappInteractor: Sendable, FeatureReducer {
 	func dismissCurrentModalAndRequest(_ request: RequestEnvelope, for state: inout State) {
 		state.requestQueue.remove(id: request.id)
 		state.destination = nil
+	}
+
+	func onCompletionScreenDismissed(_ state: inout State) -> Effect<Action> {
+		state.destination = nil
+		return delayedMediumEffect(internal: .presentQueuedRequestIfNeeded)
 	}
 }
 


### PR DESCRIPTION
DappInteractor was not hooked to handle the Success screen dismissal by swipe down, thus if there were multiple requests in the queue, the next one was not shown as DappInteractor state still was holding to the Success screen state.

Fix by handling also the dismissal by swipe done.