### PR TITLE
Be lenient when reading `dapp_definitions`

### DIFF
--- a/RadixWallet/Clients/OnLedgerEntitiesClient/Helpers/EntityMetadata+GWMetadata.swift
+++ b/RadixWallet/Clients/OnLedgerEntitiesClient/Helpers/EntityMetadata+GWMetadata.swift
@@ -185,7 +185,7 @@ extension GatewayAPI.EntityMetadataCollection {
 	}
 
 	public var dappDefinitions: [String]? {
-		value(.dappDefinitions)?.asStringCollection
+		value(.dappDefinitions)?.asStringCollection ?? value(.dappDefinitions)?.asGlobalAddressCollection
 	}
 
 	public var claimedEntities: [String]? {


### PR DESCRIPTION
From [slack](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1723026826373209)

## Description
Some resources, like Instapass Badges, encode the `dapp_definitions` metadata item as a global address collection, which seems like the correct approach, whereas most seem to encode it as a string collection. This PR will make the verification mechanism accept both options, but in the long term goal should probably be to use the global address option.

### Notes
Started a discussion about it [here](https://rdxworks.slack.com/archives/C031A0V1A1W/p1723040234354979).