### PR TITLE
Allow to drag Submit Transaction modal on failure

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Children/Completion/Completion+View.swift
@@ -64,7 +64,7 @@ extension Completion {
 									.foregroundColor(.app.blue1)
 							}
 							.textStyle(.body1Header)
-							.padding(.top, .medium3)
+							.padding(.top, .small2)
 						}
 
 						Spacer()

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
@@ -69,7 +69,7 @@ extension SubmitTransaction {
 				WithNavigationBar {
 					viewStore.send(.closeButtonTapped)
 				} content: {
-					VStack(spacing: .medium3) {
+					VStack(spacing: .zero) {
 						Spacer()
 						if viewStore.status.failed {
 							Image(.errorLarge)
@@ -78,6 +78,7 @@ extension SubmitTransaction {
 								.textStyle(.sheetTitle)
 								.multilineTextAlignment(.center)
 								.padding(.horizontal, .medium2)
+								.padding(.top, .medium3)
 						} else {
 							Image(asset: AssetResource.transactionInProgress)
 								.opacity(opacity)
@@ -99,6 +100,7 @@ extension SubmitTransaction {
 							.textStyle(.body1Regular)
 							.multilineTextAlignment(.center)
 							.padding(.horizontal, .medium2)
+							.padding(.top, .medium3)
 
 						HStack {
 							Text(L10n.TransactionReview.SubmitTransaction.txID)
@@ -108,6 +110,7 @@ extension SubmitTransaction {
 						}
 						.textStyle(.body1Header)
 						.padding(.horizontal, .medium2)
+						.padding(.top, .small2)
 
 						Spacer()
 						if viewStore.status.failed, viewStore.showSwitchBackToBrowserMessage {
@@ -128,9 +131,19 @@ extension SubmitTransaction {
 				.alert(store: store.scope(state: \.$dismissTransactionAlert, action: { .view(.dismissTransactionAlert($0)) }))
 				.interactiveDismissDisabled(viewStore.dismissalDisabled)
 				.presentationDragIndicator(.visible)
-				.presentationDetents([.fraction(0.66)])
+				.presentationDetents(viewStore.presentationDetents)
 				.presentationBackground(.blur)
 			}
+		}
+	}
+}
+
+private extension ViewStoreOf<SubmitTransaction> {
+	var presentationDetents: Set<PresentationDetent> {
+		if self.status.failed {
+			[.fraction(0.66), .large]
+		} else {
+			[.fraction(0.66)]
 		}
 	}
 }


### PR DESCRIPTION
## Description
Modal wasn't big enough for some font/screen sizes on failure, so we are allowing user to drag up to full screen on such cases.

Also updates spacing between subtitle and TX id to match designs.