### PR TITLE
[ABW-3789] Add info button to default deposit guarantees

### DIFF
--- a/RadixWallet/Features/SettingsFeature/Preferences/DefaultDepositGuarantees/DefaultDepositGuarantees+View.swift
+++ b/RadixWallet/Features/SettingsFeature/Preferences/DefaultDepositGuarantees/DefaultDepositGuarantees+View.swift
@@ -18,11 +18,13 @@ extension DefaultDepositGuarantees {
 
 extension DefaultDepositGuarantees.View {
 	public var body: some View {
-		VStack(spacing: .medium1) {
+		VStack(alignment: .leading, spacing: .medium1) {
 			Text(L10n.AccountSecuritySettings.DepositGuarantees.text)
 				.textStyle(.body1HighImportance)
 				.foregroundColor(.app.gray2)
 				.allowsHitTesting(false)
+
+			InfoButton(.guarantees, label: L10n.TransactionReview.Guarantees.howDoGuaranteesWork)
 
 			Card {
 				let stepperStore = store.scope(state: \.percentageStepper) { .child(.percentageStepper($0)) }


### PR DESCRIPTION
Jira ticket: [ABW-3789](https://radixdlt.atlassian.net/browse/ABW-3789)

## Description
Adds missing ℹ️  button to Default deposit guarantees

## Video

https://github.com/user-attachments/assets/6e03aca8-f64a-48a5-b709-efc8043f4308



[ABW-3789]: https://radixdlt.atlassian.net/browse/ABW-3789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ