### PR TITLE
Remove onDisappear in AccountDetails

### DIFF
--- a/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
+++ b/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
@@ -47,9 +47,6 @@ extension AccountDetails {
 				.task {
 					await viewStore.send(.task).finish()
 				}
-				.onDisappear {
-					viewStore.send(.onDisappear)
-				}
 				.toolbar {
 					ToolbarItem(placement: .principal) {
 						Text(viewStore.displayName)


### PR DESCRIPTION
## Description
We had an `onDisappear` that caused a runtime warning. Its purpose was to cancel portfolio fetching that was in flight when leaving the AccountDetails screen, but it does not actually do that, so this PR removes it.
