### PR TITLE
Determine fee payer update

### DIFF
--- a/RadixWallet/Clients/GatewayAPI/GatewayAPI+Utils.swift
+++ b/RadixWallet/Clients/GatewayAPI/GatewayAPI+Utils.swift
@@ -1,37 +1,37 @@
-// MARK: - GatewayAPI.StateEntityDetailsResponse + Sendable
+// MARK: - GatewayAPI.StateEntityDetailsResponse + @unchecked Sendable
 extension GatewayAPI.StateEntityDetailsResponse: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.NonFungibleResourcesCollectionItemVaultAggregatedVaultItem + Sendable
+// MARK: - GatewayAPI.NonFungibleResourcesCollectionItemVaultAggregatedVaultItem + @unchecked Sendable
 extension GatewayAPI.NonFungibleResourcesCollectionItemVaultAggregatedVaultItem: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.NonFungibleResourcesCollectionItem + Sendable
+// MARK: - GatewayAPI.NonFungibleResourcesCollectionItem + @unchecked Sendable
 extension GatewayAPI.NonFungibleResourcesCollectionItem: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.FungibleResourcesCollectionItemVaultAggregatedVaultItem + Sendable
+// MARK: - GatewayAPI.FungibleResourcesCollectionItemVaultAggregatedVaultItem + @unchecked Sendable
 extension GatewayAPI.FungibleResourcesCollectionItemVaultAggregatedVaultItem: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.FungibleResourcesCollectionItem + Sendable
+// MARK: - GatewayAPI.FungibleResourcesCollectionItem + @unchecked Sendable
 extension GatewayAPI.FungibleResourcesCollectionItem: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.LedgerState + Sendable
+// MARK: - GatewayAPI.LedgerState + @unchecked Sendable
 extension GatewayAPI.LedgerState: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.StateEntityDetailsResponseItem + Sendable
+// MARK: - GatewayAPI.StateEntityDetailsResponseItem + @unchecked Sendable
 extension GatewayAPI.StateEntityDetailsResponseItem: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.FungibleResourcesCollectionItemVaultAggregated + Sendable
+// MARK: - GatewayAPI.FungibleResourcesCollectionItemVaultAggregated + @unchecked Sendable
 extension GatewayAPI.FungibleResourcesCollectionItemVaultAggregated: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.NonFungibleResourcesCollectionItemVaultAggregated + Sendable
+// MARK: - GatewayAPI.NonFungibleResourcesCollectionItemVaultAggregated + @unchecked Sendable
 extension GatewayAPI.NonFungibleResourcesCollectionItemVaultAggregated: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.EntityMetadataItem + Sendable
+// MARK: - GatewayAPI.EntityMetadataItem + @unchecked Sendable
 extension GatewayAPI.EntityMetadataItem: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.AccountLockerVaultCollectionItem + Sendable
+// MARK: - GatewayAPI.AccountLockerVaultCollectionItem + @unchecked Sendable
 extension GatewayAPI.AccountLockerVaultCollectionItem: @unchecked Sendable {}
 
-// MARK: - GatewayAPI.StateAccountLockersTouchedAtResponse + Sendable
+// MARK: - GatewayAPI.StateAccountLockersTouchedAtResponse + @unchecked Sendable
 extension GatewayAPI.StateAccountLockersTouchedAtResponse: @unchecked Sendable {}
 
 extension GatewayAPI.StateEntityDetailsResponseItemDetails {

--- a/RadixWallet/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Live.swift
+++ b/RadixWallet/Clients/GatewayAPI/GatewayAPIClient/GatewayAPIClient+Live.swift
@@ -1,4 +1,4 @@
-// MARK: - Date + Sendable
+// MARK: - Date + @unchecked Sendable
 extension Date: @unchecked Sendable {}
 
 extension JSONDecoder {

--- a/RadixWallet/Clients/HomeCardsClient/HomeCardsClient+Live.swift
+++ b/RadixWallet/Clients/HomeCardsClient/HomeCardsClient+Live.swift
@@ -47,7 +47,7 @@ extension HomeCardsClient: DependencyKey {
 	}()
 }
 
-// MARK: - HomeCardsManager + Sendable
+// MARK: - HomeCardsManager + @unchecked Sendable
 extension HomeCardsManager: @unchecked Sendable {}
 
 // MARK: - HomeCardsStorage

--- a/RadixWallet/Clients/PasteboardClient/PasteboardClient+Live.swift
+++ b/RadixWallet/Clients/PasteboardClient/PasteboardClient+Live.swift
@@ -21,5 +21,5 @@ extension PasteboardClient: DependencyKey {
 	}
 }
 
-// MARK: - Pasteboard + Sendable
+// MARK: - Pasteboard + @unchecked Sendable
 extension Pasteboard: @unchecked Sendable {}

--- a/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
+++ b/RadixWallet/Clients/SecureStorageClient/SecureStorageClient+Live.swift
@@ -1,9 +1,9 @@
 import Sargon
 
-// MARK: - KeychainAccess.Accessibility + Sendable
+// MARK: - KeychainAccess.Accessibility + @unchecked Sendable
 extension KeychainAccess.Accessibility: @unchecked Sendable {}
 
-// MARK: - KeychainAccess.AuthenticationPolicy + Sendable
+// MARK: - KeychainAccess.AuthenticationPolicy + @unchecked Sendable
 extension KeychainAccess.AuthenticationPolicy: @unchecked Sendable {}
 
 // MARK: - SecureStorageError

--- a/RadixWallet/Clients/TransactionClient/Models/TransactionModels.swift
+++ b/RadixWallet/Clients/TransactionClient/Models/TransactionModels.swift
@@ -246,6 +246,7 @@ struct DetermineFeePayerRequest: Sendable {
 	let signingFactors: SigningFactors
 	let signingPurpose: SigningPurpose
 	let manifest: TransactionManifest
+	let accountWithdraws: [AccountAddress: [ResourceIndicator]]
 }
 
 // MARK: - DetermineFeePayerResponse

--- a/RadixWallet/Features/AppFeature/Overlay/HUD+View.swift
+++ b/RadixWallet/Features/AppFeature/Overlay/HUD+View.swift
@@ -70,7 +70,7 @@ extension HUD {
 	}
 }
 
-// MARK: - SwiftUI.Animation + Sendable
+// MARK: - SwiftUI.Animation + @unchecked Sendable
 extension SwiftUI.Animation: @unchecked Sendable {}
 
 extension SwiftUI.Animation {

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 typealias RequestEnvelope = DappInteractionClient.RequestEnvelope
 
-// MARK: Identifiable
+// MARK: - RequestEnvelope + Identifiable
 extension RequestEnvelope: Identifiable {
 	typealias ID = WalletInteractionId
 	var id: ID {

--- a/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
+++ b/RadixWallet/Features/TransactionReviewFeature/TransactionReview.swift
@@ -521,7 +521,8 @@ extension TransactionReview {
 						transactionSigners: reviewedTransaction.transactionSigners,
 						signingFactors: reviewedTransaction.signingFactors,
 						signingPurpose: .signTransaction(state.signTransactionPurpose),
-						manifest: reviewedTransaction.transactionManifest
+						manifest: reviewedTransaction.transactionManifest,
+						accountWithdraws: reviewedTransaction.accountWithdraws
 					))
 				}
 

--- a/RadixWallet/Prelude/Extensions/AsyncExtension+Sendable.swift
+++ b/RadixWallet/Prelude/Extensions/AsyncExtension+Sendable.swift
@@ -1,8 +1,8 @@
-// MARK: - AnyAsyncIterator + Sendable
+// MARK: - AnyAsyncIterator + @unchecked Sendable
 extension AnyAsyncIterator: @unchecked Sendable where Element: Sendable {}
 
-// MARK: - AnyAsyncSequence + Sendable
+// MARK: - AnyAsyncSequence + @unchecked Sendable
 extension AnyAsyncSequence: @unchecked Sendable where Element: Sendable {}
 
-// MARK: - AsyncThrowingStream.Iterator + Sendable
+// MARK: - AsyncThrowingStream.Iterator + @unchecked Sendable
 extension AsyncThrowingStream.Iterator: @unchecked Sendable where Element: Sendable {}

--- a/RadixWallet/Prelude/Extensions/BigUInt+Extra.swift
+++ b/RadixWallet/Prelude/Extensions/BigUInt+Extra.swift
@@ -1,4 +1,4 @@
-// MARK: - BigUInt + Sendable
+// MARK: - BigUInt + @unchecked Sendable
 extension BigUInt: @unchecked Sendable {}
 
 // MARK: - BigUInt.Error

--- a/RadixWallet/Prelude/Extensions/CryptoKit/PublicKey+Extensions.swift
+++ b/RadixWallet/Prelude/Extensions/CryptoKit/PublicKey+Extensions.swift
@@ -12,11 +12,11 @@ extension Curve25519.Signing.PublicKey: CustomDumpStringConvertible, CustomDebug
 	}
 }
 
-// MARK: - Data + Sendable
+// MARK: - Data + @unchecked Sendable
 extension Data: @unchecked Sendable {}
 typealias EdDSASignature = Data
 
-// MARK: - Curve25519.Signing.PublicKey + Sendable
+// MARK: - Curve25519.Signing.PublicKey + @unchecked Sendable
 extension Curve25519.Signing.PublicKey: @unchecked Sendable {}
 
 // MARK: - Curve25519.Signing.PublicKey + Hashable
@@ -30,7 +30,7 @@ extension Curve25519.Signing.PublicKey: Hashable {
 	}
 }
 
-// MARK: - Curve25519.Signing.PrivateKey + Sendable
+// MARK: - Curve25519.Signing.PrivateKey + @unchecked Sendable
 extension Curve25519.Signing.PrivateKey: @unchecked Sendable {}
 
 // MARK: - Curve25519.Signing.PrivateKey + Hashable

--- a/RadixWallet/Prelude/Extensions/Either+Extra.swift
+++ b/RadixWallet/Prelude/Extensions/Either+Extra.swift
@@ -1,4 +1,4 @@
-// MARK: - Either + Sendable
+// MARK: - Either + @unchecked Sendable
 extension Either: @unchecked Sendable {}
 
 extension Either {

--- a/RadixWallet/Prelude/Extensions/NonEmpty+Extra.swift
+++ b/RadixWallet/Prelude/Extensions/NonEmpty+Extra.swift
@@ -1,4 +1,4 @@
-// MARK: - NonEmpty + Sendable
+// MARK: - NonEmpty + @unchecked Sendable
 extension NonEmpty: @unchecked Sendable where Element: Sendable {}
 
 extension NonEmptyString {

--- a/RadixWallet/Prelude/JSON/JSONDecoder+Live.swift
+++ b/RadixWallet/Prelude/JSON/JSONDecoder+Live.swift
@@ -12,7 +12,7 @@ extension JSONDecoder: DependencyKey {
 	public static var testValue: Value { liveValue }
 }
 
-// MARK: - JSONDecoder + Sendable
+// MARK: - JSONDecoder + @unchecked Sendable
 extension JSONDecoder: @unchecked Sendable {}
 
 extension DependencyValues {

--- a/RadixWallet/Prelude/JSON/JSONEncoder+Live.swift
+++ b/RadixWallet/Prelude/JSON/JSONEncoder+Live.swift
@@ -12,7 +12,7 @@ extension JSONEncoder: DependencyKey {
 	public static var testValue: Value { liveValue }
 }
 
-// MARK: - JSONEncoder + Sendable
+// MARK: - JSONEncoder + @unchecked Sendable
 extension JSONEncoder: @unchecked Sendable {}
 
 extension DependencyValues {

--- a/RadixWallet/RadixConnect/RadixConnect/RTC/Infrastructure/AsyncWebSocket.swift
+++ b/RadixWallet/RadixConnect/RadixConnect/RTC/Infrastructure/AsyncWebSocket.swift
@@ -1,10 +1,10 @@
 import Network
 import WebRTC
 
-// MARK: - DispatchQueue.SchedulerOptions + Sendable
+// MARK: - DispatchQueue.SchedulerOptions + @unchecked Sendable
 extension DispatchQueue.SchedulerOptions: @unchecked Sendable {}
 
-// MARK: - DispatchQueue.SchedulerTimeType.Stride + Sendable
+// MARK: - DispatchQueue.SchedulerTimeType.Stride + @unchecked Sendable
 extension DispatchQueue.SchedulerTimeType.Stride: @unchecked Sendable {}
 
 // MARK: - AsyncWebSocket

--- a/RadixWallet/RadixConnect/RadixConnect/RTC/Infrastructure/WebRTC/RTCDataChannel+Delegate.swift
+++ b/RadixWallet/RadixConnect/RadixConnect/RTC/Infrastructure/WebRTC/RTCDataChannel+Delegate.swift
@@ -1,6 +1,6 @@
 import WebRTC
 
-// MARK: - RTCDataChannel + Sendable
+// MARK: - RTCDataChannel + @unchecked Sendable
 extension RTCDataChannel: @unchecked Sendable {}
 
 // MARK: - RTCDataChannel + DataChannel

--- a/RadixWallet/RadixConnect/RadixConnect/RTC/Infrastructure/WebRTC/RTCPeerConnection+PeerConnection.swift
+++ b/RadixWallet/RadixConnect/RadixConnect/RTC/Infrastructure/WebRTC/RTCPeerConnection+PeerConnection.swift
@@ -35,7 +35,7 @@ extension RTCPeerConnection: PeerConnection {
 	}
 }
 
-// MARK: - RTCPeerConnection + Sendable
+// MARK: - RTCPeerConnection + @unchecked Sendable
 extension RTCPeerConnection: @unchecked Sendable {}
 
 extension RTCMediaConstraints {

--- a/RadixWallet/RadixConnect/RadixConnectModels/Types.swift
+++ b/RadixWallet/RadixConnect/RadixConnectModels/Types.swift
@@ -5,7 +5,7 @@ import WebRTC
 enum PeerConnectionIdTag {}
 typealias PeerConnectionID = Tagged<PeerConnectionIdTag, String>
 
-// MARK: Sendable
+// MARK: - PeerConnectionID + Sendable
 extension PeerConnectionID: Sendable {}
 
 extension LinkConnectionQRData {

--- a/RadixWalletTests/Clients/TransactionClientTests/TransactionClientTests.swift
+++ b/RadixWalletTests/Clients/TransactionClientTests/TransactionClientTests.swift
@@ -164,7 +164,8 @@ final class TransactionClientTests: TestCase {
 					transactionSigners: defaultSigners,
 					signingFactors: [.device: .init(rawValue: Set(defaultFactors))!],
 					signingPurpose: .signTransaction(.manifestFromDapp),
-					manifest: TransactionManifest.sample
+					manifest: TransactionManifest.sample,
+					accountWithdraws: [:]
 				),
 				allFeePayerCandidates: .init(rawValue: .init(uncheckedUniqueElements: allFeePayerCandidates))!,
 				involvedEntities: .init(
@@ -172,7 +173,8 @@ final class TransactionClientTests: TestCase {
 					accountsRequiringAuth: OrderedSet(signersAfterAnalysis),
 					accountsWithdrawnFrom: OrderedSet(signersAfterAnalysis),
 					accountsDepositedInto: OrderedSet(accounts.suffix(2))
-				)
+				),
+				accountWithdraws: [:]
 			)
 		}
 


### PR DESCRIPTION
When determining fee payer take into account the withdrawn XRD amount for the fee payer candidates from which withdraw is happening.
This is very important in the context of account deletion, when all XRDs will be transferred, so then the Wallet should try to use the account into which the deposit is happening.

# Demo
https://github.com/user-attachments/assets/bd430119-d924-4221-ba5e-a4dc2a2a6e72

