### PR TITLE
[ABW-3719] Warn When Linking Accounts Through Fee Payer

### DIFF
--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
@@ -42,9 +42,9 @@ extension TransactionReviewNetworkFee {
 						case .needsFeePayer:
 							WarningErrorView(text: L10n.TransactionReview.feePayerRequiredMessage, type: .warning)
 						case .insufficientBalance:
-							WarningErrorView(text: L10n.TransactionReview.insufficientBalance, type: .warning)
+							WarningErrorView(text: L10n.TransactionReview.insufficientBalance, type: .error)
 						case .valid(introducesNewAccount: true):
-							EmptyView() // TODO: Here we could show a warning, that this introduces a new account into the transaction - the link between the accounts will now be public
+							WarningErrorView(text: L10n.TransactionReview.insufficientBalance, type: .warning)
 						case .valid(introducesNewAccount: false):
 							EmptyView()
 						}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
@@ -40,11 +40,11 @@ extension TransactionReviewNetworkFee {
 					loadable(viewStore.reviewedTransaction.feePayingValidation) { validation in
 						switch validation {
 						case .needsFeePayer:
-							WarningErrorView(text: L10n.TransactionReview.feePayerRequiredMessage, type: .warning)
+							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.feePayerRequired, type: .warning)
 						case .insufficientBalance:
-							WarningErrorView(text: L10n.TransactionReview.insufficientBalance, type: .error)
+							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.insufficientBalance, type: .error)
 						case .valid(introducesNewAccount: true):
-							WarningErrorView(text: L10n.TransactionReview.insufficientBalance, type: .warning)
+							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.linksNewAccount, type: .warning)
 						case .valid(introducesNewAccount: false):
 							EmptyView()
 						}


### PR DESCRIPTION
Jira ticket: [ABW-3719](https://radixdlt.atlassian.net/browse/ABW-3719)

## Description
When a user selects as fee payer an account that isn't already part of the transaction, this PR will show a warning text.

## How to test
1. Create three accounts, A, B and C
2. Put some XRD in at least A and C
3. Make a transfer from A to B
4. Select C as fee payer for the transaction
-> The warning should be shown, as per the screenshot

## Screenshot

## PR submission checklist
- [ ] I have tested account to account transfer flow and have confirmed that it works
