### PR TITLE
[ABW-3574] Fix AccountView screen empty space

### DIFF
--- a/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
+++ b/RadixWallet/Features/AccountDetailsFeature/Coordinator/AccountDetails+View.swift
@@ -44,6 +44,7 @@ extension AccountDetails {
 				.ignoresSafeArea(edges: .bottom)
 				.background(viewStore.appearanceID.gradient)
 				.navigationBarBackButtonHidden()
+				.navigationBarTitleDisplayMode(.inline)
 				.task {
 					await viewStore.send(.task).finish()
 				}


### PR DESCRIPTION
Jira ticket: [ABW-3574](https://radixdlt.atlassian.net/browse/ABW-3574)

## Description
Fixes the empty space at the top of the AccountView screen

## Screenshot

| iOS 18 Before | iOS 18 After |
| - | - |
| ![simulator_screenshot_349B20BB-4980-42BF-B6AF-0CCF8389A2E9](https://github.com/user-attachments/assets/5572dc54-9188-4abd-a123-bcc7425de6f4) | ![simulator_screenshot_DCFFA317-72F6-4201-B758-2711AF95DA09](https://github.com/user-attachments/assets/3d3b67ca-82df-4c14-820a-6344483d9e15)|

| iOS 17.4 Before | iOS 17.4 After |
| - | - |
| ![simulator_screenshot_6ED815F9-69DC-49BE-9D88-CCAFD73B738A](https://github.com/user-attachments/assets/27a14a5d-4259-4fa1-be41-cf16712a28b1) | ![simulator_screenshot_3E548D32-D9F8-494A-9674-EFEA24074B38](https://github.com/user-attachments/assets/47a897b3-89a0-445f-a3fe-11ea09b7e64b) |




[ABW-3574]: https://radixdlt.atlassian.net/browse/ABW-3574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ