### PR TITLE
[ABW-3062] Display nil fiat values without fractional digits

### DIFF
--- a/RadixWallet/Core/SharedModels/Assets/FiatWorth.swift
+++ b/RadixWallet/Core/SharedModels/Assets/FiatWorth.swift
@@ -99,16 +99,18 @@ extension FiatWorth {
 	private static let hiddenValue = "• • • •"
 	private static let unknownValue = "—"
 
-	func currencyFormatted(applyCustomFont: Bool = false) -> AttributedString {
+	private static let currencyFormatter: NumberFormatter = {
 		let formatter = NumberFormatter()
 		formatter.numberStyle = .currency
-		formatter.currencyCode = currency.currencyCode
+		return formatter
+	}()
 
+	func currencyFormatted(applyCustomFont: Bool = false) -> AttributedString {
 		let value = worth.value ?? .zero // Zero for the unknown case, just to do to the base formatting
 
-		if value == .zero {
-			formatter.maximumFractionDigits = 0
-		}
+		let formatter = Self.currencyFormatter
+		formatter.currencyCode = currency.currencyCode
+		formatter.maximumFractionDigits = value == .zero ? 0 : 2
 
 		let formattedValue = {
 			let double = value.asDouble

--- a/RadixWallet/Core/SharedModels/Assets/FiatWorth.swift
+++ b/RadixWallet/Core/SharedModels/Assets/FiatWorth.swift
@@ -106,6 +106,10 @@ extension FiatWorth {
 
 		let value = worth.value ?? .zero // Zero for the unknown case, just to do to the base formatting
 
+		if value == .zero {
+			formatter.maximumFractionDigits = 0
+		}
+
 		let formattedValue = {
 			let double = value.asDouble
 			guard let value = formatter.string(for: double) else {


### PR DESCRIPTION
Jira ticket: [ABW-3062](https://radixdlt.atlassian.net/browse/ABW-3062)

## Description
Display nil fiat values without fractional digits

## Screenshot

| Screen 1 Before | Screen 1 After |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-05 at 10 59 39](https://github.com/user-attachments/assets/4e14b977-2587-4112-b34d-4fa2781d8582)| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-05 at 10 57 59](https://github.com/user-attachments/assets/b06f89e7-e322-45cf-931c-f1a7de86441b) |


[ABW-3062]: https://radixdlt.atlassian.net/browse/ABW-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ