### PR TITLE
Fix validation of NFT tranfers to external accounts

### DIFF
--- a/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+View.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/ThirdPartyDeposits/ResourcesList+View.swift
@@ -107,7 +107,7 @@ extension ResourcesList.View {
 
 	private func items(resources: IdentifiedArrayOf<ResourceViewState>) -> some SwiftUI.View {
 		ScrollView {
-			VStack(spacing: .zero) {
+			VStack(spacing: .medium3) {
 				ForEach(resources) { resource in
 					Card {
 						AssetRow(

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/ReceivingAccount+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/ReceivingAccount+Reducer.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Sargon
 import SwiftUI
 
-public typealias AssetsDepositStatus = [ResourceAsset.State.ID: ResourceAsset.State.DepositStatus]
+public typealias AssetsDepositStatus = [ResourceAddress: ResourceAsset.State.DepositStatus]
 
 // MARK: - ReceivingAccount
 public struct ReceivingAccount: Sendable, FeatureReducer {
@@ -91,8 +91,10 @@ extension ReceivingAccount.State {
 	}
 
 	mutating func updateDepositStatus(values: AssetsDepositStatus) {
-		for (id, status) in values {
-			assets[id: id]?.depositStatus = .success(status)
+		assets.mutateAll { asset in
+			if let depositStatus = values[asset.resourceAddress] {
+				asset.depositStatus = .success(depositStatus)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where the app would also show a 400 error when reviewing a transfer of at least one NFT to an external account.

<img width="200" alt="before" src="https://github.com/user-attachments/assets/33855145-ba81-4ed3-ae9f-eb1d94e56bc7">

Also, it adds vertical spacing among the elements of `Allow/Deny Specific Assets` view, after they were migrated to use the same UI than `Hidden Assets` view.

## Video

https://github.com/user-attachments/assets/a2c6cbc2-b862-4787-96c4-23fac2664ba4

## Screenshot

| Before | After |
| - | - |
| <img src=https://github.com/user-attachments/assets/5e08d9b6-7a89-4c66-8a18-a105d1cc0a13 width=200> | <img src=https://github.com/user-attachments/assets/d7289a64-b579-428d-94ea-5b6a9f31ef59 width=200> |


