### PR TITLE
[ABW-3533, ABW-3541] UI adjustments - Personas List & Persona profile

### DIFF
--- a/RadixWallet/Core/DesignSystem/Components/PlainListRow.swift
+++ b/RadixWallet/Core/DesignSystem/Components/PlainListRow.swift
@@ -52,12 +52,13 @@ struct PlainListRow<Icon: View, Accessory: View>: View {
 	}
 
 	init(
+		context: PlainListRowCore.ViewState.Context = .settings,
 		title: String?,
 		subtitle: String? = nil,
 		accessory: ImageResource? = .chevronRight,
 		@ViewBuilder icon: () -> Icon
 	) where Accessory == Image {
-		self.viewState = ViewState(rowCoreViewState: .init(title: title, subtitle: subtitle), accessory: accessory, icon: icon)
+		self.viewState = ViewState(rowCoreViewState: .init(context: context, title: title, subtitle: subtitle), accessory: accessory, icon: icon)
 	}
 
 	init(
@@ -75,7 +76,7 @@ struct PlainListRow<Icon: View, Accessory: View>: View {
 			hints
 		}
 		.padding(.vertical, viewState.rowCoreViewState.verticalPadding)
-		.padding(.horizontal, .medium3)
+		.padding(.horizontal, viewState.rowCoreViewState.horizontalPadding)
 		.frame(minHeight: .plainListRowMinHeight)
 		.contentShape(Rectangle())
 	}
@@ -193,7 +194,7 @@ private extension PlainListRowCore.ViewState {
 		switch context {
 		case .toggle:
 			.secondaryHeader
-		case .settings:
+		case .settings, .dappAndPersona:
 			.body1Header
 		}
 	}
@@ -202,7 +203,7 @@ private extension PlainListRowCore.ViewState {
 		switch context {
 		case .toggle:
 			.body2Regular
-		case .settings:
+		case .settings, .dappAndPersona:
 			detail == nil ? .body1Regular : .body2Regular
 		}
 	}
@@ -211,14 +212,14 @@ private extension PlainListRowCore.ViewState {
 		switch context {
 		case .toggle:
 			.app.gray2
-		case .settings:
+		case .settings, .dappAndPersona:
 			.app.gray1
 		}
 	}
 
 	var titleLineLimit: Int? {
 		switch context {
-		case .settings:
+		case .settings, .dappAndPersona:
 			1
 		case .toggle:
 			nil
@@ -229,7 +230,7 @@ private extension PlainListRowCore.ViewState {
 		switch context {
 		case .toggle:
 			2
-		case .settings:
+		case .settings, .dappAndPersona:
 			3
 		}
 	}
@@ -240,6 +241,17 @@ private extension PlainListRowCore.ViewState {
 			.zero
 		case .settings:
 			.medium1
+		case .dappAndPersona:
+			.medium3
+		}
+	}
+
+	var horizontalPadding: CGFloat {
+		switch context {
+		case .toggle, .settings:
+			.medium3
+		case .dappAndPersona:
+			.medium1
 		}
 	}
 }
@@ -249,6 +261,7 @@ extension PlainListRowCore.ViewState {
 	enum Context {
 		case settings
 		case toggle
+		case dappAndPersona
 	}
 }
 

--- a/RadixWallet/Core/DesignSystem/EntitySecurityProblemsView.swift
+++ b/RadixWallet/Core/DesignSystem/EntitySecurityProblemsView.swift
@@ -19,7 +19,6 @@ public struct EntitySecurityProblemsView: SwiftUI.View {
 					}
 				}
 			}
-			.padding(.vertical, config.verticalPadding)
 		}
 	}
 
@@ -64,17 +63,6 @@ extension EntitySecurityProblemsView {
 			if self.problems != filtered {
 				self.problems = filtered
 			}
-		}
-	}
-}
-
-private extension EntitySecurityProblemsView.Config {
-	var verticalPadding: CGFloat {
-		switch kind {
-		case .account:
-			.zero
-		case .persona:
-			problems.isEmpty ? .zero : .small2
 		}
 	}
 }

--- a/RadixWallet/Features/DappsAndPersonas/AuthorizedDApps/AuthorizedDApps+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/AuthorizedDApps/AuthorizedDApps+View.swift
@@ -38,7 +38,7 @@ extension AuthorizedDappsFeature.View {
 							Card {
 								viewStore.send(.didSelectDapp(dApp.id))
 							} contents: {
-								PlainListRow(title: dApp.name) {
+								PlainListRow(context: .dappAndPersona, title: dApp.name) {
 									Thumbnail(.dapp, url: dApp.thumbnail)
 								}
 							}

--- a/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/PersonaDetails/PersonaDetails+View.swift
@@ -237,7 +237,7 @@ extension PersonaDetails.View {
 
 		var body: some View {
 			WithViewStore(store, observe: { $0 }) { viewStore in
-				VStack(spacing: .medium1) {
+				VStack(spacing: .medium3) {
 					Text(L10n.AuthorizedDapps.PersonaDetails.authorizedDappsHeading)
 						.textBlock
 						.flushedLeft
@@ -247,7 +247,7 @@ extension PersonaDetails.View {
 						Card {
 							viewStore.send(.dAppTapped(dApp.id))
 						} contents: {
-							PlainListRow(title: dApp.displayName) {
+							PlainListRow(context: .dappAndPersona, title: dApp.displayName) {
 								Thumbnail(.dapp, url: dApp.thumbnail)
 							}
 						}

--- a/RadixWallet/Features/DappsAndPersonas/Personas/Child/Row/Persona+View.swift
+++ b/RadixWallet/Features/DappsAndPersonas/Personas/Child/Row/Persona+View.swift
@@ -22,20 +22,21 @@ extension PersonaFeature {
 						viewStore.send(.tapped)
 					} contents: {
 						VStack(spacing: .zero) {
-							PlainListRow(title: viewStore.displayName) {
+							PlainListRow(context: .dappAndPersona, title: viewStore.displayName) {
 								Thumbnail(.persona, url: viewStore.thumbnail)
 							}
 							if showShield {
 								EntitySecurityProblemsView(config: viewStore.securityProblemsConfig) {
 									viewStore.send(.securityProblemsTapped)
 								}
-								.padding(.horizontal, .medium3)
+								.padding(.horizontal, .medium1)
+								.padding(.bottom, .small1)
 							}
 						}
 					}
 				} else {
 					Card {
-						PlainListRow(title: viewStore.displayName, accessory: nil) {
+						PlainListRow(context: .dappAndPersona, title: viewStore.displayName, accessory: nil) {
 							Thumbnail(.persona, url: viewStore.thumbnail)
 						}
 					}


### PR DESCRIPTION
Jira ticket: [ABW-3533](https://radixdlt.atlassian.net/browse/ABW-3533)
Jira ticket: [ABW-3541](https://radixdlt.atlassian.net/browse/ABW-3541)

## Description
- Updated Personas List screen
- Updated Persona Profile screen
- Added a new `dappAndPersona` context for `PlainListRow` as those cards have different padding

## Screenshot

| Screen Before | Screen After |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-01 at 13 04 54](https://github.com/user-attachments/assets/c73e11fc-8593-464f-a380-811e413da59e) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-01 at 13 02 59](https://github.com/user-attachments/assets/6bf9ee7b-9fde-4436-967f-73804cd5509e) |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-01 at 13 05 20](https://github.com/user-attachments/assets/f825dc0e-86f8-4881-b4d2-ba3451efe6ca) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-01 at 13 03 21](https://github.com/user-attachments/assets/d88ce7e9-c441-45a8-9424-0f2c5a17f88f) |

[ABW-3533]: https://radixdlt.atlassian.net/browse/ABW-3533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-3541]: https://radixdlt.atlassian.net/browse/ABW-3541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ