### PR TITLE
ABW-3719 Warn When Linking New Accounts (again)

### DIFF
--- a/RadixWallet/Core/DesignSystem/Components/WarningView.swift
+++ b/RadixWallet/Core/DesignSystem/Components/WarningView.swift
@@ -23,6 +23,7 @@ public struct WarningErrorView: View {
 		HStack(spacing: spacing) {
 			Image(.error)
 			Text(text)
+				.lineSpacing(-.small3)
 				.textStyle(.body1Header)
 				.multilineTextAlignment(.leading)
 		}

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
@@ -1,58 +1,64 @@
 
 extension CustomizeFees.State {
-	// Need to disable, since broken in swiftformat 0.52.7
-	// swiftformat:disable redundantClosure
-
 	var viewState: CustomizeFees.ViewState {
 		.init(
-			title: {
-				switch transactionFee.mode {
-				case .normal:
-					L10n.CustomizeNetworkFees.NormalMode.title
-				case .advanced:
-					L10n.CustomizeNetworkFees.AdvancedMode.title
-				}
-			}(),
-			description: {
-				switch transactionFee.mode {
-				case .normal:
-					L10n.CustomizeNetworkFees.NormalMode.subtitle
-				case .advanced:
-					L10n.CustomizeNetworkFees.AdvancedMode.subtitle
-				}
-			}(),
-			modeSwitchTitle: {
-				switch transactionFee.mode {
-				case .normal:
-					L10n.CustomizeNetworkFees.viewAdvancedModeButtonTitle
-				case .advanced:
-					L10n.CustomizeNetworkFees.viewNormalModeButtonTitle
-				}
-			}(),
-			feePayer: feePayer,
-			noFeePayerText: {
-				if feePayingValidation == .valid(.feePayerSuperfluous) {
-					L10n.CustomizeNetworkFees.noneRequired
-				} else {
-					L10n.CustomizeNetworkFees.noAccountSelected
-				}
-			}(),
-			insufficientBalance:
-			feePayingValidation == .insufficientBalance
+			mode: transactionFee.mode,
+			feePayer: feePayer?.account,
+			feePayingValidation: feePayingValidation
 		)
 	}
+}
 
-	// swiftformat:enable redundantClosure
+extension CustomizeFees.ViewState {
+	var title: String {
+		switch mode {
+		case .normal:
+			L10n.CustomizeNetworkFees.NormalMode.title
+		case .advanced:
+			L10n.CustomizeNetworkFees.AdvancedMode.title
+		}
+	}
+
+	var description: String {
+		switch mode {
+		case .normal:
+			L10n.CustomizeNetworkFees.NormalMode.subtitle
+		case .advanced:
+			L10n.CustomizeNetworkFees.AdvancedMode.subtitle
+		}
+	}
+
+	var modeSwitchTitle: String {
+		switch mode {
+		case .normal:
+			L10n.CustomizeNetworkFees.viewAdvancedModeButtonTitle
+		case .advanced:
+			L10n.CustomizeNetworkFees.viewNormalModeButtonTitle
+		}
+	}
+
+	var noFeePayerText: String {
+		if feePayingValidation == .valid(.feePayerSuperfluous) {
+			L10n.CustomizeNetworkFees.noneRequired
+		} else {
+			L10n.CustomizeNetworkFees.noAccountSelected
+		}
+	}
+
+	var insufficientBalance: Bool {
+		feePayingValidation == .insufficientBalance
+	}
+
+	var linkingNewAccount: Bool {
+		feePayingValidation == .valid(.introducesNewAccount)
+	}
 }
 
 extension CustomizeFees {
 	public struct ViewState: Equatable {
-		let title: String
-		let description: String
-		let modeSwitchTitle: String
-		let feePayer: FeePayerCandidate?
-		let noFeePayerText: String
-		let insufficientBalance: Bool
+		let mode: TransactionFee.Mode
+		let feePayer: Account?
+		let feePayingValidation: FeeValidationOutcome?
 	}
 
 	@MainActor
@@ -139,7 +145,7 @@ extension CustomizeFees {
 					.textStyle(.body1StandaloneLink)
 					.foregroundColor(.app.blue2)
 				}
-				if let feePayer = viewState.feePayer?.account {
+				if let feePayer = viewState.feePayer {
 					AccountCard(account: feePayer)
 				} else {
 					AppTextField(
@@ -151,6 +157,8 @@ extension CustomizeFees {
 
 				if viewState.insufficientBalance {
 					WarningErrorView(text: L10n.CustomizeNetworkFees.Warning.insufficientBalance, type: .error)
+				} else if viewState.linkingNewAccount {
+					WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.linksNewAccount, type: .warning)
 				}
 			}
 		}

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
@@ -31,20 +31,14 @@ extension CustomizeFees.State {
 			}(),
 			feePayer: feePayer,
 			noFeePayerText: {
-				if transactionFee.totalFee.lockFee == .zero {
+				if feePayingValidation == .valid(.feePayerSuperfluous) {
 					L10n.CustomizeNetworkFees.noneRequired
 				} else {
 					L10n.CustomizeNetworkFees.noAccountSelected
 				}
 			}(),
-			insufficientBalanceMessage: {
-				if let feePayer {
-					if feePayer.xrdBalance < transactionFee.totalFee.lockFee {
-						return L10n.CustomizeNetworkFees.Warning.insufficientBalance
-					}
-				}
-				return nil
-			}()
+			insufficientBalance:
+			feePayingValidation == .insufficientBalance
 		)
 	}
 
@@ -58,7 +52,7 @@ extension CustomizeFees {
 		let modeSwitchTitle: String
 		let feePayer: FeePayerCandidate?
 		let noFeePayerText: String
-		let insufficientBalanceMessage: String?
+		let insufficientBalance: Bool
 	}
 
 	@MainActor
@@ -155,8 +149,8 @@ extension CustomizeFees {
 					.disabled(true)
 				}
 
-				if let insufficientBalanceMessage = viewState.insufficientBalanceMessage {
-					WarningErrorView(text: insufficientBalanceMessage, type: .error)
+				if viewState.insufficientBalance {
+					WarningErrorView(text: L10n.CustomizeNetworkFees.Warning.insufficientBalance, type: .error)
 				}
 			}
 		}

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees+View.swift
@@ -156,7 +156,7 @@ extension CustomizeFees {
 				}
 
 				if let insufficientBalanceMessage = viewState.insufficientBalanceMessage {
-					WarningErrorView(text: insufficientBalanceMessage, type: .warning)
+					WarningErrorView(text: insufficientBalanceMessage, type: .error)
 				}
 			}
 		}

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
@@ -27,7 +27,7 @@ public struct CustomizeFees: FeatureReducer, Sendable {
 			reviewedTransaction.transactionFee
 		}
 
-		var feePayingValidationValidation: FeeValidationOutcome? {
+		var feePayingValidation: FeeValidationOutcome? {
 			reviewedTransaction.feePayingValidation.wrappedValue
 		}
 

--- a/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/CustomizeFees/CustomizeFees.swift
@@ -27,6 +27,10 @@ public struct CustomizeFees: FeatureReducer, Sendable {
 			reviewedTransaction.transactionFee
 		}
 
+		var feePayingValidationValidation: FeeValidationOutcome? {
+			reviewedTransaction.feePayingValidation.wrappedValue
+		}
+
 		@PresentationState
 		public var destination: Destination.State? = nil
 

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -973,7 +973,7 @@ public struct ReviewedTransaction: Hashable, Sendable {
 }
 
 // MARK: - FeeValidationOutcome
-enum FeeValidationOutcome {
+enum FeeValidationOutcome: Equatable {
 	case valid(Details?)
 	case needsFeePayer
 	case insufficientBalance

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -974,9 +974,14 @@ public struct ReviewedTransaction: Hashable, Sendable {
 
 // MARK: - FeeValidationOutcome
 enum FeeValidationOutcome {
-	case valid(introducesNewAccount: Bool)
+	case valid(Details?)
 	case needsFeePayer
 	case insufficientBalance
+
+	enum Details {
+		case introducesNewAccount
+		case feePayerSuperfluous
+	}
 
 	var isValid: Bool {
 		guard case .valid = self else { return false }
@@ -991,53 +996,36 @@ extension ReviewedTransaction {
 
 	var feePayingValidation: Loadable<FeeValidationOutcome> {
 		feePayer.map { selected in
-			let introducesNewAccount = selected.map { !involvedAccounts.contains($0.account.address) } ?? false
-
-			guard let feePayer = selected,
-			      let feePayerWithdraws = accountWithdraws[feePayer.account.address]
-			else {
-				return selected.validateBalance(forFee: transactionFee, introducesNewAccount: introducesNewAccount)
+			guard transactionFee.totalFee.lockFee > .zero else {
+				// No fee is required - valid regardless of balance
+				return .valid(.feePayerSuperfluous)
 			}
 
-			let xrdAddress = ResourceAddress.xrd(on: networkID)
+			guard let selected else {
+				// Fee is required, but no fee payer selected - invalid
+				return .needsFeePayer
+			}
 
-			let xrdTotalTransfer: Decimal192 = feePayerWithdraws.reduce(.zero) { partialResult, resource in
+			let feePayerWithdraws = accountWithdraws[selected.account.address] ?? []
+			let xrdAddress = ResourceAddress.xrd(on: networkID)
+			let xrdTransfer: Decimal192 = feePayerWithdraws.reduce(.zero) { partialResult, resource in
 				if case let .fungible(resourceAddress, indicator) = resource, resourceAddress == xrdAddress {
 					return partialResult + indicator.amount
 				}
 				return partialResult
 			}
 
-			let total = xrdTotalTransfer + transactionFee.totalFee.lockFee
-
-			guard feePayer.xrdBalance >= total else {
+			guard selected.xrdBalance >= xrdTransfer + transactionFee.totalFee.lockFee else {
 				// Insufficient balance to pay for withdraws and transaction fee
 				return .insufficientBalance
 			}
 
-			return .valid(introducesNewAccount: false)
+			if !involvedAccounts.contains(selected.account.address) {
+				return .valid(.introducesNewAccount)
+			} else {
+				return .valid(nil)
+			}
 		}
-	}
-}
-
-extension FeePayerCandidate? {
-	func validateBalance(forFee transactionFee: TransactionFee, introducesNewAccount: Bool) -> FeeValidationOutcome {
-		if transactionFee.totalFee.lockFee == .zero {
-			// If no fee is required - valid
-			return .valid(introducesNewAccount: introducesNewAccount)
-		}
-
-		guard let self else {
-			// If fee is required, but no fee payer selected - invalid
-			return .needsFeePayer
-		}
-
-		guard self.xrdBalance >= transactionFee.totalFee.lockFee else {
-			// If insufficient balance - invalid
-			return .insufficientBalance
-		}
-
-		return .valid(introducesNewAccount: introducesNewAccount)
 	}
 }
 

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
@@ -44,7 +44,7 @@ extension TransactionReviewNetworkFee {
 						case .insufficientBalance:
 							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.insufficientBalance, type: .warning)
 						case .valid(introducesNewAccount: true):
-							EmptyView() // TODO: Here we could show a warning, that this introduces a new account into the transaction - the link between the accounts will now be public
+							WarningErrorView(text: L10n.TransactionReview.insufficientBalance, type: .warning)
 						case .valid(introducesNewAccount: false):
 							EmptyView()
 						}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
@@ -42,9 +42,9 @@ extension TransactionReviewNetworkFee {
 						case .needsFeePayer:
 							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.feePayerRequired, type: .warning)
 						case .insufficientBalance:
-							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.insufficientBalance, type: .warning)
+							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.insufficientBalance, type: .error)
 						case .valid(introducesNewAccount: true):
-							WarningErrorView(text: L10n.TransactionReview.insufficientBalance, type: .warning)
+							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.linksNewAccount, type: .warning)
 						case .valid(introducesNewAccount: false):
 							EmptyView()
 						}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
@@ -43,9 +43,9 @@ extension TransactionReviewNetworkFee {
 							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.feePayerRequired, type: .warning)
 						case .insufficientBalance:
 							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.insufficientBalance, type: .error)
-						case .valid(introducesNewAccount: true):
+						case .valid(.introducesNewAccount):
 							WarningErrorView(text: L10n.TransactionReview.FeePayerValidation.linksNewAccount, type: .warning)
-						case .valid(introducesNewAccount: false):
+						case .valid:
 							EmptyView()
 						}
 


### PR DESCRIPTION
Jira ticket: [ABW-3719](https://radixdlt.atlassian.net/browse/ABW-3720)

## Description
(Apparently all changes were lost when GitHub changed the branch for the [previous PR](https://github.com/radixdlt/babylon-wallet-ios/pull/1282))

Adds the warning shown in the screenshot, when a fee payer is selected that wouldn't otherwise be part of the transaction. Also refactors the warning logic, along the lines described [here](https://rdxworks.slack.com/archives/C031A0V1A1W/p1723455294380409).

## How to test
1. Create three accounts, A, B and C
2. Put some XRD in at least A and C
3. Make a transfer from A to B
4. Select C as fee payer for the transaction
-> The warning should be shown, as per the screenshot

## Screenshot

<img src="https://github.com/user-attachments/assets/a80d3f0c-5e11-43cf-8588-6845dc200f9a" width="200"/>

<img src="https://github.com/user-attachments/assets/4fdaa283-ea7e-404d-947b-2725480df432" width="200"/>

## PR submission checklist
- [x] I have tested account to account transfer flow and have confirmed that it works

[ABW-3719]: https://radixdlt.atlassian.net/browse/ABW-3719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ