### PR TITLE
[ABW-3581] Inform users when signing with Ledger without P2PLinks

### DIFF
--- a/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Interface.swift
+++ b/RadixWallet/Clients/P2PLinksClient/P2PLinksClient+Interface.swift
@@ -32,3 +32,9 @@ extension P2PLinksClient {
 	public typealias GetP2PLinkPrivateKey = @Sendable () async throws -> (privateKey: Curve25519.PrivateKey, isNew: Bool)
 	public typealias StoreP2PLinkPrivateKey = @Sendable (Curve25519.PrivateKey) async throws -> Void
 }
+
+extension P2PLinksClient {
+	func hasP2PLinks() async -> Bool {
+		await !getP2PLinks().isEmpty
+	}
+}

--- a/RadixWallet/Features/FactorSourceAccess/FactorSourceAccess+View.swift
+++ b/RadixWallet/Features/FactorSourceAccess/FactorSourceAccess+View.swift
@@ -30,6 +30,7 @@ public extension FactorSourceAccess {
 					.onFirstTask { @MainActor in
 						await store.send(.view(.onFirstTask)).finish()
 					}
+					.destinations(with: store)
 			}
 		}
 
@@ -84,5 +85,26 @@ public extension FactorSourceAccess {
 				.cornerRadius(.large1)
 			}
 		}
+	}
+}
+
+private extension StoreOf<FactorSourceAccess> {
+	var destination: PresentationStoreOf<FactorSourceAccess.Destination> {
+		func scopeState(state: State) -> PresentationState<FactorSourceAccess.Destination.State> {
+			state.$destination
+		}
+		return scope(state: scopeState, action: Action.destination)
+	}
+}
+
+@MainActor
+private extension View {
+	func destinations(with store: StoreOf<FactorSourceAccess>) -> some View {
+		let destinationStore = store.destination
+		return noP2PLinkAlert(with: destinationStore)
+	}
+
+	private func noP2PLinkAlert(with destinationStore: PresentationStoreOf<FactorSourceAccess.Destination>) -> some View {
+		alert(store: destinationStore.scope(state: \.noP2PLink, action: \.noP2PLink))
 	}
 }

--- a/RadixWallet/Features/FactorSourceAccess/FactorSourceAccess.swift
+++ b/RadixWallet/Features/FactorSourceAccess/FactorSourceAccess.swift
@@ -4,31 +4,108 @@ public struct FactorSourceAccess: Sendable, FeatureReducer {
 		public let kind: Kind
 		public let purpose: Purpose
 
+		@PresentationState
+		public var destination: Destination.State? = nil
+
 		public init(kind: Kind, purpose: Purpose) {
 			self.kind = kind
 			self.purpose = purpose
 		}
 	}
 
-	public enum ViewAction: Sendable, Equatable {
+	public enum ViewAction: Sendable, Hashable {
 		case onFirstTask
 		case retryButtonTapped
 		case closeButtonTapped
 	}
 
-	public enum DelegateAction: Sendable, Equatable {
+	public enum InternalAction: Sendable, Hashable {
+		case isConnectedToAnyConnectorExtension(Bool)
+	}
+
+	public enum DelegateAction: Sendable, Hashable {
 		case perform
 		case cancel
 	}
 
+	public struct Destination: DestinationReducer {
+		@CasePathable
+		public enum State: Sendable, Hashable {
+			case noP2PLink(AlertState<NoP2PLinkAlert>)
+		}
+
+		@CasePathable
+		public enum Action: Sendable, Hashable {
+			case noP2PLink(NoP2PLinkAlert)
+		}
+
+		public var body: some ReducerOf<Self> {
+			EmptyReducer()
+		}
+
+		public enum NoP2PLinkAlert: Sendable, Hashable {
+			case okTapped
+		}
+	}
+
+	@Dependency(\.ledgerHardwareWalletClient) var ledgerHardwareWalletClient
+
+	public var body: some ReducerOf<Self> {
+		Reduce(core)
+			.ifLet(destinationPath, action: /Action.destination) {
+				Destination()
+			}
+	}
+
 	public init() {}
 
-	public func reduce(into _: inout State, viewAction: ViewAction) -> Effect<Action> {
+	private let destinationPath: WritableKeyPath<State, PresentationState<Destination.State>> = \.$destination
+
+	public func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
-		case .onFirstTask, .retryButtonTapped:
+		case .onFirstTask:
+			.send(.delegate(.perform))
+				.merge(with: checkP2PLinksEffect(state: state))
+		case .retryButtonTapped:
 			.send(.delegate(.perform))
 		case .closeButtonTapped:
 			.send(.delegate(.cancel))
+		}
+	}
+
+	public func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
+		switch internalAction {
+		case let .isConnectedToAnyConnectorExtension(isConnected):
+			if !isConnected {
+				state.destination = .noP2PLink(.noP2Plink)
+			}
+			return .none
+		}
+	}
+
+	public func reduce(into state: inout State, presentedAction: Destination.Action) -> Effect<Action> {
+		switch presentedAction {
+		case .noP2PLink(.okTapped):
+			state.destination = nil
+			return .run { send in
+				// Dispatching this in an async process is enough for it to take place after alert has been dismissed.
+				// No need to place an actual delay with continuousClock.
+				await send(.delegate(.cancel))
+			}
+		}
+	}
+
+	private func checkP2PLinksEffect(state: State) -> Effect<Action> {
+		guard case .ledger = state.kind else {
+			return .none
+		}
+		return .run { send in
+			for try await isConnected in await ledgerHardwareWalletClient.isConnectedToAnyConnectorExtension() {
+				guard !Task.isCancelled else { return }
+				await send(.internal(.isConnectedToAnyConnectorExtension(isConnected)))
+			}
+		} catch: { error, _ in
+			loggerGlobal.error("failed to get links updates, error: \(error)")
 		}
 	}
 }
@@ -60,5 +137,19 @@ extension FactorSourceAccess.State {
 
 		/// MFA signing, ROLA or encryption.
 		case createKey
+	}
+}
+
+private extension AlertState<FactorSourceAccess.Destination.NoP2PLinkAlert> {
+	static var noP2Plink: AlertState {
+		AlertState {
+			TextState(L10n.LedgerHardwareDevices.LinkConnectorAlert.title)
+		} actions: {
+			ButtonState(action: .okTapped) {
+				TextState(L10n.Common.ok)
+			}
+		} message: {
+			TextState(L10n.LedgerHardwareDevices.LinkConnectorAlert.message)
+		}
 	}
 }

--- a/RadixWallet/Features/Signing/Children/SignWithFactorSource.swift
+++ b/RadixWallet/Features/Signing/Children/SignWithFactorSource.swift
@@ -24,7 +24,8 @@ public struct SignWithFactorSource: Sendable, FeatureReducer {
 				self.factorSourceAccess = .init(kind: .device, purpose: .signature)
 			case .ledger:
 				assert(signingFactors.allSatisfy { $0.factorSource.kind == LedgerHardwareWalletFactorSource.kind })
-				self.factorSourceAccess = .init(kind: .ledger(nil), purpose: .signature)
+				let ledger: LedgerHardwareWalletFactorSource? = signingFactors.first?.factorSource.extract()
+				self.factorSourceAccess = .init(kind: .ledger(ledger), purpose: .signature)
 			}
 		}
 	}


### PR DESCRIPTION
Jira ticket: [ABW-3581](https://radixdlt.atlassian.net/browse/ABW-3581)

## Description
Inform users when they attempt to access a Ledger factor source but the wallet isn't connected to any connector extension. 
Also, improves the UX by removing a glitch where the ledger name wouldn't show up for an instant.

## Videos

| Before | After |
| - | - |
| <video src=https://github.com/user-attachments/assets/65ba3267-6b8b-428d-ac30-9b021bdfc454> | <video src=https://github.com/user-attachments/assets/902b2f3a-5ccf-41e2-8597-51bac5507a24> |





[ABW-3581]: https://radixdlt.atlassian.net/browse/ABW-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ