### PR TITLE
[ABW-3642] Associated Resources in Approved dApps

### DIFF
--- a/RadixWallet/Clients/OnLedgerEntitiesClient/Helpers/EntityMetadata+GWMetadata.swift
+++ b/RadixWallet/Clients/OnLedgerEntitiesClient/Helpers/EntityMetadata+GWMetadata.swift
@@ -185,7 +185,7 @@ extension GatewayAPI.EntityMetadataCollection {
 	}
 
 	public var dappDefinitions: [String]? {
-		value(.dappDefinitions)?.asGlobalAddressCollection
+		value(.dappDefinitions)?.asStringCollection
 	}
 
 	public var claimedEntities: [String]? {

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Details/NonFungibleTokenDetails+View.swift
@@ -69,7 +69,7 @@ extension NonFungibleTokenDetails {
 				DetailsContainer(title: .success(viewStore.tokenDetails?.name ?? "")) {
 					store.send(.view(.closeButtonTapped))
 				} contents: {
-					VStack(spacing: .medium1) {
+					VStack(spacing: .zero) {
 						if let tokenDetails = viewStore.tokenDetails {
 							VStack(spacing: .medium3) {
 								if let keyImage = tokenDetails.keyImage {
@@ -107,7 +107,9 @@ extension NonFungibleTokenDetails {
 							}
 							.lineLimit(1)
 							.frame(maxWidth: .infinity, alignment: .leading)
+							.padding(.top, .small1)
 							.padding(.horizontal, .large2)
+							.padding(.bottom, .medium1)
 						}
 
 						VStack(spacing: .medium1) {
@@ -120,7 +122,6 @@ extension NonFungibleTokenDetails {
 						.padding(.vertical, .medium1)
 						.background(.app.gray5, ignoresSafeAreaEdges: .bottom)
 					}
-					.padding(.top, .small1)
 				}
 				.foregroundColor(.app.gray1)
 				.task { @MainActor in


### PR DESCRIPTION
Jira ticket: [ABW-3652](https://radixdlt.atlassian.net/browse/ABW-3652)

## Description
We should be showing associated tokens and NFTs for dApps, whether showing the dApp from a transaction or the list of approved dApps. It turned out that we filtered them out because the `dapp_definitions` metadata item was parsed in the wrong way, causing it to always appear to be empty. Specifically, the item is sent as a string collection, rather than a collection of `globalAddress`, which is what we expected.

There was also a slight update to the visual appearance of the NFT details screen, to make it work better when showing only a resource, without the individual token.

### Notes
Since the item `dapp_definition` _is_ being sent as a `globalAddress`, it might seem that the fix should be on the Gateway side, for consistency, but this PR will make things work as expected.

## How to test

- Approve a dApp that has associated resources, like RadQuest.
- Go to the Approved dApps list in Settings
- --> You should see the resources listed there

## Screenshot

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works


[ABW-3652]: https://radixdlt.atlassian.net/browse/ABW-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ