### PR TITLE
[ABW-3667] dApp interaction go back crash

### DIFF
--- a/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Coordinator/DappInteractionFlow.swift
@@ -785,7 +785,7 @@ extension DappInteractionFlow {
 
 	func goBackEffect(for state: inout State) -> Effect<Action> {
 		state.responseItems.removeLast()
-		state.path.removeLast()
+		_ = state.path.popLast()
 		return .none
 	}
 


### PR DESCRIPTION
Jira ticket: [ABW-3667](https://radixdlt.atlassian.net/browse/ABW-3667)

## Description
I attempted to reproduce this crash but was unsuccessful. According to the logs, the crash occurs when the back button is tapped on the `DappInteractionFlow` and the code tries to remove the last element from `state.path`, which is unexpectedly empty.

This issue has only occurred once for a single user, making it difficult to reproduce. To prevent this crash, I replaced the `removeLast()` method with `popLast()`, as `popLast()` can safely handle an empty collection.

[ABW-3667]: https://radixdlt.atlassian.net/browse/ABW-3667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ