### PR TITLE
Update GH actions to use macos 15

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     name: "Test Flight Deploy"
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' && !(contains(github.event.head_commit.message, '[skip cd]') || contains(github.event.head_commit.message, '[cd skip]')) }}
-    runs-on: macos-14-xlarge
+    runs-on: macos-15-xlarge
 
     steps:
       - uses: RDXWorks-actions/checkout@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
           xcode-version: "16.0.0"
 
       - name: "Set up ruby"
-        uses: RDXWorks-actions/setup-ruby@master-upgrade-to-v1-171-0
+        uses: RDXWorks-actions/setup-ruby@master
         with:
           ruby-version: 3.1.2
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       ( github.event.pull_request.draft == false && github.event.action == 'synchronize' ) ||
       ( github.event.action == 'ready_for_review' ) ||
       ( github.event_name == 'push' && github.ref == 'refs/heads/main' )
-    runs-on: macos-14-xlarge
+    runs-on: macos-15-xlarge
 
     steps:
       - uses: RDXWorks-actions/checkout@main
@@ -134,7 +134,7 @@ jobs:
       contents: read
       checks: write
     name: "Unit test"
-    runs-on: macos-14-xlarge
+    runs-on: macos-15-xlarge
     timeout-minutes: 20
 
     needs:


### PR DESCRIPTION
GH removed Xcode 16 from Macos-14 images because policy -> https://github.com/actions/runner-images/issues/10703.