### PR TITLE
Fix Linked Connectors on iOS 18

### DIFF
--- a/Aux/en.lproj/InfoPlist.strings
+++ b/Aux/en.lproj/InfoPlist.strings
@@ -12,3 +12,6 @@ NSDownloadsFolderUsageDescription = "This lets you import a Radix Wallet backup 
 
 // A message that tells the user why the app is requesting the ability to authenticate with Face ID.
 NSFaceIDUsageDescription = "This app authenticates you when signing transactions and connecting to dApps.";
+
+// A message that tells the user why the app is requesting access to local network.
+NSLocalNetworkUsageDescription = "This lets you connect to a Radix Wallet Connector on your desktop browser";

--- a/Aux/en.lproj/InfoPlist.strings
+++ b/Aux/en.lproj/InfoPlist.strings
@@ -14,4 +14,4 @@ NSDownloadsFolderUsageDescription = "This lets you import a Radix Wallet backup 
 NSFaceIDUsageDescription = "This app authenticates you when signing transactions and connecting to dApps.";
 
 // A message that tells the user why the app is requesting access to local network.
-NSLocalNetworkUsageDescription = "This lets you connect to a Radix Wallet Connector on your desktop browser";
+NSLocalNetworkUsageDescription = "This lets you connect to a Radix Wallet Connector on your desktop browser.";


### PR DESCRIPTION
## Description
As reported by Umair in [Slack](https://rdxworks.slack.com/archives/C03QFAWBRNX/p1727800499569819), it isn't possible to connect to a Linked Connector on iOS 18.

Adding the missing key to `InfoPlist.strings` fixes it.