### PR TITLE
[ABW-3676] Third party deposits text fix

### DIFF
--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+Reducer.swift
@@ -29,6 +29,10 @@ public struct ResourcesList: FeatureReducer, Sendable {
 
 	public struct State: Hashable, Sendable {
 		let canModify: Bool
+		var mode: ResourcesListMode
+		var thirdPartyDeposits: ThirdPartyDeposits
+		let networkID: NetworkID
+		var loadedResources: [ResourceViewState] = []
 
 		var allDepositorAddresses: OrderedSet<ResourceViewState.Address> {
 			switch mode {
@@ -38,24 +42,6 @@ public struct ResourcesList: FeatureReducer, Sendable {
 				OrderedSet(thirdPartyDeposits.depositorsAllowSet().map { .allowedDepositor($0) })
 			}
 		}
-
-		var resourcesForDisplay: [ResourceViewState] {
-			switch mode {
-			case let .allowDenyAssets(exception):
-				let addresses: [ResourceViewState.Address] = thirdPartyDeposits.assetsExceptionSet()
-					.filter { $0.exceptionRule == exception }
-					.map { .assetException($0) }
-
-				return loadedResources.filter { addresses.contains($0.address) }
-			case .allowDepositors:
-				return loadedResources
-			}
-		}
-
-		var mode: ResourcesListMode
-		var thirdPartyDeposits: ThirdPartyDeposits
-		let networkID: NetworkID
-		var loadedResources: [ResourceViewState] = []
 
 		@PresentationState
 		var destination: Destination.State? = nil
@@ -112,7 +98,7 @@ public struct ResourcesList: FeatureReducer, Sendable {
 
 	public var body: some ReducerOf<Self> {
 		Reduce(core)
-			.ifLet(destinationPath, action: /Action.destination) {
+			.ifLet(destinationPath, action: \.destination) {
 				Destination()
 			}
 	}

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+View.swift
@@ -10,19 +10,23 @@ extension ResourcesList.State {
 			canModify: canModify,
 			resources: .init(uncheckedUniqueElements: resourcesForDisplay),
 			info: {
+				guard canModify else {
+					return L10n.AccountSettings.SpecificAssetsDeposits.modificationDisabledForRecoveredAccount
+				}
+
 				switch mode {
 				case .allowDenyAssets(.allow) where resourcesForDisplay.isEmpty:
-					L10n.AccountSettings.SpecificAssetsDeposits.emptyAllowAll
+					return L10n.AccountSettings.SpecificAssetsDeposits.emptyAllowAll
 				case .allowDenyAssets(.allow):
-					L10n.AccountSettings.SpecificAssetsDeposits.allowInfo
+					return L10n.AccountSettings.SpecificAssetsDeposits.allowInfo
 				case .allowDenyAssets(.deny) where resourcesForDisplay.isEmpty:
-					L10n.AccountSettings.SpecificAssetsDeposits.emptyDenyAll
+					return L10n.AccountSettings.SpecificAssetsDeposits.emptyDenyAll
 				case .allowDenyAssets(.deny):
-					L10n.AccountSettings.SpecificAssetsDeposits.denyInfo
+					return L10n.AccountSettings.SpecificAssetsDeposits.denyInfo
 				case .allowDepositors where resourcesForDisplay.isEmpty:
-					L10n.AccountSettings.SpecificAssetsDeposits.allowDepositorsNoResources
+					return L10n.AccountSettings.SpecificAssetsDeposits.allowDepositorsNoResources
 				case .allowDepositors:
-					L10n.AccountSettings.SpecificAssetsDeposits.allowDepositors
+					return L10n.AccountSettings.SpecificAssetsDeposits.allowDepositors
 				}
 			}(),
 			mode: mode
@@ -97,13 +101,6 @@ extension ResourcesList.View {
 				.textStyle(.body1HighImportance)
 				.foregroundColor(.app.gray2)
 				.multilineTextAlignment(.center)
-
-			if !viewStore.canModify {
-				Text(L10n.AccountSettings.SpecificAssetsDeposits.modificationDisabledForRecoveredAccount)
-					.textStyle(.body1HighImportance)
-					.foregroundColor(.app.gray2)
-					.multilineTextAlignment(.center)
-			}
 		}
 		.padding(.horizontal, .medium3)
 	}


### PR DESCRIPTION
Jira ticket: [ABW-3676](https://radixdlt.atlassian.net/browse/ABW-3676)

## Description
- Fixed the text at the top of the screen for the "Allow/Deny Specific Assets" and "Allow Specific Depositors" screens for accounts that have been recovered via MARS.
- Removed ViewState

## Screenshot

| Screen Before | Screen After |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-07 at 13 01 58](https://github.com/user-attachments/assets/0f412381-6b9e-4d01-80f0-810027447752) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-07 at 12 55 45](https://github.com/user-attachments/assets/0b129ee7-ea98-4297-9645-860e6888642b) |
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-07 at 13 02 03](https://github.com/user-attachments/assets/7eb1e047-f10a-4b02-9607-822acc4989c3) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-07 at 12 55 53](https://github.com/user-attachments/assets/73551677-2adc-4045-b181-0ae0e4a5cafc) |


[ABW-3676]: https://radixdlt.atlassian.net/browse/ABW-3676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ