### PR TITLE
[ABW-3613] Fix fungible resources sorting

### DIFF
--- a/RadixWallet/Clients/OnLedgerEntitiesClient/Helpers/OnLedgerEntitiesClient+CreateEntity.swift
+++ b/RadixWallet/Clients/OnLedgerEntitiesClient/Helpers/OnLedgerEntitiesClient+CreateEntity.swift
@@ -625,13 +625,6 @@ extension OnLedgerEntity.OwnedFungibleResource: Comparable {
 			return lhs.amount.fiatWorth != nil
 		}
 
-		if lhs.amount.nominalAmount > .zero, rhs.amount.nominalAmount > .zero {
-			return lhs.amount.nominalAmount > rhs.amount.nominalAmount // Sort descending by amount
-		}
-		if lhs.amount.nominalAmount != .zero || rhs.amount.nominalAmount != .zero {
-			return lhs.amount.nominalAmount != .zero
-		}
-
 		if let lhsSymbol = lhs.metadata.symbol, let rhsSymbol = rhs.metadata.symbol {
 			return lhsSymbol < rhsSymbol // Sort alphabetically by symbol
 		}


### PR DESCRIPTION
Jira ticket: [ABW-3613](https://radixdlt.atlassian.net/browse/ABW-3613)

## Description
Removes nominal amount from fungibles resources sorting criteria.

## Notes
To test this on stokenet, update [this](https://github.com/radixdlt/babylon-wallet-ios/blob/main/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient%2BState.swift#L143) line so that it returns `nil`.

## Screenshot

| Screen 1 Before | Screen 1 After |
| - | - |
| <img src=https://github.com/user-attachments/assets/c8e6a06e-1530-45cc-bf97-551a60515064 width=250> | <img src=https://github.com/user-attachments/assets/e1706e7d-9080-4d7c-93d1-1d25615712b3 width=250> |



[ABW-3613]: https://radixdlt.atlassian.net/browse/ABW-3613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ