### PR TITLE
[ABW-3458] NFT page request updates

### DIFF
--- a/RadixWallet/Clients/OnLedgerEntitiesClient/OnLedgerEntitiesClient+Live.swift
+++ b/RadixWallet/Clients/OnLedgerEntitiesClient/OnLedgerEntitiesClient+Live.swift
@@ -2,7 +2,7 @@ import Sargon
 
 // MARK: - OnLedgerEntitiesClient + DependencyKey
 extension OnLedgerEntitiesClient: DependencyKey {
-	public static let maximumNFTIDChunkSize = 29
+	public static let maximumNFTIDChunkSize = 100
 
 	enum Error: Swift.Error {
 		case emptyResponse

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DevAccountPreferences+Reducer.swift
@@ -190,8 +190,8 @@ public struct DevAccountPreferences: Sendable, FeatureReducer {
 
 				let manifest = TransactionManifest.createMultipleNonFungibleTokens(
 					addressOfOwner: accountAddress,
-					collectionCount: 5,
-					nftsPerCollection: 10
+					collectionCount: 1,
+					nftsPerCollection: 120
 				)
 
 				await send(.internal(.reviewTransaction(manifest)))

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
@@ -83,7 +83,6 @@ extension NonFungibleAssetList {
 				if state.isExpanded {
 					state.lastLoadedTokenIndex = 0
 					setTokensPlaceholders(&state)
-					print("M- is expanded")
 					return loadResources(&state, previousTokenIndex: 0)
 				}
 
@@ -91,9 +90,8 @@ extension NonFungibleAssetList {
 
 			case let .onTokenDidAppear(index):
 				state.lastVisibleRowIndex = index
-				/// Load next page if not currently loading and current page was not loaded.
-				if state.isLoadingResources == false, index > state.lastLoadedTokenIndex, state.nextPageCursor != nil {
-					print("M- on token did appear, row: \(index), last: \(state.lastLoadedTokenIndex)")
+				/// Load next page if not currently loading, there are more pages to load and current page was not loaded.
+				if state.isLoadingResources == false, state.nextPageCursor != nil, index > state.lastLoadedTokenIndex {
 					return loadResources(&state, previousTokenIndex: state.lastLoadedTokenIndex)
 				}
 				return .none
@@ -105,7 +103,6 @@ extension NonFungibleAssetList {
 			case let .tokensLoaded(result):
 				switch result {
 				case let .success(tokensPage):
-					print("M- TokensPage: \(tokensPage.previousTokenIndex)")
 					state.nextPageCursor = tokensPage.nextPageCursor
 					let success = tokensPage.tokens.map(Loadable.success)
 					state.tokens[tokensPage.previousTokenIndex ..< tokensPage.previousTokenIndex + success.count] = success[0 ..< success.count]
@@ -127,14 +124,12 @@ extension NonFungibleAssetList {
 			case .refreshResources:
 				state.nextPageCursor = nil
 				setTokensPlaceholders(&state)
-				print("M- refresh resources")
 				return loadResources(&state, previousTokenIndex: 0)
 			}
 		}
 
 		private func loadResources(_ state: inout State, previousTokenIndex: Int) -> Effect<Action> {
 			let cursor = state.nextPageCursor
-			print("M- Will load previous \(previousTokenIndex), cursor \(cursor ?? "nil"), isLoading: \(state.isLoadingResources)")
 			state.isLoadingResources = true
 			return .run { [resource = state.resource, accountAddress = state.accountAddress] send in
 				let result = await TaskResult {

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
@@ -106,7 +106,7 @@ extension NonFungibleAssetList {
 					state.nextPageCursor = tokensPage.nextPageCursor
 					let success = tokensPage.tokens.map(Loadable.success)
 					state.tokens[tokensPage.previousTokenIndex ..< tokensPage.previousTokenIndex + success.count] = success[0 ..< success.count]
-					state.lastLoadedTokenIndex = max(state.lastLoadedTokenIndex, tokensPage.previousTokenIndex + success.count)
+					state.lastLoadedTokenIndex = tokensPage.previousTokenIndex + success.count
 
 					/// If user did quick scroll over the currently loading page, proactively load the next page.
 					/// If there are 5 pages in total, and user did scroll fast to last one, this will load all pages in chain, one after another.

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
@@ -82,6 +82,7 @@ extension NonFungibleAssetList {
 				state.isExpanded.toggle()
 				if state.isExpanded {
 					setTokensPlaceholders(&state)
+					print("M- is expanded")
 					return loadResources(&state, pageIndex: 0)
 				}
 
@@ -92,6 +93,7 @@ extension NonFungibleAssetList {
 				let rowPageIndex = index / State.pageSize
 				/// Load next page if not currently loading and current page was not loaded.
 				if state.isLoadingResources == false, rowPageIndex > state.lastLoadedPageIndex {
+					print("M- on token did appear, row: \(index), pageIndex: \(rowPageIndex), last: \(state.lastLoadedPageIndex)")
 					return loadResources(&state, pageIndex: state.lastLoadedPageIndex + 1)
 				}
 				return .none
@@ -110,6 +112,7 @@ extension NonFungibleAssetList {
 					/// If user did quick scroll over the currently loading page, proactively load the next page.
 					/// If there are 5 pages in total, and user did scroll fast to last one, this will load all pages in chain, one after another.
 					if state.lastVisibleRowIndex / State.pageSize > tokensPage.pageIndex {
+						print("M- quick scroll")
 						return loadResources(&state, pageIndex: tokensPage.pageIndex + 1)
 					}
 
@@ -123,13 +126,15 @@ extension NonFungibleAssetList {
 			case .refreshResources:
 				state.nextPageCursor = nil
 				setTokensPlaceholders(&state)
+				print("M- refresh resources")
 				return loadResources(&state, pageIndex: 0)
 			}
 		}
 
 		private func loadResources(_ state: inout State, pageIndex: Int) -> Effect<Action> {
-			state.isLoadingResources = true
 			let cursor = state.nextPageCursor
+			print("M- Will load page \(pageIndex), cursor \(cursor ?? "nil"), isLoading: \(state.isLoadingResources)")
+			state.isLoadingResources = true
 			return .run { [resource = state.resource, accountAddress = state.accountAddress] send in
 				let result = await TaskResult {
 					let data = try await onLedgerEntitiesClient.getAccountOwnedNonFungibleTokenData(.init(accountAddress: accountAddress, resource: resource, mode: .loadPage(pageCursor: cursor)))

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
@@ -113,10 +113,9 @@ extension NonFungibleAssetList {
 
 					/// If user did quick scroll over the currently loading page, proactively load the next page.
 					/// If there are 5 pages in total, and user did scroll fast to last one, this will load all pages in chain, one after another.
-//					if state.lastVisibleRowIndex / State.pageSize > tokensPage.pageIndex {
-//						print("M- quick scroll")
-//						return loadResources(&state, pageIndex: tokensPage.pageIndex + 1)
-//					}
+					if state.lastVisibleRowIndex - State.pageSize + 2 > state.lastLoadedTokenIndex {
+						return loadResources(&state, previousTokenIndex: state.lastLoadedTokenIndex)
+					}
 
 					state.isLoadingResources = false
 				case let .failure(err):

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungbileAssetRow+Reducer.swift
@@ -123,6 +123,7 @@ extension NonFungibleAssetList {
 
 			case .refreshResources:
 				state.nextPageCursor = nil
+				state.lastLoadedTokenIndex = 0
 				setTokensPlaceholders(&state)
 				return loadResources(&state, previousTokenIndex: 0)
 			}

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungibleAssetRow+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungibleAssetRow+View.swift
@@ -29,7 +29,7 @@ extension NonFungibleAssetList.Row.View {
 				if viewStore.isExpanded {
 					ForEach(
 						Array(
-							viewStore.tokens.flatMap(identity).enumerated()
+							viewStore.tokens.enumerated()
 						),
 						id: \.offset
 					) { index, item in
@@ -39,6 +39,8 @@ extension NonFungibleAssetList.Row.View {
 								viewStore.send(.onTokenDidAppear(index: index))
 							}
 					}
+
+					Text("Count displayed: \(viewStore.tokens.count)")
 				}
 			}
 			.listSectionSeparator(.hidden)

--- a/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungibleAssetRow+View.swift
+++ b/RadixWallet/Features/AssetsFeature/Components/NonFungibleAssetList/Components/Row/NonFungibleAssetRow+View.swift
@@ -39,8 +39,6 @@ extension NonFungibleAssetList.Row.View {
 								viewStore.send(.onTokenDidAppear(index: index))
 							}
 					}
-
-					Text("Count displayed: \(viewStore.tokens.count)")
 				}
 			}
 			.listSectionSeparator(.hidden)


### PR DESCRIPTION
Jira ticket: [ABW-3458](https://radixdlt.atlassian.net/browse/ABW-3458)

## Description
This PR updates paging mechanism for NFTs. Our current logic was based on the assumptions that the GW would return pages with the max amount of items, and this could change in the future. In other words, if there are 100 elements to load and we were requesting pages of 29 elements, the app assumed the GW would return 4 pages with `[29, 29, 29, 13]` elements each. However, GW will change and the amount of pages/elements per page won't be fixed.

## How to test
Play with different NFT collections and sizes to verify the loading happens correctly every time.


[ABW-3458]: https://radixdlt.atlassian.net/browse/ABW-3458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ