### PR TITLE
Hotfix for dApp validation error

### DIFF
--- a/Aux/Config/Common.xcconfig
+++ b/Aux/Config/Common.xcconfig
@@ -1,7 +1,7 @@
 // MARK: - Custom flags
 
 /// Application version shared across all targets and flavours
-APP_VERSION = 1.8.1
+APP_VERSION = 1.8.2
 
 /// App Icon base name
 APP_ICON = AppIcon

--- a/RadixWallet/Clients/HTTPClient/HTTPClient+Live.swift
+++ b/RadixWallet/Clients/HTTPClient/HTTPClient+Live.swift
@@ -4,7 +4,31 @@ extension HTTPClient {
 
 		return .init(
 			executeRequest: { request, acceptedStatusCodes in
-				let (data, urlResponse) = try await session.data(for: request)
+				let (data, urlResponse) = try await {
+					// Retrying only once seems to be enough, but better to be on the safe side and retry more.
+					var retryAttempts = 5
+					while retryAttempts > 0 {
+						do {
+							return try await session.data(for: request)
+						} catch {
+							// Handle the very obscure error when the CFNetwork drops the request after it being sent.
+							// Note that NSURLErrorNetworkConnectionLost seems to be an opaque error hiding some other
+							// possible error withing CFNetwork, it does not literally mean that hte network connection
+							// was actually lost. This error will usually be thrown when the request was made right after
+							// the app did come to foreground, it happens seldomly, but consistently.
+							// As a workaround - retry the request if it failed initially.
+							if let nsError = error as NSError?,
+							   nsError.domain == NSURLErrorDomain,
+							   nsError.code == NSURLErrorNetworkConnectionLost
+							{
+								retryAttempts -= 1
+								continue
+							}
+							throw error
+						}
+					}
+					throw RequestRetryAttemptsExceeded()
+				}()
 
 				guard let httpURLResponse = urlResponse as? HTTPURLResponse else {
 					throw ExpectedHTTPURLResponse()

--- a/RadixWallet/Core/SharedModels/HTTPURLSessionResponse/HTTPURLSessionResponse.swift
+++ b/RadixWallet/Core/SharedModels/HTTPURLSessionResponse/HTTPURLSessionResponse.swift
@@ -3,6 +3,11 @@ public struct ExpectedHTTPURLResponse: Swift.Error {
 	public init() {}
 }
 
+// MARK: - RequestRetryAttemptsExceeded
+public struct RequestRetryAttemptsExceeded: Swift.Error {
+	public init() {}
+}
+
 // MARK: - BadHTTPResponseCode
 public struct BadHTTPResponseCode: LocalizedError {
 	public let got: Int

--- a/RadixWallet/RadixConnect/RadixConnect/Mobile/RadixConnectMobile.swift
+++ b/RadixWallet/RadixConnect/RadixConnect/Mobile/RadixConnectMobile.swift
@@ -15,20 +15,6 @@ extension RadixConnectMobile {
 	}
 
 	func handleRequest(_ request: URL) async throws {
-		@Dependency(\.continuousClock) var clock
-		// A slight delay before handling the request.
-		//
-		// This is mainly added to fix the following issue:
-		// In some cases the Wallet will show the "Failed to validate dApp" alert.
-		//
-		// The cause for this issue is that during dApp validation, when Dev mode is not enabled,
-		// network requests are being made, and seldomly, but quite consistent, the OS will terminate
-		// the request with the quite obscure message - "Network connection lost".
-		// Likely that this is because the app is not fully in foreground at the moment the request is being made.
-		// So adding a small delay allows the OS to be ready to handle the request. Still, this assumption is based
-		// purely on expirementation, and there might be some other more robust fix.
-		try? await clock.sleep(for: .milliseconds(100))
-
 		let result = try await radixConnectMobile.handleDeepLink(url: request.absoluteString)
 		incomingMessagesSubject.send(
 			.init(


### PR DESCRIPTION
Hotfix for the issue when sometimes the Wallet would fail to validate the dApp after deepLink.


The bug, occurring after several tries

https://github.com/user-attachments/assets/7aabf843-9c71-4927-84cb-bbbe472c07b9

