### PR TITLE
[ABW-3750] Fix infinite loading on fiat price after updating TX fee

### DIFF
--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee+View.swift
@@ -66,7 +66,7 @@ extension TransactionReviewNetworkFee {
 						.foregroundColor(.app.blue2)
 					}
 				}
-				.task {
+				.task(id: viewStore.id) {
 					viewStore.send(.task)
 				}
 			}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReviewNetworkFee/TransactionReviewNetworkFee.swift
@@ -6,11 +6,13 @@ public struct TransactionReviewNetworkFee: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable {
 		public var reviewedTransaction: ReviewedTransaction
 		public var fiatValue: Loadable<String> = .idle
+		let id: UUID
 
 		public init(
 			reviewedTransaction: ReviewedTransaction
 		) {
 			self.reviewedTransaction = reviewedTransaction
+			self.id = .init()
 		}
 	}
 


### PR DESCRIPTION
Jira ticket: [ABW-3750](https://radixdlt.atlassian.net/browse/ABW-3750)

## Description
This PR fixes an issue introduced in https://github.com/radixdlt/babylon-wallet-ios/pull/1292, where the fiat value for the price would show an infinite loading spinner after updating such price.

## Video

https://github.com/user-attachments/assets/32e8acf3-14ab-4d4b-aa13-627560ed101d



[ABW-3750]: https://radixdlt.atlassian.net/browse/ABW-3750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ