### PR TITLE
[ABW-3620] Home view UI adjustments

### DIFF
--- a/RadixWallet/Features/CardCarousel/CardCarousel+View.swift
+++ b/RadixWallet/Features/CardCarousel/CardCarousel+View.swift
@@ -15,7 +15,7 @@ extension CardCarousel {
 			WithPerceptionTracking {
 				VStack(spacing: .small2) {
 					coreView
-						.frame(height: store.cards.isEmpty ? 0 : height)
+						.frame(height: store.cards.isEmpty ? .small2 : height)
 
 					positionIndicator
 				}

--- a/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
+++ b/RadixWallet/Features/HomeFeature/Coordinator/Home+View.swift
@@ -24,8 +24,8 @@ extension Home {
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState) { viewStore in
 				ScrollView {
-					VStack(spacing: .medium1) {
-						HeaderView(store: store)
+					VStack(spacing: .medium3) {
+						CardCarousel.View(store: store.scope(state: \.carousel, action: \.child.carousel))
 
 						if let fiatWorth = viewStore.totalFiatWorth {
 							VStack(spacing: .small2) {
@@ -62,14 +62,22 @@ extension Home {
 						.buttonStyle(.secondaryRectangular())
 					}
 					.padding(.bottom, .medium3)
+					.padding(.top, .small1)
 				}
 				.toolbar {
+					ToolbarItem(placement: .topBarLeading) {
+						Text(L10n.HomePage.title)
+							.foregroundColor(.app.gray1)
+							.textStyle(.sheetTitle)
+							.padding(.leading, .medium3)
+					}
 					ToolbarItem(placement: .navigationBarTrailing) {
 						Button {
 							store.send(.view(.settingsButtonTapped))
 						} label: {
 							Image(.homeHeaderSettings)
 						}
+						.padding(.trailing, .medium3)
 					}
 				}
 			}
@@ -85,23 +93,6 @@ extension Home {
 			}
 			.onDisappear {
 				store.send(.view(.onDisappear))
-			}
-		}
-
-		struct HeaderView: SwiftUI.View {
-			let store: StoreOf<Home>
-
-			var body: some SwiftUI.View {
-				VStack(spacing: .small2) {
-					Text(L10n.HomePage.title)
-						.foregroundColor(.app.gray1)
-						.textStyle(.sheetTitle)
-						.flushedLeft
-						.padding(.horizontal, .medium1)
-
-					CardCarousel.View(store: store.scope(state: \.carousel, action: \.child.carousel))
-				}
-				.padding(.top, .small3)
 			}
 		}
 	}


### PR DESCRIPTION
Jira ticket: [ABW-3620](https://radixdlt.atlassian.net/browse/ABW-3620)

## Description
This PR updates the UI on Home view to match the designs.

### Notes
Changes to the Account cards are done in https://github.com/radixdlt/babylon-wallet-ios/pull/1216.

## Screenshot

| Screen 1 Before | Screen 1 After |
| - | - |
| <img width=250 src=https://github.com/user-attachments/assets/fb3a8f35-fe32-4cd3-b336-a6015d05b661> | <img width=250 src=https://github.com/user-attachments/assets/ec0e37b0-cfe7-4fa2-b58a-366ea6de72e2> |
| <img width=250 src=https://github.com/user-attachments/assets/3ec1d98a-479e-4cbe-94f3-1ad0e0bda8c9> | <img width=250 src=https://github.com/user-attachments/assets/77b0d82a-fa0c-48e7-bcb2-e19f24e5ac2a> |



[ABW-3620]: https://radixdlt.atlassian.net/browse/ABW-3620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ