### PR TITLE
[DO NOT MERGE] 1.10.1 release

### DIFF
--- a/Aux/Config/Common.xcconfig
+++ b/Aux/Config/Common.xcconfig
@@ -1,7 +1,7 @@
 // MARK: - Custom flags
 
 /// Application version shared across all targets and flavours
-APP_VERSION = 1.10.0
+APP_VERSION = 1.10.1
 
 /// App Icon base name
 APP_ICON = AppIcon


### PR DESCRIPTION
Bumps version to generate a new htofix release with the fix to allow linking connectors on iOS 18