### PR TITLE
Fix AccountLinking warning for manifests without withdrawals/deposits

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -3047,11 +3047,11 @@
 		48CFBCEA2ADC10D800E77A5C /* CustomizeFees */ = {
 			isa = PBXGroup;
 			children = (
+				48CFBCEF2ADC10D800E77A5C /* AdvancedFeesCustomization.swift */,
 				48CFBCEB2ADC10D800E77A5C /* AdvancedFeesCustomization+View.swift */,
+				48CFBCEE2ADC10D800E77A5C /* NormalFeesCustomization.swift */,
 				48CFBCEC2ADC10D800E77A5C /* NormalFeesCustomization+View.swift */,
 				48CFBCED2ADC10D800E77A5C /* FeesView.swift */,
-				48CFBCEE2ADC10D800E77A5C /* NormalFeesCustomization.swift */,
-				48CFBCEF2ADC10D800E77A5C /* AdvancedFeesCustomization.swift */,
 				48CFBCF02ADC10D800E77A5C /* CustomizeFees+View.swift */,
 				48CFBCF12ADC10D800E77A5C /* CustomizeFees.swift */,
 			);

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -991,7 +991,9 @@ public enum FeePayerValidationOutcome: Sendable, Hashable {
 
 extension ReviewedTransaction {
 	var involvedAccounts: Set<AccountAddress> {
-		Set(accountWithdraws.keys).union(accountDeposits.keys)
+		Set(accountWithdraws.keys)
+			.union(accountDeposits.keys)
+			.union(transactionManifest.summary.addressesOfAccountsRequiringAuth)
 	}
 
 	var feePayingValidation: Loadable<FeePayerValidationOutcome> {


### PR DESCRIPTION
For manifests without any withdrawals or deposits, the Wallet was incorrectly showing the Account Linking error.

https://github.com/user-attachments/assets/b453ecb9-809b-418a-914a-6b6d0159529a