### PR TITLE
Don't present success screen if there are other transaction in the queue

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -214,6 +214,9 @@ struct DappInteractor: Sendable, FeatureReducer {
 
 		case let .presentResponseSuccessView(dappMetadata, txID, p2pRoute):
 			state.shouldIncrementOnCompletionDismiss = txID != nil
+			if !state.requestQueue.isEmpty {
+				return delayedMediumEffect(internal: .presentQueuedRequestIfNeeded)
+			}
 			state.destination = .dappInteractionCompletion(
 				.init(
 					txID: txID,


### PR DESCRIPTION
Don't present success screen if there are other transaction in the queue

# Demo
- A transfer from the Wallet is added.
- A transaction from Gumball Club is added.
- Account update interaction from Gumball Club is added.
Success screen is shown only for the last interaction as there were no other interactions in the queue.


https://github.com/user-attachments/assets/4fa129bd-299c-4ac0-87cf-f45ad4250333

