### PR TITLE
[ABW-3776] Unable to create new persona fix 

### DIFF
--- a/RadixWallet/Features/CreatePersona/Children/Introduction/IntroductionToPersonas.swift
+++ b/RadixWallet/Features/CreatePersona/Children/Introduction/IntroductionToPersonas.swift
@@ -15,6 +15,10 @@ public struct IntroductionToPersonas: Sendable, FeatureReducer {
 
 	public init() {}
 
+	public var body: some ReducerOf<Self> {
+		Reduce(core)
+	}
+
 	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
 		case .continueButtonTapped:


### PR DESCRIPTION
Jira ticket: [ABW-3776](https://radixdlt.atlassian.net/browse/ABW-3776)

## Description
This PR fixes the issue where users could not create a new persona by explicitly declaring the `body`. This was necessary due to a conflict between our `FeatureReducer` protocol and the `@Reducer` macro.

[ABW-3776]: https://radixdlt.atlassian.net/browse/ABW-3776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ