### PR TITLE
[ABW-3858] Submit transaction and poll its status via SargonOS

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -9051,7 +9051,7 @@
 			repositoryURL = "https://github.com/radixdlt/sargon";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.27;
+				version = 1.1.28;
 			};
 		};
 		A415574E2B757C5E0040AD4E /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {

--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/radixdlt/sargon/",
       "state" : {
-        "revision" : "8ece3fe5575438d31ddda0e56f608345726dc262",
-        "version" : "1.1.27"
+        "revision" : "7e9cbbaa253f9ccf27bf503b274ddbb0e4fbc52e",
+        "version" : "1.1.28"
       }
     },
     {

--- a/RadixWallet/Clients/AccountLockersClient/AccountLockersClient+Live.swift
+++ b/RadixWallet/Clients/AccountLockersClient/AccountLockersClient+Live.swift
@@ -226,9 +226,10 @@ extension AccountLockersClient {
 			switch result {
 			case let .dapp(.success(success)):
 				if case let .transaction(tx) = success.items {
-					// Wait for the transaction to be committed
+					// Poll transaction status until available
 					let txID = tx.send.transactionIntentHash
-					try await submitTXClient.hasTXBeenCommittedSuccessfully(txID)
+					let _ = try await submitTXClient.pollTransactionStatus(txID)
+
 					// And update claim status after
 					forceRefreshSubject.send(true)
 				}

--- a/RadixWallet/Clients/FaucetClient/FaucetClient+Live.swift
+++ b/RadixWallet/Clients/FaucetClient/FaucetClient+Live.swift
@@ -61,10 +61,9 @@ extension FaucetClient: DependencyKey {
 
 			let txID = notarized.txID
 
-			_ = try await submitTXClient.submitTransaction(.init(
-				txID: txID,
-				compiledNotarizedTXIntent: notarized.notarized
-			))
+			_ = try await submitTXClient.submitTransaction(notarized.notarized)
+
+			_ = try await submitTXClient.pollTransactionStatus(txID)
 
 			try await submitTXClient.hasTXBeenCommittedSuccessfully(txID)
 		}
@@ -81,9 +80,9 @@ extension FaucetClient: DependencyKey {
 			}
 
 			let networkID = await gatewaysClient.getCurrentNetworkID()
-			let networkIDOfAddress = try accountAddress.networkID
+			let networkIDOfAddress = accountAddress.networkID
 			assert(networkIDOfAddress == networkID)
-			let manifest = try TransactionManifest.faucet(
+			let manifest = TransactionManifest.faucet(
 				includeLockFeeInstruction: true,
 				addressOfReceivingAccount: accountAddress
 			)

--- a/RadixWallet/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Interface.swift
+++ b/RadixWallet/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Interface.swift
@@ -27,8 +27,6 @@ struct GatewayAPIClient: Sendable, DependencyKey {
 	var getAccountLockerVaults: GetAccountLockerVaults
 
 	// MARK: Transaction
-	var submitTransaction: SubmitTransaction
-	var transactionStatus: GetTransactionStatus
 	var transactionPreview: TransactionPreview
 	var streamTransactions: StreamTransactions
 	var prevalidateDeposit: PrevalidateDeposit
@@ -58,8 +56,6 @@ extension GatewayAPIClient {
 	typealias GetAccountLockerVaults = @Sendable (GatewayAPI.StateAccountLockerPageVaultsRequest) async throws -> GatewayAPI.StateAccountLockerPageVaultsResponse
 
 	// MARK: - Transaction
-	typealias SubmitTransaction = @Sendable (GatewayAPI.TransactionSubmitRequest) async throws -> GatewayAPI.TransactionSubmitResponse
-	typealias GetTransactionStatus = @Sendable (GatewayAPI.TransactionStatusRequest) async throws -> GatewayAPI.TransactionStatusResponse
 	typealias TransactionPreview = @Sendable (GatewayAPI.TransactionPreviewRequest) async throws -> GatewayAPI.TransactionPreviewResponse
 	typealias StreamTransactions = @Sendable (GatewayAPI.StreamTransactionsRequest) async throws -> GatewayAPI.StreamTransactionsResponse
 	typealias PrevalidateDeposit = @Sendable (GatewayAPI.AccountDepositPreValidationRequest) async throws -> GatewayAPI.AccountDepositPreValidationResponse

--- a/RadixWallet/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Live.swift
+++ b/RadixWallet/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Live.swift
@@ -204,16 +204,6 @@ extension GatewayAPIClient {
 					request: request
 				) { $0.appendingPathComponent("/state/account-locker/page/vaults") }
 			},
-			submitTransaction: { transactionSubmitRequest in
-				try await post(
-					request: transactionSubmitRequest
-				) { $0.appendingPathComponent("transaction/submit") }
-			},
-			transactionStatus: { transactionStatusRequest in
-				try await post(
-					request: transactionStatusRequest
-				) { $0.appendingPathComponent("transaction/status") }
-			},
 			transactionPreview: { transactionPreviewRequest in
 				try await post(
 					request: transactionPreviewRequest

--- a/RadixWallet/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Mock.swift
+++ b/RadixWallet/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Mock.swift
@@ -16,8 +16,6 @@ extension GatewayAPIClient: TestDependencyKey {
 		getNonFungibleData: unimplemented("\(Self.self).getNonFungibleData"),
 		getAccountLockerTouchedAt: unimplemented("\(Self.self).getAccountLockerTouchedAt"),
 		getAccountLockerVaults: unimplemented("\(Self.self).GetAccountLockerVaults"),
-		submitTransaction: unimplemented("\(Self.self).submitTransaction"),
-		transactionStatus: unimplemented("\(Self.self).transactionStatus"),
 		transactionPreview: unimplemented("\(Self.self).transactionPreview"),
 		streamTransactions: unimplemented("\(Self.self).streamTransactions"),
 		prevalidateDeposit: unimplemented("\(Self.self).prevalidateDeposit")
@@ -44,19 +42,6 @@ extension GatewayAPIClient: TestDependencyKey {
 			getNonFungibleData: unimplemented("\(self).getNonFungibleData"),
 			getAccountLockerTouchedAt: unimplemented("\(Self.self).getAccountLockerTouchedAt"),
 			getAccountLockerVaults: unimplemented("\(Self.self).GetAccountLockerVaults"),
-			submitTransaction: { _ in
-				.init(duplicate: submittedTXIsDoubleSpend)
-			},
-			transactionStatus: { _ in
-				.init(
-					ledgerState: .previewValue,
-					status: .committedSuccess,
-					intentStatus: .committedSuccess,
-					intentStatusDescription: "",
-					knownPayloads: [.init(payloadHash: "payload-hash-hex", status: .committedSuccess)],
-					errorMessage: nil
-				)
-			},
 			transactionPreview: unimplemented("\(self).transactionPreview"),
 			streamTransactions: unimplemented("\(self).streamTransactions"),
 			prevalidateDeposit: unimplemented("\(Self.self).prevalidateDeposit")

--- a/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Live.swift
+++ b/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Live.swift
@@ -5,162 +5,17 @@ extension SubmitTransactionClient: DependencyKey {
 	typealias Value = SubmitTransactionClient
 
 	static let liveValue: Self = {
-		@Dependency(\.gatewayAPIClient) var gatewayAPIClient
-
-		let hasTXBeenCommittedSuccessfully: HasTXBeenCommittedSuccessfully = { intentHash in
-			@Dependency(\.continuousClock) var clock
-
-			@Sendable func pollTransactionStatus() async throws -> GatewayAPI.TransactionStatusResponse {
-				let txStatusRequest = GatewayAPI.TransactionStatusRequest(
-					intentHash: intentHash.toRawString()
-				)
-				let txStatusResponse = try await gatewayAPIClient.transactionStatus(txStatusRequest)
-				return txStatusResponse
-			}
-
-			var delayDuration = PollStrategy.default.sleepDuration
-
-			while true {
-				guard !Task.isCancelled else {
-					throw CancellationError()
-				}
-
-				// Increase delay by 1 second on subsequent calls
-				delayDuration += 1
-
-				guard let transactionStatusResponse = try? await pollTransactionStatus(),
-				      let transactionStatus = transactionStatusResponse.knownPayloads.first?.payloadStatus
-				else {
-					try? await clock.sleep(for: .seconds(delayDuration))
-					continue
-				}
-
-				switch transactionStatus {
-				case .unknown, .commitPendingOutcomeUnknown, .pending:
-					try? await clock.sleep(for: .seconds(delayDuration))
-					continue
-				case .committedSuccess:
-					return
-				case .committedFailure:
-					throw TXFailureStatus.failed(reason: .init(transactionStatusResponse.errorMessage))
-				case .permanentlyRejected:
-					throw TXFailureStatus.permanentlyRejected(reason: .init(transactionStatusResponse.errorMessage))
-				case .temporarilyRejected:
-					throw TXFailureStatus.temporarilyRejected(currentEpoch: .init(UInt64(transactionStatusResponse.ledgerState.epoch)))
-				}
-			}
+		let submitTransaction: SubmitTransaction = { notarizedTransaction in
+			try await SargonOS.shared.submitTransaction(notarizedTransaction: notarizedTransaction)
 		}
 
-		let submitTransaction: SubmitTransaction = { request in
-			let txID = request.txID
-
-			#if DEBUG
-			debugPrintCompiledNotarizedIntent(compiled: request.compiledNotarizedTXIntent)
-			#endif
-
-			let submitTransactionRequest = GatewayAPI.TransactionSubmitRequest(
-				notarizedTransactionHex: request.compiledNotarizedTXIntent.data.hex
-			)
-
-			let response = try await gatewayAPIClient.submitTransaction(submitTransactionRequest)
-
-			guard !response.duplicate else {
-				throw SubmitTXFailure.invalidTXWasDuplicate(txID: txID)
-			}
-
-			return txID
+		let pollTransactionStatus: PollTransactionStatus = { intentHash in
+			try await SargonOS.shared.pollTransactionStatus(intentHash: intentHash)
 		}
 
 		return Self(
 			submitTransaction: submitTransaction,
-			hasTXBeenCommittedSuccessfully: hasTXBeenCommittedSuccessfully
+			pollTransactionStatus: pollTransactionStatus
 		)
 	}()
-}
-
-extension Result where Success == GatewayAPI.TransactionStatus {
-	var isComplete: Bool {
-		switch self {
-		case .failure: true
-		case let .success(status): status.isComplete
-		}
-	}
-}
-
-extension GatewayAPI.TransactionStatus {
-	var isComplete: Bool {
-		switch self {
-		case .committedSuccess, .committedFailure, .rejected:
-			true
-		case .pending, .unknown:
-			false
-		}
-	}
-}
-
-// MARK: - GatewayAPI.TransactionCommittedDetailsResponse + Sendable
-extension GatewayAPI.TransactionCommittedDetailsResponse: @unchecked Sendable {}
-
-// MARK: - GatewayAPI.TransactionStatus + Sendable
-extension GatewayAPI.TransactionStatus: @unchecked Sendable {}
-
-// MARK: - SubmitTXFailure
-enum SubmitTXFailure: Sendable, LocalizedError, Equatable {
-	case failedToSubmitTX
-	case invalidTXWasDuplicate(txID: IntentHash)
-
-	var errorDescription: String? {
-		switch self {
-		case .failedToSubmitTX:
-			"Failed to submit transaction"
-		case let .invalidTXWasDuplicate(txID):
-			"Duplicate TX id: \(txID)"
-		}
-	}
-}
-
-// MARK: - TXFailureStatus
-enum TXFailureStatus: LocalizedError, Sendable, Hashable {
-	case permanentlyRejected(reason: Reason)
-	case temporarilyRejected(currentEpoch: Epoch)
-	case failed(reason: Reason)
-
-	var errorDescription: String? {
-		switch self {
-		case .permanentlyRejected: "Permanently Rejected"
-		case .temporarilyRejected: "Temporarily Rejected"
-		case .failed: "Failed"
-		}
-	}
-}
-
-// MARK: TXFailureStatus.Reason
-extension TXFailureStatus {
-	enum Reason: Sendable, Hashable, Equatable {
-		enum ApplicationError: Equatable, Sendable, Hashable {
-			enum WorktopError: Sendable, Hashable, Equatable {
-				case assertionFailed
-			}
-
-			case worktopError(WorktopError)
-		}
-
-		case applicationError(ApplicationError)
-		case unknown
-	}
-}
-
-extension TXFailureStatus.Reason {
-	init(_ rawError: String?) {
-		guard let rawError else {
-			self = .unknown
-			return
-		}
-
-		if rawError.contains("AssertionFailed") {
-			self = .applicationError(.worktopError(.assertionFailed))
-		} else {
-			self = .unknown
-		}
-	}
 }

--- a/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Test.swift
+++ b/RadixWallet/Clients/SubmitTransactionClient/SubmitTransactionClient+Test.swift
@@ -12,13 +12,15 @@ extension SubmitTransactionClient: TestDependencyKey {
 
 	static let testValue = Self(
 		submitTransaction: unimplemented("\(Self.self).submitTransaction"),
-		hasTXBeenCommittedSuccessfully: unimplemented("\(Self.self).hasTXBeenCommittedSuccessfully")
+		pollTransactionStatus: unimplemented("\(Self.self).pollTransactionStatus")
 	)
 
 	static let noop = Self(
 		submitTransaction: { _ in
 			throw NoopError()
 		},
-		hasTXBeenCommittedSuccessfully: { _ in }
+		pollTransactionStatus: { _ in
+			throw NoopError()
+		}
 	)
 }

--- a/RadixWallet/Clients/TransactionClient/Models/TransactionModels.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionModels.swift
@@ -109,11 +109,11 @@ struct NotarizeTransactionRequest: Sendable, Hashable {
 
 // MARK: - NotarizeTransactionResponse
 struct NotarizeTransactionResponse: Sendable, Hashable {
-	let notarized: CompiledNotarizedIntent
+	let notarized: NotarizedTransaction
 	let intent: TransactionIntent
 	let txID: IntentHash
 	init(
-		notarized: CompiledNotarizedIntent,
+		notarized: NotarizedTransaction,
 		intent: TransactionIntent,
 		txID: IntentHash
 	) {

--- a/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
@@ -141,17 +141,15 @@ extension TransactionClient {
 
 			let notarySignature = try request.notary.signature(for: signedIntentHash.hash.data)
 
-			let uncompiledNotarized = try NotarizedTransaction(
+			let notarizedTransaction = try NotarizedTransaction(
 				signedIntent: signedTransactionIntent,
 				notarySignature: NotarySignature(signature: .ed25519(value: .init(bytes: .init(bytes: notarySignature))))
 			)
 
-			let compiledNotarizedTXIntent = uncompiledNotarized.compile()
-
 			let txID = request.transactionIntent.hash()
 
 			return .init(
-				notarized: compiledNotarizedTXIntent,
+				notarized: notarizedTransaction,
 				intent: request.transactionIntent,
 				txID: txID
 			)

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -160,7 +160,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 			dismissCurrentModalAndRequest(request, for: &state)
 			switch response {
 			case .success:
-				return .send(.internal(.presentResponseSuccessView(dappMetadata, txID, request.route)))
+				return delayedShortEffect(for: .internal(.presentResponseSuccessView(dappMetadata, txID, request.route)))
 			case .failure:
 				return delayedMediumEffect(internal: .presentQueuedRequestIfNeeded)
 			}
@@ -244,7 +244,7 @@ struct DappInteractor: Sendable, FeatureReducer {
 				return sendResponseToDappEffect(responseToDapp, for: request, dappMetadata: dappMetadata)
 			case let .dismiss(dappMetadata, txID):
 				dismissCurrentModalAndRequest(request, for: &state)
-				return .send(.internal(.presentResponseSuccessView(dappMetadata, txID, request.route)))
+				return delayedShortEffect(for: .internal(.presentResponseSuccessView(dappMetadata, txID, request.route)))
 			case .dismissSilently:
 				dismissCurrentModalAndRequest(request, for: &state)
 				return delayedMediumEffect(internal: .presentQueuedRequestIfNeeded)

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction+View.swift
@@ -15,8 +15,7 @@ extension SubmitTransaction.State {
 extension SubmitTransaction.State.TXStatus {
 	var display: String {
 		switch self {
-		case .failed(.applicationError(.worktopError(.assertionFailed))),
-		     .permanentlyRejected(.applicationError(.worktopError(.assertionFailed))):
+		case .failed(.worktopError), .permanentlyRejected(.worktopError):
 			L10n.TransactionStatus.AssertionFailure.text
 		case .failed:
 			L10n.TransactionStatus.Failed.text

--- a/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/SubmitTransaction/SubmitTransaction.swift
@@ -16,8 +16,8 @@ struct SubmitTransaction: Sendable, FeatureReducer {
 			case submitted
 			case committedSuccessfully
 			case temporarilyRejected(remainingProcessingTime: Int)
-			case permanentlyRejected(TXFailureStatus.Reason)
-			case failed(TXFailureStatus.Reason)
+			case permanentlyRejected(TransactionStatusReason)
+			case failed(TransactionStatusReason)
 		}
 
 		let notarizedTX: NotarizeTransactionResponse
@@ -80,13 +80,10 @@ struct SubmitTransaction: Sendable, FeatureReducer {
 		switch viewAction {
 		case .appeared:
 			state.status = .submitting
-			return .run { [txID = state.notarizedTX.txID, notarized = state.notarizedTX.notarized] send in
+			return .run { [notarized = state.notarizedTX.notarized] send in
 				await send(.internal(.submitTXResult(
 					TaskResult {
-						try await submitTXClient.submitTransaction(.init(
-							txID: txID,
-							compiledNotarizedTXIntent: notarized
-						))
+						try await submitTXClient.submitTransaction(notarized)
 					}
 				)))
 			}
@@ -128,23 +125,20 @@ struct SubmitTransaction: Sendable, FeatureReducer {
 		case let .submitTXResult(.success(txID)):
 			state.status = .submitted
 			return .run { [endEpoch = state.notarizedTX.intent.header.endEpochExclusive] send in
-				do {
-					try await submitTXClient.hasTXBeenCommittedSuccessfully(txID)
+				let status = try await submitTXClient.pollTransactionStatus(txID)
+				switch status {
+				case .success:
 					await send(.internal(.statusUpdate(.committedSuccessfully)))
-				} catch let error as TXFailureStatus {
-					// Error is always TXFailureStatus, just that it is erased to generic Error
-					switch error {
-					case let .permanentlyRejected(reason):
-						await send(.internal(.statusUpdate(.permanentlyRejected(reason))))
-					case let .temporarilyRejected(epoch):
-						await send(.internal(.statusUpdate(
-							.temporarilyRejected(
-								remainingProcessingTime: Int(endEpoch - epoch) * epochDurationInMinutes
-							)
-						)))
-					case let .failed(reason):
-						await send(.internal(.statusUpdate(.failed(reason))))
-					}
+				case let .permanentlyRejected(reason):
+					await send(.internal(.statusUpdate(.permanentlyRejected(reason))))
+				case let .temporarilyRejected(epoch):
+					await send(.internal(.statusUpdate(
+						.temporarilyRejected(
+							remainingProcessingTime: Int(endEpoch - epoch) * epochDurationInMinutes
+						)
+					)))
+				case let .failed(reason):
+					await send(.internal(.statusUpdate(.failed(reason))))
 				}
 			}
 			.cancellable(id: CancellableId.transactionStatus, cancelInFlight: true)

--- a/RadixWalletTests/Clients/FaucetClientTests/FaucetClientTests.swift
+++ b/RadixWalletTests/Clients/FaucetClientTests/FaucetClientTests.swift
@@ -129,9 +129,9 @@ final class FaucetClientTests: TestCase {
 			}
 			$0.userDefaults = userDefaults
 			$0.transactionClient.notarizeTransaction = { _ in
-				try NotarizeTransactionResponse(notarized: CompiledNotarizedIntent.sample, intent: TransactionIntent.sample, txID: IntentHash.sample)
+				NotarizeTransactionResponse(notarized: NotarizedTransaction.sample, intent: TransactionIntent.sample, txID: IntentHash.sample)
 			}
-			$0.submitTXClient.hasTXBeenCommittedSuccessfully = { _ in }
+			$0.submitTXClient.pollTransactionStatus = { _ in .success }
 			$0.gatewaysClient.getCurrentGateway = { .enkinet }
 		} operation: {
 			try await sut.getFreeXRD(.init(recipientAccountAddress: acco0))


### PR DESCRIPTION
Jira ticket: [ABW-3858](https://radixdlt.atlassian.net/browse/ABW-3858)

## Dependencies
Depends on https://github.com/radixdlt/babylon-wallet-ios/pull/1234

## Description
Use SargonOS to submit a transaction and then poll for its status.
Also, fixes an issue where the `Completion.View` was displayed full screen on iOS 18.

## Video

https://github.com/user-attachments/assets/d1416f64-5f07-44f7-a454-985b30fbc413

## Screenshot

| Before | After |
| - | - |
| <img src=https://github.com/user-attachments/assets/86fe1861-7f92-483d-944e-97f05d4111d2 width=250> | <img src=https://github.com/user-attachments/assets/0d7284d8-e609-4cfc-8509-21efd7bec32c width=250> |




[ABW-3858]: https://radixdlt.atlassian.net/browse/ABW-3858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ