### PR TITLE
[ABW-3790] Fix auto dismiss keyboard when entering Seed Phrase

### DIFF
--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
@@ -300,6 +300,12 @@ extension ImportMnemonic.View {
 			) { action in
 				if viewStore.isNonChecksummed {
 					WarningErrorView(text: L10n.ImportMnemonic.checksumFailure, type: .error)
+				} else {
+					// We need to leave some empty space before the button. Otherwise, the keyboard will get automatically dismissed
+					// when focused on one of the last 3 words. It only happens on release mode, since it is related to the screenshot
+					// prevention solution (which isn't enabled in debug).
+					// More info: https://radixdlt.atlassian.net/browse/ABW-3789
+					Spacer(minLength: .small3)
 				}
 				Button(L10n.ImportMnemonic.importSeedPhrase, action: action)
 					.buttonStyle(.primaryRectangular)

--- a/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
+++ b/RadixWallet/Features/ImportMnemonic/ImportMnemonic+View.swift
@@ -304,7 +304,7 @@ extension ImportMnemonic.View {
 					// We need to leave some empty space before the button. Otherwise, the keyboard will get automatically dismissed
 					// when focused on one of the last 3 words. It only happens on release mode, since it is related to the screenshot
 					// prevention solution (which isn't enabled in debug).
-					// More info: https://radixdlt.atlassian.net/browse/ABW-3789
+					// More info: https://radixdlt.atlassian.net/browse/ABW-3790
 					Spacer(minLength: .small3)
 				}
 				Button(L10n.ImportMnemonic.importSeedPhrase, action: action)


### PR DESCRIPTION
Jira ticket: [ABW-3790](https://radixdlt.atlassian.net/browse/ABW-3790)

## Description
This PR fixes a bug happening only on release mode, where the keyboard would be automatically dismissed when entering seed phrase.

## How to test

1. Select `Radix Wallet PROD` scheme
2. Archive app
3. On Organizer `Distribute App` > `Release Testing`
4. Export and drag `.ipa` file to your device
5. Recover wallet from Backup to enter seed phrase
6. Verify you have no issues as shown in JIRA video.



[ABW-3790]: https://radixdlt.atlassian.net/browse/ABW-3790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ