### PR TITLE
[ABW-3739] Show the Privacy overlay only after the app enters the background

### DIFF
--- a/RadixWallet/Features/AppFeature/SceneDelegate.swift
+++ b/RadixWallet/Features/AppFeature/SceneDelegate.swift
@@ -25,14 +25,13 @@ public final class SceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObj
 		appsFlyerClient.continue(userActivity)
 	}
 
-	public func sceneWillResignActive(_ scene: UIScene) {
+	public func sceneDidEnterBackground(_ scene: UIScene) {
 		guard let scene = scene as? UIWindowScene else { return }
 		showPrivacyProtectionWindow(in: scene)
 	}
 
-	public func sceneDidBecomeActive(_ scene: UIScene) {
-		guard let scene = scene as? UIWindowScene else { return }
-		hidePrivacyProtectionWindow(in: scene)
+	public func sceneWillEnterForeground(_ scene: UIScene) {
+		hidePrivacyProtectionWindow()
 	}
 
 	func overlayWindow(in scene: UIWindowScene) {
@@ -70,7 +69,7 @@ public final class SceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObj
 		privacyProtectionWindow?.makeKeyAndVisible()
 	}
 
-	private func hidePrivacyProtectionWindow(in scene: UIWindowScene) {
+	private func hidePrivacyProtectionWindow() {
 		privacyProtectionWindow?.isHidden = true
 		privacyProtectionWindow = nil
 	}


### PR DESCRIPTION
Jira tickets: [ABW-3738](https://radixdlt.atlassian.net/browse/ABW-3738), [ABW-3739](https://radixdlt.atlassian.net/browse/ABW-3739)

## Description
This PR updates the logic so that the privacy overlay is displayed only after the app enters the background. This ensures that when the app is inactive (e.g., during a biometric check), the privacy overlay will not be shown.

## Video

https://github.com/user-attachments/assets/1f7eea9b-1aae-4741-b8e3-ab9aac95940b



[ABW-3738]: https://radixdlt.atlassian.net/browse/ABW-3738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-3739]: https://radixdlt.atlassian.net/browse/ABW-3739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ