### PR TITLE
[ABW-2072] Transfer flow choose account adjustment

### DIFF
--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+Reducer.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 // MARK: - ChooseReceivingAccount
 public struct ChooseReceivingAccount: Sendable, FeatureReducer {
+	@ObservableState
 	public struct State: Sendable, Hashable {
 		var chooseAccounts: ChooseAccounts.State
 		var manualAccountAddress: String = "" {
@@ -50,7 +51,7 @@ public struct ChooseReceivingAccount: Sendable, FeatureReducer {
 
 		let networkID: NetworkID
 
-		@PresentationState
+		@Presents
 		var destination: Destination.State? = nil
 
 		public init(networkID: NetworkID, chooseAccounts: ChooseAccounts.State) {
@@ -59,6 +60,7 @@ public struct ChooseReceivingAccount: Sendable, FeatureReducer {
 		}
 	}
 
+	@CasePathable
 	public enum ViewAction: Sendable, Equatable {
 		case scanQRCode
 		case closeButtonTapped

--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+Reducer.swift
@@ -18,38 +18,6 @@ public struct ChooseReceivingAccount: Sendable, FeatureReducer {
 
 		var manualAccountAddressFocused: Bool = false
 
-		public enum AddressValidation: Sendable, Hashable {
-			case valid(AccountAddress)
-			case wrongNetwork(AccountAddress, incorrectNetwork: UInt8)
-			case invalid
-		}
-
-		var validatedManualAccountAddress: AddressValidation {
-			guard !manualAccountAddress.isEmpty,
-			      !chooseAccounts.filteredAccounts.contains(where: { $0.address == manualAccountAddress })
-			else {
-				return .invalid
-			}
-			guard
-				let addressOnSomeNetwork = try? AccountAddress(validatingAddress: manualAccountAddress)
-			else {
-				return .invalid
-			}
-			let networkOfAddress = addressOnSomeNetwork.networkID
-			guard networkOfAddress == networkID else {
-				loggerGlobal.warning("Manually inputted address is valid, but is on the WRONG network, inputted: \(networkOfAddress), but current network is: \(networkID.rawValue)")
-				return .wrongNetwork(addressOnSomeNetwork, incorrectNetwork: networkOfAddress.rawValue)
-			}
-			return .valid(addressOnSomeNetwork)
-		}
-
-		var validatedAccountAddress: AccountAddress? {
-			guard case let .valid(address) = validatedManualAccountAddress else {
-				return nil
-			}
-			return address
-		}
-
 		let networkID: NetworkID
 
 		@Presents

--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+Reducer.swift
@@ -3,6 +3,7 @@ import Sargon
 import SwiftUI
 
 // MARK: - ChooseReceivingAccount
+@Reducer
 public struct ChooseReceivingAccount: Sendable, FeatureReducer {
 	@ObservableState
 	public struct State: Sendable, Hashable {
@@ -59,6 +60,8 @@ public struct ChooseReceivingAccount: Sendable, FeatureReducer {
 			self.chooseAccounts = chooseAccounts
 		}
 	}
+
+	public typealias Action = FeatureAction<Self>
 
 	@CasePathable
 	public enum ViewAction: Sendable, Equatable {

--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
@@ -62,9 +62,11 @@ extension ChooseReceivingAccount.View {
 
 						addressField(viewStore)
 
-						Divider()
+						if !viewStore.chooseAccounts.availableAccounts.isEmpty {
+							Divider()
 
-						Text(L10n.AssetTransfer.ChooseReceivingAccount.chooseOwnAccount)
+							Text(L10n.AssetTransfer.ChooseReceivingAccount.chooseOwnAccount)
+						}
 
 						ChooseAccounts.View(
 							store: store.scope(

--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
@@ -124,14 +124,9 @@ private extension StoreOf<ChooseReceivingAccount> {
 private extension View {
 	func destinations(with store: StoreOf<ChooseReceivingAccount>) -> some View {
 		let destinationStore = store.destination
-		return navigationDestination(
-			store: destinationStore,
-			state: /ChooseReceivingAccount.Destination.State.scanAccountAddress,
-			action: ChooseReceivingAccount.Destination.Action.scanAccountAddress,
-			destination: {
-				ScanQRCoordinator.View(store: $0)
-					.radixToolbar(title: L10n.AssetTransfer.ChooseReceivingAccount.scanQRNavigationTitle, alwaysVisible: false)
-			}
-		)
+		return navigationDestination(store: destinationStore.scope(state: \.scanAccountAddress, action: \.scanAccountAddress)) {
+			ScanQRCoordinator.View(store: $0)
+				.radixToolbar(title: L10n.AssetTransfer.ChooseReceivingAccount.scanQRNavigationTitle, alwaysVisible: false)
+		}
 	}
 }

--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseAccount/ChooseReceivingAccount+View.swift
@@ -1,44 +1,32 @@
 import ComposableArchitecture
 import SwiftUI
 
-// MARK: - ChooseAccount.View
-extension ChooseReceivingAccount {
-	public struct ViewState: Equatable {
-		var manualAccountAddress: String
-		var manualAccountAddressFocused: Bool
-		var chooseAccounts: ChooseAccounts.State
-		var canSelectOwnAccount: Bool
-		var validateAccountAddress: AccountAddress?
-		var manualAddressHint: Hint?
-
-		init(state: ChooseReceivingAccount.State) {
-			manualAccountAddress = state.manualAccountAddress
-			chooseAccounts = state.chooseAccounts
-			manualAccountAddressFocused = state.manualAccountAddressFocused
-			validateAccountAddress = state.validatedAccountAddress
-
-			manualAddressHint = {
-				guard !state.manualAccountAddressFocused, !state.manualAccountAddress.isEmpty else {
-					return .none
-				}
-
-				switch state.validateManualAccountAddress() {
-				case .invalid:
-					return .error(L10n.AssetTransfer.ChooseReceivingAccount.invalidAddressError)
-				case .wrongNetwork:
-					return .error(L10n.AssetTransfer.Error.wrongNetwork)
-				case let .valid(validAddress):
-					if state.chooseAccounts.filteredAccounts.contains(where: { $0 == validAddress }) {
-						return .error(L10n.AssetTransfer.ChooseReceivingAccount.alreadyAddedError)
-					}
-					return .none
-				}
-
-			}()
-			canSelectOwnAccount = manualAccountAddress.isEmpty
-		}
+extension ChooseReceivingAccount.State {
+	var canSelectOwnAccount: Bool {
+		manualAccountAddress.isEmpty
 	}
 
+	var manualAddressHint: Hint? {
+		guard !manualAccountAddressFocused, !manualAccountAddress.isEmpty else {
+			return .none
+		}
+
+		switch validatedManualAccountAddress {
+		case .invalid:
+			return .error(L10n.AssetTransfer.ChooseReceivingAccount.invalidAddressError)
+		case .wrongNetwork:
+			return .error(L10n.AssetTransfer.Error.wrongNetwork)
+		case let .valid(validAddress):
+			if chooseAccounts.filteredAccounts.contains(where: { $0 == validAddress }) {
+				return .error(L10n.AssetTransfer.ChooseReceivingAccount.alreadyAddedError)
+			}
+			return .none
+		}
+	}
+}
+
+// MARK: - ChooseReceivingAccount.View
+extension ChooseReceivingAccount {
 	@MainActor
 	public struct View: SwiftUI.View {
 		private let store: StoreOf<ChooseReceivingAccount>
@@ -47,97 +35,87 @@ extension ChooseReceivingAccount {
 		public init(store: StoreOf<ChooseReceivingAccount>) {
 			self.store = store
 		}
-	}
-}
 
-extension ChooseReceivingAccount.View {
-	public var body: some View {
-		NavigationStack {
-			WithViewStore(store, observe: ChooseReceivingAccount.ViewState.init(state:), send: { .view($0) }) { viewStore in
-				ScrollView {
-					VStack(spacing: .medium2) {
-						Text(L10n.AssetTransfer.ChooseReceivingAccount.enterManually)
-							.textStyle(.body1Regular)
-							.foregroundColor(.app.gray1)
+		public var body: some SwiftUI.View {
+			NavigationStack {
+				WithViewStore(store, observe: { $0 }) { viewStore in
+					ScrollView {
+						VStack(spacing: .medium2) {
+							Text(L10n.AssetTransfer.ChooseReceivingAccount.enterManually)
+								.textStyle(.body1Regular)
+								.foregroundColor(.app.gray1)
 
-						addressField(viewStore)
+							addressField(viewStore)
 
-						if !viewStore.chooseAccounts.availableAccounts.isEmpty {
-							Divider()
+							if !viewStore.chooseAccounts.availableAccounts.isEmpty {
+								Divider()
 
-							Text(L10n.AssetTransfer.ChooseReceivingAccount.chooseOwnAccount)
-						}
+								Text(L10n.AssetTransfer.ChooseReceivingAccount.chooseOwnAccount)
+							}
 
-						ChooseAccounts.View(
-							store: store.scope(
-								state: \.chooseAccounts,
-								action: { .child(.chooseAccounts($0)) }
+							ChooseAccounts.View(
+								store: store.scope(state: \.chooseAccounts, action: \.child.chooseAccounts)
 							)
-						)
-						.opacity(viewStore.canSelectOwnAccount ? 1.0 : 0.6)
-						.disabled(!viewStore.canSelectOwnAccount)
-					}
-					.padding(.medium3)
-				}
-				.destinations(with: store)
-				.footer { chooseButton(viewStore) }
-				.radixToolbar(title: L10n.AssetTransfer.ChooseReceivingAccount.navigationTitle)
-				.toolbar {
-					ToolbarItem(placement: .navigationBarLeading) {
-						CloseButton {
-							store.send(.view(.closeButtonTapped))
+							.opacity(viewStore.canSelectOwnAccount ? 1.0 : 0.6)
+							.disabled(!viewStore.canSelectOwnAccount)
 						}
+						.padding(.medium3)
+					}
+					.destinations(with: store)
+					.footer { chooseButton(viewStore) }
+					.radixToolbar(title: L10n.AssetTransfer.ChooseReceivingAccount.navigationTitle) {
+						viewStore.send(.view(.closeButtonTapped))
 					}
 				}
 			}
 		}
-	}
 
-	private func addressField(_ viewStore: ViewStoreOf<ChooseReceivingAccount>) -> some View {
-		AppTextField(
-			placeholder: L10n.AssetTransfer.ChooseReceivingAccount.addressFieldPlaceholder,
-			text: viewStore.binding(
-				get: \.manualAccountAddress,
-				send: { .manualAccountAddressChanged($0) }
-			),
-			hint: viewStore.manualAddressHint,
-			focus: .on(
-				true,
-				binding: viewStore.binding(
-					get: \.manualAccountAddressFocused,
-					send: { .focusChanged($0) }
+		private func addressField(_ viewStore: ViewStore<ChooseReceivingAccount.State, ChooseReceivingAccount.Action>) -> some SwiftUI.View {
+			AppTextField(
+				placeholder: L10n.AssetTransfer.ChooseReceivingAccount.addressFieldPlaceholder,
+				text: viewStore.binding(
+					get: \.manualAccountAddress,
+					send: { .view(.manualAccountAddressChanged($0)) }
 				),
-				to: $focusedField
-			),
-			showClearButton: true,
-			innerAccessory: {
-				Button {
-					viewStore.send(.scanQRCode)
-				} label: {
-					Image(asset: AssetResource.qrCodeScanner)
+				hint: viewStore.manualAddressHint,
+				focus: .on(
+					true,
+					binding: viewStore.binding(
+						get: \.manualAccountAddressFocused,
+						send: { .view(.focusChanged($0)) }
+					),
+					to: $focusedField
+				),
+				showClearButton: true,
+				innerAccessory: {
+					Button {
+						viewStore.send(.view(.scanQRCode))
+					} label: {
+						Image(asset: AssetResource.qrCodeScanner)
+					}
 				}
-			}
-		)
-		.autocorrectionDisabled()
-		.keyboardType(.alphabet)
-	}
+			)
+			.autocorrectionDisabled()
+			.keyboardType(.alphabet)
+		}
 
-	private func chooseButton(_ viewStore: ViewStoreOf<ChooseReceivingAccount>) -> some View {
-		WithControlRequirements(
-			viewStore.chooseAccounts.selectedAccounts?.first?.account,
-			or: viewStore.validateAccountAddress,
-			forAction: { result in
-				let recipient: AccountOrAddressOf = switch result {
-				case let .left(account): .profileAccount(value: account)
-				case let .right(address): .addressOfExternalAccount(value: address)
+		private func chooseButton(_ viewStore: ViewStore<ChooseReceivingAccount.State, ChooseReceivingAccount.Action>) -> some SwiftUI.View {
+			WithControlRequirements(
+				viewStore.chooseAccounts.selectedAccounts?.first?.account,
+				or: viewStore.validatedAccountAddress,
+				forAction: { result in
+					let recipient: AccountOrAddressOf = switch result {
+					case let .left(account): .profileAccount(value: account)
+					case let .right(address): .addressOfExternalAccount(value: address)
+					}
+					viewStore.send(.view(.chooseButtonTapped(recipient)))
+				},
+				control: { action in
+					Button(L10n.Common.choose, action: action)
+						.buttonStyle(.primaryRectangular)
 				}
-				viewStore.send(.chooseButtonTapped(recipient))
-			},
-			control: { action in
-				Button(L10n.Common.choose, action: action)
-					.buttonStyle(.primaryRectangular)
-			}
-		)
+			)
+		}
 	}
 }
 


### PR DESCRIPTION
Jira ticket: [ABW-2072](https://radixdlt.atlassian.net/browse/ABW-2072)

## Description
- Hid the "Or: Choose one of your own Accounts" label if there are no more available accounts
- Updated `ChooseReceivingAccount` to use `ObservableState`

## Screenshot

| Screen 1 Before | Screen 1 After |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-05 at 10 05 45](https://github.com/user-attachments/assets/267e1858-37fd-402b-971a-18d3ea8e5a7f)| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-05 at 10 02 09](https://github.com/user-attachments/assets/5401d45c-59a6-4b97-8aef-b710184d7d83) |


[ABW-2072]: https://radixdlt.atlassian.net/browse/ABW-2072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ