### PR TITLE
[ABW-3869] Fix crash when transferring multiple NFTs from same collection

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -6822,6 +6822,7 @@
 			buildConfigurationList = 48CFBC5D2ADC106400E77A5C /* Build configuration list for PBXNativeTarget "RadixWallet" */;
 			buildPhases = (
 				5B9846C32BBD643700E814F3 /* Create SensitiveInfo Sample */,
+				5B4E1D142CB423C9002FAC2E /* Custom linter */,
 				48CFBC4B2ADC106300E77A5C /* Sources */,
 				48CFBC4C2ADC106300E77A5C /* Frameworks */,
 				48CFBC4D2ADC106300E77A5C /* Resources */,
@@ -7009,6 +7010,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		5B4E1D142CB423C9002FAC2E /* Custom linter */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Custom linter";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Custom linter to avoid using Dictionary.init(uniqueKeysWithValues:)\n# Quick solution before considering using an external tool, such as SwiftLint \n\nPATTERN=\"uniqueKeysWithValues:\"\nFILES=$(grep -rnw --include=\\*.swift \"$PATTERN\" \"$SRCROOT\")\n\nif [ ! -z \"$FILES\" ]; then\n    echo \"Error: We shouldn't use Dictionary(uniqueKeysWithValues:), as it could lead to unhandled crashes if key is repeated\"\n    echo \"Instead, use our custom init(keysWithValues:), or consider refactoring your solution to use IdentifiedArrayOf\"\n    echo \"Please fix on the following files:\"\n    echo \"$FILES\"\n    exit 1 \nfi\n";
+		};
 		5B9846C32BBD643700E814F3 /* Create SensitiveInfo Sample */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -734,6 +734,7 @@
 		5B45E2FF2BC59780007C4C84 /* SignWithFactorSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B45E2FD2BC59780007C4C84 /* SignWithFactorSource.swift */; };
 		5B45E3012BC5A491007C4C84 /* FactorSourceAccess+ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B45E3002BC5A491007C4C84 /* FactorSourceAccess+ViewState.swift */; };
 		5B4712CC2C526146003B4712 /* HeaderButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4712CB2C526146003B4712 /* HeaderButtonStyle.swift */; };
+		5B4E1D132CB421EB002FAC2E /* DepositStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4E1D122CB421E3002FAC2E /* DepositStatus.swift */; };
 		5B526ADB2C876E7C00AF8B72 /* AccountLockerClaimDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B526ADA2C876E7C00AF8B72 /* AccountLockerClaimDetails.swift */; };
 		5B526AEC2C89C3C200AF8B72 /* ResourcesVisibilityClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B526AE82C89C3C200AF8B72 /* ResourcesVisibilityClient+Interface.swift */; };
 		5B526AED2C89C3C200AF8B72 /* ResourcesVisibilityClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B526AE92C89C3C200AF8B72 /* ResourcesVisibilityClient+Live.swift */; };
@@ -1946,6 +1947,7 @@
 		5B45E2FD2BC59780007C4C84 /* SignWithFactorSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignWithFactorSource.swift; sourceTree = "<group>"; };
 		5B45E3002BC5A491007C4C84 /* FactorSourceAccess+ViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FactorSourceAccess+ViewState.swift"; sourceTree = "<group>"; };
 		5B4712CB2C526146003B4712 /* HeaderButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderButtonStyle.swift; sourceTree = "<group>"; };
+		5B4E1D122CB421E3002FAC2E /* DepositStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepositStatus.swift; sourceTree = "<group>"; };
 		5B526ADA2C876E7C00AF8B72 /* AccountLockerClaimDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLockerClaimDetails.swift; sourceTree = "<group>"; };
 		5B526AE82C89C3C200AF8B72 /* ResourcesVisibilityClient+Interface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ResourcesVisibilityClient+Interface.swift"; sourceTree = "<group>"; };
 		5B526AE92C89C3C200AF8B72 /* ResourcesVisibilityClient+Live.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ResourcesVisibilityClient+Live.swift"; sourceTree = "<group>"; };
@@ -3349,6 +3351,7 @@
 		48CFBD402ADC10D800E77A5C /* Asset */ = {
 			isa = PBXGroup;
 			children = (
+				5B4E1D122CB421E3002FAC2E /* DepositStatus.swift */,
 				48CFBD412ADC10D800E77A5C /* ResourceAsset+Reducer.swift */,
 				48CFBD442ADC10D800E77A5C /* ResourceAsset+View.swift */,
 				48CFBD452ADC10D800E77A5C /* FungibleResourceAsset+Reducer.swift */,
@@ -7690,6 +7693,7 @@
 				48CFC3762ADC10D900E77A5C /* ValidatorStakeView.swift in Sources */,
 				48CFC4612ADC10DA00E77A5C /* MakeTransactionHeaderInput.swift in Sources */,
 				A40815C62C7E0D08005E65B9 /* NonFungibleResourcesCollectionItemVaultAggregatedVault.swift in Sources */,
+				5B4E1D132CB421EB002FAC2E /* DepositStatus.swift in Sources */,
 				48CFC2F22ADC10D900E77A5C /* CreatePersonaCoordinator+View.swift in Sources */,
 				48CFC4652ADC10DA00E77A5C /* AccountPortfoliosClient+Live.swift in Sources */,
 				48CFC5832ADC10DA00E77A5C /* SecureStorageClient+Test.swift in Sources */,

--- a/RadixWallet/Clients/AccountLockersClient/AccountLockersClient+Live.swift
+++ b/RadixWallet/Clients/AccountLockersClient/AccountLockersClient+Live.swift
@@ -166,7 +166,7 @@ extension AccountLockersClient {
 				let response = try await gatewayAPIClient.getAccountLockerTouchedAt(.init(accountLockers: accountLockers))
 				return (accountAddress, response)
 			}
-			return Dictionary(uniqueKeysWithValues: result.map { ($0.0, $0.1) })
+			return try Dictionary(keysWithValues: result.map { ($0.0, $0.1) })
 		}
 
 		@Sendable

--- a/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
+++ b/RadixWallet/Clients/FactorSourcesClient/FactorSourcesClient+Live.swift
@@ -401,8 +401,8 @@ func signingFactors(
 		}
 	}
 
-	return SigningFactors(
-		uniqueKeysWithValues: signingFactors.map { keyValuePair -> (key: FactorSourceKind, value: NonEmpty<Set<SigningFactor>>) in
+	return try SigningFactors(
+		keysWithValues: signingFactors.map { keyValuePair -> (key: FactorSourceKind, value: NonEmpty<Set<SigningFactor>>) in
 			assert(!keyValuePair.value.isEmpty, "Incorrect implementation, IdentifiedArrayOf<SigningFactor> should never be empty.")
 			let value: NonEmpty<Set<SigningFactor>> = .init(rawValue: Set(keyValuePair.value))!
 			return (key: keyValuePair.key, value: value)

--- a/RadixWallet/Core/Dictionary+Extensions.swift
+++ b/RadixWallet/Core/Dictionary+Extensions.swift
@@ -14,3 +14,36 @@ extension Dictionary {
 		)
 	}
 }
+
+extension Dictionary {
+	// Custom initializer that throws if there are duplicate keys
+	init(keysWithValues: [(Key, Value)]) throws {
+		self = [:] // Initialize an empty dictionary
+
+		for (key, value) in keysWithValues {
+			if self[key] != nil {
+				throw DictionaryDuplicateKeyError()
+			}
+			self[key] = value
+		}
+	}
+
+	struct DictionaryDuplicateKeyError: Error {}
+}
+
+extension OrderedDictionary {
+	// Custom initializer that throws if there are duplicate keys
+	init(keysWithValues: [(Key, Value)]) throws {
+		self = OrderedDictionary()
+
+		for (key, value) in keysWithValues {
+			// Check if the key already exists in the OrderedDictionary
+			if self[key] != nil {
+				throw OrderedDictionaryDuplicateKeyError()
+			}
+			self[key] = value
+		}
+	}
+
+	struct OrderedDictionaryDuplicateKeyError: Error {}
+}

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/DepositStatus.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/DepositStatus.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public typealias DepositStatus = DepositStatusPerResource.DepositStatus
+public typealias DepositStatusPerResources = IdentifiedArrayOf<DepositStatusPerResource>
+
+// MARK: - DepositStatusPerResource
+public struct DepositStatusPerResource: Sendable, Hashable, Identifiable {
+	let resourceAddress: ResourceAddress
+	let depositStatus: DepositStatus
+
+	public var id: ResourceAddress { resourceAddress }
+
+	public enum DepositStatus: Sendable, Hashable {
+		/// The deposit of this asset is allowed.
+		case allowed
+
+		/// The user needs to provide an additional signature to deposit this asset.
+		case additionalSignatureRequired
+
+		/// The user cannot deposit this asset since the receiving acccount has disallowed it.
+		case denied
+	}
+}

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/ResourceAsset+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/ResourceAsset+Reducer.swift
@@ -247,17 +247,6 @@ extension OnLedgerEntity.NonFungibleToken {
 
 // MARK: - ResourceAsset.State.DepositStatus
 extension ResourceAsset.State {
-	public enum DepositStatus: Sendable, Hashable {
-		/// The deposit of this asset is allowed.
-		case allowed
-
-		/// The user needs to provide an additional signature to deposit this asset.
-		case additionalSignatureRequired
-
-		/// The user cannot deposit this asset since the receiving acccount has disallowed it.
-		case denied
-	}
-
 	var isDepositEnabled: Bool {
 		switch depositStatus {
 		case .idle, .loading:

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/ResourceAsset+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/Asset/ResourceAsset+View.swift
@@ -111,7 +111,7 @@ private extension View {
 	}
 }
 
-private extension Loadable<ResourceAsset.State.DepositStatus> {
+private extension Loadable<DepositStatus> {
 	var hint: Hint.ViewState? {
 		switch self {
 		case .idle, .loading, .failure, .success(.allowed):

--- a/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/ReceivingAccount+Reducer.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/TransferAccountList/ReceivingAccount/ReceivingAccount+Reducer.swift
@@ -2,8 +2,6 @@ import ComposableArchitecture
 import Sargon
 import SwiftUI
 
-public typealias AssetsDepositStatus = [ResourceAddress: ResourceAsset.State.DepositStatus]
-
 // MARK: - ReceivingAccount
 public struct ReceivingAccount: Sendable, FeatureReducer {
 	public struct State: Sendable, Hashable, Identifiable {
@@ -84,16 +82,16 @@ extension ReceivingAccount.State {
 		assets.contains(where: { $0.depositStatus == .loading })
 	}
 
-	mutating func setAllDepositStatus(_ status: Loadable<ResourceAsset.State.DepositStatus>) {
+	mutating func setAllDepositStatus(_ status: Loadable<DepositStatus>) {
 		assets.mutateAll { asset in
 			asset.depositStatus = status
 		}
 	}
 
-	mutating func updateDepositStatus(values: AssetsDepositStatus) {
+	mutating func updateDepositStatus(values: DepositStatusPerResources) {
 		assets.mutateAll { asset in
-			if let depositStatus = values[asset.resourceAddress] {
-				asset.depositStatus = .success(depositStatus)
+			if let value = values[id: asset.resourceAddress] {
+				asset.depositStatus = .success(value.depositStatus)
 			}
 		}
 	}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview+Sections.swift
@@ -33,8 +33,8 @@ extension TransactionReview {
 		let allAddresses: IdentifiedArrayOf<ResourceAddress> = Array((allWithdrawAddresses + allDepositAddresses).uniqued()).asIdentified()
 
 		func resourcesInfo(_ resourceAddresses: [ResourceAddress]) async throws -> ResourcesInfo {
-			var newlyCreatedMetadata = Dictionary(
-				uniqueKeysWithValues: resourceAddresses.compactMap { resourceAddress in
+			var newlyCreatedMetadata = try Dictionary(
+				keysWithValues: resourceAddresses.compactMap { resourceAddress in
 					summary.newEntities.metadata[resourceAddress].map {
 						(
 							resourceAddress,
@@ -114,7 +114,7 @@ extension TransactionReview {
 
 			let dApps = await extractDappEntities(poolAddresses.map(\.asGeneral))
 
-			let perPoolUnitDapps = perPoolUnitDapps(dApps, poolInteractions: poolContributions)
+			let perPoolUnitDapps = try perPoolUnitDapps(dApps, poolInteractions: poolContributions)
 
 			// Extract Contributing to Pools section
 			let pools: TransactionReviewPools.State? = try await extractDapps(dApps, unknownTitle: L10n.TransactionReview.unknownPools)
@@ -155,7 +155,7 @@ extension TransactionReview {
 
 			let dApps = await extractDappEntities(poolAddresses.map(\.asGeneral))
 
-			let perPoolUnitDapps = perPoolUnitDapps(dApps, poolInteractions: poolRedemptions)
+			let perPoolUnitDapps = try perPoolUnitDapps(dApps, poolInteractions: poolRedemptions)
 
 			// Extract Contributing to Pools section
 			let pools: TransactionReviewPools.State? = try await extractDapps(dApps, unknownTitle: L10n.TransactionReview.unknownPools)
@@ -577,8 +577,8 @@ extension TransactionReview {
 	private func perPoolUnitDapps(
 		_ dappEntities: [(address: Address, entity: TransactionReview.DappEntity?)],
 		poolInteractions: [some TrackedPoolInteraction]
-	) -> ResourceAssociatedDapps {
-		Dictionary(uniqueKeysWithValues: dappEntities.compactMap { data -> (ResourceAddress, OnLedgerEntity.Metadata)? in
+	) throws -> ResourceAssociatedDapps {
+		try Dictionary(keysWithValues: dappEntities.compactMap { data -> (ResourceAddress, OnLedgerEntity.Metadata)? in
 			let poolUnitResource: ResourceAddress? = poolInteractions
 				.first(where: { $0.poolAddress.asGeneral == data.address })?
 				.poolUnitsResourceAddress

--- a/RadixWallet/Prelude/Extensions/Array+Identifiable.swift
+++ b/RadixWallet/Prelude/Extensions/Array+Identifiable.swift
@@ -6,7 +6,7 @@ extension Array where Element: Identifiable {
 	public func asIdentified() -> IdentifiedArrayOf<Element> {
 		var array: IdentifiedArrayOf<Element> = []
 		for element in self {
-			let (inserted, _) = array.append(element)
+			let _ = array.append(element)
 		}
 		return array
 	}


### PR DESCRIPTION
Jira ticket: [ABW-3869](https://radixdlt.atlassian.net/browse/ABW-3869)

## Description
This PR fixes a crash caused by attempting to add multiple values with same `Key` to a dictionary. The solution for this particular case required adding a new wrapper model to use `IdentifiedArrayOf<>` instead. 
Still, the PR adds a custom throwing init for `Dictionary` and `OrderedDictionary` to at least catch these potential failures in other situations. 

## Video

https://github.com/user-attachments/assets/9c6d3cf6-9e8e-4e8b-b006-040307c5c469


