### PR TITLE
[ABW-3655][ABW-3656] Entry seed phrase updates

### DIFF
--- a/RadixWallet/Core/DesignSystem/Components/AppTextField.swift
+++ b/RadixWallet/Core/DesignSystem/Components/AppTextField.swift
@@ -99,7 +99,7 @@ public struct AppTextField<FocusValue: Hashable, Accessory: View, InnerAccessory
 
 	public var body: some View {
 		HStack(alignment: .textFieldAlignment, spacing: 0) {
-			VStack(alignment: .leading, spacing: .small1) {
+			VStack(alignment: .leading, spacing: Constants.appTextFieldSpacing) {
 				if primaryHeading != nil || secondaryHeading != nil {
 					HStack(spacing: 0) {
 						if let primaryHeading {
@@ -207,6 +207,10 @@ extension VerticalAlignment {
 	}
 
 	fileprivate static let textFieldAlignment = VerticalAlignment(TextFieldAlignment.self)
+}
+
+extension Constants {
+	static let appTextFieldSpacing: CGFloat = .small1
 }
 
 #if DEBUG

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
@@ -601,7 +601,7 @@ extension ImportMnemonic {
 		_ state: inout State
 	) -> Effect<Action> {
 		state.words[id: id]?.value = .complete(text: input, word: word, completion: completion)
-		return focusNext(&state, after: id)
+		return .none
 	}
 
 	private func updateWord(

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
@@ -29,11 +29,6 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 				words.append(contentsOf: (wordCount ..< Int(newWordCount.rawValue)).map {
 					.init(
 						id: $0,
-						placeholder: ImportMnemonic.placeholder(
-							index: $0,
-							wordCount: newWordCount,
-							language: language
-						),
 						isReadonlyMode: mode.readonly != nil
 					)
 				})
@@ -228,11 +223,6 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 								text: $0.element.word,
 								word: $0.element,
 								completion: .auto(match: .exact)
-							),
-							placeholder: ImportMnemonic.placeholder(
-								index: $0.offset,
-								wordCount: mnemonic.wordCount,
-								language: mnemonic.language
 							),
 							isReadonlyMode: isReadonlyMode
 						)
@@ -671,36 +661,6 @@ extension ImportMnemonic {
 			try? await clock.sleep(for: .milliseconds(75))
 			await send(.internal(.focusNext(nextID)))
 		}
-	}
-}
-
-extension ImportMnemonic {
-	static func placeholder(
-		index: Int,
-		wordCount: BIP39WordCount,
-		language: BIP39Language
-	) -> String {
-		precondition(index <= 23, "Invalid BIP39 word index, got index: \(index), exected less than 24.")
-		let word: BIP39Word = {
-			let wordList = language.wordlist() // BIP39.wordList(for: language)
-			switch language {
-			case .english:
-				let bip39Alphabet = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", /* X is missing */ "y", "z"]
-				return wordList
-					// we use `last` simply because we did not like the words "abandon baby"
-					// which we get by using `first`, too sad a combination.
-					.last(
-						where: { $0.word.hasPrefix(bip39Alphabet[index]) }
-					)!
-
-			default:
-				let scale = UInt16(89) // 2048 / 23
-				let indexScaled = U11(inner: scale * UInt16(index))
-				return wordList.first(where: { $0.index == indexScaled })!
-			}
-
-		}()
-		return word.word
 	}
 }
 

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic.swift
@@ -391,6 +391,10 @@ public struct ImportMnemonic: Sendable, FeatureReducer {
 				&state
 			)
 
+		case let .word(id, child: .delegate(.didSubmit)):
+			state.words[id: id]?.resignFocus()
+			return delayedEffect(delay: .milliseconds(75), for: .internal(.focusNext(id + 1)))
+
 		default:
 			return .none
 		}
@@ -652,15 +656,12 @@ extension ImportMnemonic {
 	private func focusNext(_ state: inout State) -> Effect<Action> {
 		if let current = state.idOfWordWithTextFieldFocus {
 			state.words[id: current]?.resignFocus()
+			return delayedEffect(delay: .milliseconds(75), for: .internal(.focusNext(current + 1)))
 		}
-		guard let nextID = state.words.first(where: { !$0.isComplete })?.id else {
+		guard let firstIncomplete = state.words.first(where: { !$0.isComplete })?.id else {
 			return .none
 		}
-
-		return .run { send in
-			try? await clock.sleep(for: .milliseconds(75))
-			await send(.internal(.focusNext(nextID)))
-		}
+		return delayedEffect(delay: .milliseconds(75), for: .internal(.focusNext(firstIncomplete)))
 	}
 }
 

--- a/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord+View.swift
@@ -78,15 +78,14 @@ extension ImportMnemonicWord {
 							set: { viewStore.send(.wordChanged(input: $0.lowercased().trimmingWhitespacesAndNewlines())) }
 						),
 						hint: viewStore.hint,
-						// FIXME: Bring back autofocus
-						//	focus: .on(
-						//		.textField,
-						//		binding: viewStore.binding(
-						//			get: \.focusedField,
-						//			send: { .textFieldFocused($0) }
-						//		),
-						//		to: $focusedField
-						//	),
+						focus: .on(
+							State.Field.textField,
+							binding: viewStore.binding(
+								get: \.focusedField,
+								send: ViewAction.focusChanged
+							),
+							to: $focusedField
+						),
 						showClearButton: viewStore.showClearButton,
 						innerAccessory: {
 							if viewStore.displayValidAccessory {
@@ -123,6 +122,9 @@ extension ImportMnemonicWord {
 								}
 							}
 						}
+					}
+					.onSubmit {
+						viewStore.send(.onSubmit)
 					}
 
 					if viewStore.hint == nil {

--- a/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord+View.swift
@@ -7,7 +7,6 @@ extension ImportMnemonicWord.State {
 		.init(
 			isReadonlyMode: isReadonlyMode,
 			index: id,
-			placeholder: placeholder,
 			displayText: value.text,
 			autocompletionCandidates: autocompletionCandidates,
 			focusedField: focusedField,
@@ -37,7 +36,6 @@ extension ImportMnemonicWord {
 	public struct ViewState: Equatable {
 		let isReadonlyMode: Bool
 		let index: Int
-		let placeholder: String
 		let displayText: String
 		let autocompletionCandidates: ImportMnemonicWord.State.AutocompletionCandidates?
 		let focusedField: State.Field?
@@ -74,7 +72,7 @@ extension ImportMnemonicWord {
 				VStack(spacing: .small3) {
 					AppTextField(
 						primaryHeading: .init(text: L10n.ImportMnemonic.wordHeading(viewStore.index + 1), isProminent: true),
-						placeholder: viewStore.placeholder,
+						placeholder: "",
 						text: .init(
 							get: { viewStore.displayText },
 							set: { viewStore.send(.wordChanged(input: $0.lowercased().trimmingWhitespacesAndNewlines())) }

--- a/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord+View.swift
@@ -69,7 +69,7 @@ extension ImportMnemonicWord {
 
 		public var body: some SwiftUI.View {
 			WithViewStore(store, observe: \.viewState, send: { .view($0) }) { viewStore in
-				VStack(spacing: .small3) {
+				VStack(spacing: Constants.appTextFieldSpacing) {
 					AppTextField(
 						primaryHeading: .init(text: L10n.ImportMnemonic.wordHeading(viewStore.index + 1), isProminent: true),
 						placeholder: "",

--- a/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord+View.swift
@@ -123,6 +123,7 @@ extension ImportMnemonicWord {
 							}
 						}
 					}
+					.submitLabel(.next)
 					.onSubmit {
 						viewStore.send(.onSubmit)
 					}

--- a/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord.swift
@@ -107,13 +107,15 @@ public struct ImportMnemonicWord: Sendable, FeatureReducer {
 	public enum ViewAction: Sendable, Hashable {
 		case wordChanged(input: String)
 		case userSelectedCandidate(BIP39Word)
-		case textFieldFocused(State.Field?)
+		case focusChanged(State.Field?)
+		case onSubmit
 	}
 
 	public enum DelegateAction: Sendable, Hashable {
 		case lookupWord(input: String)
 		case lostFocus(displayText: String)
 		case userSelectedCandidate(BIP39Word, fromPartial: String)
+		case didSubmit
 	}
 
 	public init() {}
@@ -155,9 +157,12 @@ public struct ImportMnemonicWord: Sendable, FeatureReducer {
 				fromPartial: state.value.text
 			)))
 
-		case let .textFieldFocused(field):
+		case let .focusChanged(field):
 			state.focusedField = field
-			return field == nil ? .send(.delegate(.lostFocus(displayText: state.value.text))) : .none
+			return .none
+
+		case .onSubmit:
+			return .send(.delegate(.didSubmit))
 		}
 	}
 }

--- a/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportWord/ImportMnemonicWord.swift
@@ -69,7 +69,6 @@ public struct ImportMnemonicWord: Sendable, FeatureReducer {
 		public typealias ID = Int
 		public let id: ID
 		public var value: WordValue
-		public let placeholder: String
 		public let isReadonlyMode: Bool
 
 		public var autocompletionCandidates: AutocompletionCandidates? = nil
@@ -78,12 +77,10 @@ public struct ImportMnemonicWord: Sendable, FeatureReducer {
 		public init(
 			id: ID,
 			value: WordValue = .incomplete(text: "", hasFailedValidation: false),
-			placeholder: String,
 			isReadonlyMode: Bool
 		) {
 			self.id = id
 			self.value = value
-			self.placeholder = placeholder
 			self.isReadonlyMode = isReadonlyMode
 		}
 


### PR DESCRIPTION
Jira ticket: [ABW-3655](https://radixdlt.atlassian.net/browse/ABW-3655)
Jira ticket: [ABW-3656](https://radixdlt.atlassian.net/browse/ABW-3656)

Depends on: https://github.com/radixdlt/babylon-wallet-ios/pull/1255

## Description
This PR:
- Removes placeholder words from Entry Seed Phrase view
- Allows moving to next seed phrase word when tapping on return key
- Fixes UI issue where word would incorrectly align when showing an error.

## Video
https://github.com/user-attachments/assets/8ddd5119-8a8d-4aec-9191-354ebe1814b5



[ABW-3655]: https://radixdlt.atlassian.net/browse/ABW-3655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-3656]: https://radixdlt.atlassian.net/browse/ABW-3656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ