### PR TITLE
[fix] Send correct error message from TX preview failure

### DIFF
--- a/RadixWallet/Clients/TransactionClient/Models/TransactionFailure.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionFailure.swift
@@ -33,8 +33,8 @@ extension TransactionFailure {
 			}
 
 		case .failedToPrepareTXReview(.failedToExtractTXReceiptBytes),
-		     .failedToPrepareTXReview(.failedToGenerateTXReview),
-		     .failedToPrepareTXReview(.failedToRetrieveTXReceipt),
+		     .failedToPrepareTXReview(.abortedTXReview),
+		     .failedToPrepareTXReview(.failedTXPreview),
 		     .failedToPrepareTXReview(.manifestWithReservedInstructions),
 		     .failedToPrepareTXReview(.oneOfRecevingAccountsDoesNotAllowDeposits):
 			(errorKind: .failedToPrepareTransaction, message: self.errorDescription)
@@ -77,9 +77,9 @@ extension TransactionFailure {
 extension TransactionFailure {
 	enum FailedToPreviewTXReview: Sendable, LocalizedError, Equatable {
 		case failedSigning(FailedToPrepareForTXSigning)
-		case failedToRetrieveTXReceipt(String)
+		case abortedTXReview(Error)
+		case failedTXPreview(String)
 		case failedToExtractTXReceiptBytes
-		case failedToGenerateTXReview(Error)
 		case manifestWithReservedInstructions(String)
 		case oneOfRecevingAccountsDoesNotAllowDeposits
 
@@ -87,12 +87,12 @@ extension TransactionFailure {
 			switch self {
 			case let .failedSigning(error):
 				error.errorDescription
+			case let .abortedTXReview(error):
+				"Transaction review aborted: \(error.localizedDescription)"
+			case let .failedTXPreview(message):
+				"Error when generating TX preview: \(message)"
 			case .failedToExtractTXReceiptBytes:
 				"Failed to extract TX review bytes"
-			case let .failedToGenerateTXReview(error):
-				"ET failed to generate TX review: \(error.localizedDescription)"
-			case let .failedToRetrieveTXReceipt(message):
-				"Failed to retrive TX receipt from gateway: \(message)"
 			case .manifestWithReservedInstructions:
 				"Transaction Manifest contains forbidden instructions"
 			case .oneOfRecevingAccountsDoesNotAllowDeposits:

--- a/RadixWallet/Clients/TransactionClient/Models/TransactionFailure.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionFailure.swift
@@ -32,8 +32,7 @@ extension TransactionFailure {
 				(errorKind: .failedToPrepareTransaction, message: error.errorDescription)
 			}
 
-		case .failedToPrepareTXReview(.failedToRetrieveTXPreview),
-		     .failedToPrepareTXReview(.failedToExtractTXReceiptBytes),
+		case .failedToPrepareTXReview(.failedToExtractTXReceiptBytes),
 		     .failedToPrepareTXReview(.failedToGenerateTXReview),
 		     .failedToPrepareTXReview(.failedToRetrieveTXReceipt),
 		     .failedToPrepareTXReview(.manifestWithReservedInstructions),
@@ -78,7 +77,6 @@ extension TransactionFailure {
 extension TransactionFailure {
 	enum FailedToPreviewTXReview: Sendable, LocalizedError, Equatable {
 		case failedSigning(FailedToPrepareForTXSigning)
-		case failedToRetrieveTXPreview(Error)
 		case failedToRetrieveTXReceipt(String)
 		case failedToExtractTXReceiptBytes
 		case failedToGenerateTXReview(Error)
@@ -89,8 +87,6 @@ extension TransactionFailure {
 			switch self {
 			case let .failedSigning(error):
 				error.errorDescription
-			case let .failedToRetrieveTXPreview(error):
-				"Failed to retrieve TX review from gateway: \(error.localizedDescription)"
 			case .failedToExtractTXReceiptBytes:
 				"Failed to extract TX review bytes"
 			case let .failedToGenerateTXReview(error):

--- a/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
@@ -363,7 +363,11 @@ extension TransactionFailure {
 			.failedToPrepareTXReview(.failedToExtractTXReceiptBytes)
 
 		default:
-			.failedToPrepareTXReview(.failedToRetrieveTXReceipt("Unknown reason"))
+			if let code = commonError?.errorCode {
+				.failedToPrepareTXReview(.failedToRetrieveTXReceipt("Unknown reason, code: \(code)"))
+			} else {
+				.failedToPrepareTXReview(.failedToRetrieveTXReceipt("Unknown reason"))
+			}
 		}
 	}
 }

--- a/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
@@ -356,8 +356,8 @@ extension TransactionFailure {
 		case .OneOfReceivingAccountsDoesNotAllowDeposits:
 			.failedToPrepareTXReview(.oneOfRecevingAccountsDoesNotAllowDeposits)
 
-		case .FailedTransactionPreview:
-			.failedToPrepareTXReview(.failedToRetrieveTXReceipt("Unknown reason"))
+		case let .FailedTransactionPreview(message):
+			.failedToPrepareTXReview(.failedToRetrieveTXReceipt(message))
 
 		case .FailedToExtractTransactionReceiptBytes:
 			.failedToPrepareTXReview(.failedToExtractTXReceiptBytes)

--- a/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
+++ b/RadixWallet/Clients/TransactionClient/TransactionClient+Live.swift
@@ -357,16 +357,16 @@ extension TransactionFailure {
 			.failedToPrepareTXReview(.oneOfRecevingAccountsDoesNotAllowDeposits)
 
 		case let .FailedTransactionPreview(message):
-			.failedToPrepareTXReview(.failedToRetrieveTXReceipt(message))
+			.failedToPrepareTXReview(.failedTXPreview(message))
 
 		case .FailedToExtractTransactionReceiptBytes:
 			.failedToPrepareTXReview(.failedToExtractTXReceiptBytes)
 
 		default:
 			if let code = commonError?.errorCode {
-				.failedToPrepareTXReview(.failedToRetrieveTXReceipt("Unknown reason, code: \(code)"))
+				.failedToPrepareTXReview(.failedTXPreview("Unknown reason, code: \(code)"))
 			} else {
-				.failedToPrepareTXReview(.failedToRetrieveTXReceipt("Unknown reason"))
+				.failedToPrepareTXReview(.failedTXPreview("Unknown reason"))
 			}
 		}
 	}

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -288,7 +288,11 @@ struct TransactionReview: Sendable, FeatureReducer {
 		case let .previewLoaded(.failure(error)):
 			loggerGlobal.error("Transaction preview failed, error: \(error)")
 			errorQueue.schedule(TransactionReviewFailure(underylying: error))
-			return .send(.delegate(.failed(TransactionFailure.failedToPrepareTXReview(.failedToGenerateTXReview(error)))))
+			if let txFailure = error as? TransactionFailure {
+				return .send(.delegate(.failed(txFailure)))
+			} else {
+				return .send(.delegate(.failed(TransactionFailure.failedToPrepareTXReview(.abortedTXReview(error)))))
+			}
 
 		case let .previewLoaded(.success(preview)):
 			let reviewedTransaction = ReviewedTransaction(


### PR DESCRIPTION
## Changelog
- If the transaction analysis fails with `FailedTransactionPreview`, we should send back the error message that Sargon determines (instead of `"Unknown reason"`).
- Stop [appending](https://github.com/radixdlt/babylon-wallet-ios/blob/main/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift#L288-L291) `ET failed to generate TX review` before any error parsed during TX preview loading.  
- If the error is an unknown `CommonError` (meaning a specific message cannot be determined for it for this flow), include its code in the message sent back to the dApp.
- Updates error messages to be more descriptive


## Before vs After
Before
```
"message": "ET failed to generate TX review: Failed to retrive TX receipt from gateway: Unknown reason"
"message": "ET failed to generate TX review: Transaction Manifest contains forbidden instructions"
```

After
```
"message": "Error when generating TX preview: Unknown reason, code: 10093"
"message": "Transaction Manifest contains forbidden instructions"  
```

| Before | After |
| -- | -- |
| <img src=https://github.com/user-attachments/assets/96858928-0e5e-44cd-aaaf-6d4c0f0f27a3 width=200> | <img src=https://github.com/user-attachments/assets/750f3efe-0994-4ff8-b728-7dc462007217 width=200> |
