### PR TITLE
Fix stake unit resource redemption value

### DIFF
--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
@@ -288,8 +288,15 @@ private extension MutableCollection where Element == OnLedgerEntitiesClient.Owne
 private extension MutableCollection where Element == OnLedgerEntitiesClient.OwnedStakeDetails {
 	mutating func updateFiatWorth(_ change: (ResourceAddress, ResourceAmount) -> FiatWorth?) {
 		mutateAll { detail in
+			let xrdRedemptionValue = detail.xrdRedemptionValue
 			detail.stakeUnitResource.mutate {
-				$0.amount.fiatWorth = change(.mainnetXRD, $0.amount)
+				$0.amount.fiatWorth = change(
+					.mainnetXRD,
+					.init(
+						nominalAmount: xrdRedemptionValue,
+						fiatWorth: $0.amount.fiatWorth
+					)
+				)
 			}
 			detail.stakeClaimTokens.mutate {
 				$0.stakeClaims.mutateAll { token in


### PR DESCRIPTION
The wallet was mistakenly calculating the worth of stake unit resource amount instead of the xrd redemption value.

## Image with the XRD worth - 0.0216 USD XRD price
<img src="https://github.com/user-attachments/assets/b5c56dbd-073a-4142-8804-d248f2b48999" alt="IMG_0212" width="300" style="aspect-ratio: 9 / 19.5;" />

## Image with wrong stake unit worth
This multiplies the stake unit resource amount with the XRD price
<img src="https://github.com/user-attachments/assets/63c32e59-9689-41dd-ac2f-7b0ebc565ae7" alt="IMG_0213" width="300" style="aspect-ratio: 9 / 19.5;" />

## Image with fixed stake unit worth
This multiplies the xrd redemption with xrd price
<img src="https://github.com/user-attachments/assets/af20c13d-251a-4df5-88ae-4158f2970930" alt="IMG_0211" width="300" style="aspect-ratio: 9 / 19.5;" />
