### PR TITLE
Debug Only: Inspect `FactorInstancesCache`

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -48,7 +48,6 @@
 		488A42F02BCAF9AF00F285BC /* Stage2MigrateToSargon+DeviceFactorSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488A42EF2BCAF9AF00F285BC /* Stage2MigrateToSargon+DeviceFactorSource.swift */; };
 		488A42F42BCAFD4200F285BC /* AccountsRecoveredFromScanning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488A42F32BCAFD4200F285BC /* AccountsRecoveredFromScanning.swift */; };
 		489122782B186F61005F2EEE /* AlternativeRectangularButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489122772B186F61005F2EEE /* AlternativeRectangularButtonStyle.swift */; };
-		489FEF912BDD0B80003EC10D /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = 489FEF902BDD0B80003EC10D /* Sargon */; };
 		489FEF932BDD0BA7003EC10D /* Signer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489FEF922BDD0BA7003EC10D /* Signer.swift */; };
 		489FEF952BDD0BEA003EC10D /* SigningPurpose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489FEF942BDD0BEA003EC10D /* SigningPurpose.swift */; };
 		48AB4E842AE19F5B001B238E /* ProfileStore+AsyncSequence+Updates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AB4E832AE19F5B001B238E /* ProfileStore+AsyncSequence+Updates.swift */; };
@@ -63,7 +62,6 @@
 		48AE39EC2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AE39EA2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete+View.swift */; };
 		48AE39ED2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AE39EB2B0CCA7600813CF3 /* RecoverWalletControlWithBDFSComplete.swift */; };
 		48AF19CE2BB71C1600796130 /* IntoSargon+Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AF19CD2BB71C1600796130 /* IntoSargon+Bridge.swift */; };
-		48C845C72BEA6DC600F74DA7 /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = 48C845C62BEA6DC600F74DA7 /* Sargon */; };
 		48C845CA2BEA6E2000F74DA7 /* Stage0MigrateToSargon+Accounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C845C92BEA6E2000F74DA7 /* Stage0MigrateToSargon+Accounts.swift */; };
 		48CFC23F2ADC10D900E77A5C /* PreferenceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48CFBC6E2ADC10D800E77A5C /* PreferenceList.swift */; };
 		48CFC2402ADC10D900E77A5C /* AccountPreferences+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48CFBC6F2ADC10D800E77A5C /* AccountPreferences+Reducer.swift */; };
@@ -739,7 +737,6 @@
 		5B3C48C32C874C8D00DB160D /* Dispatch+Extra.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3C48C22C874C8D00DB160D /* Dispatch+Extra.swift */; };
 		5B43B08B2BDAAD4B00AA1E92 /* AddressDetails+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B43B0892BDAAD4B00AA1E92 /* AddressDetails+View.swift */; };
 		5B43B08C2BDAAD4B00AA1E92 /* AddressDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B43B08A2BDAAD4B00AA1E92 /* AddressDetails.swift */; };
-		5B447E0B2CAAFC2D0063AE39 /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = 5B447E0A2CAAFC2D0063AE39 /* Sargon */; };
 		5B45E2FA2BC45770007C4C84 /* FactorSourceAccess+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B45E2F82BC45770007C4C84 /* FactorSourceAccess+View.swift */; };
 		5B45E2FB2BC45770007C4C84 /* FactorSourceAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B45E2F92BC45770007C4C84 /* FactorSourceAccess.swift */; };
 		5B45E2FE2BC59780007C4C84 /* SignWithFactorSource+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B45E2FC2BC59780007C4C84 /* SignWithFactorSource+View.swift */; };
@@ -755,7 +752,6 @@
 		5B4A1AC42CC0125700679EE6 /* InteractionReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4A1AC32CC0123300679EE6 /* InteractionReview.swift */; };
 		5B4A1AC62CC0151300679EE6 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4A1AC52CC0150D00679EE6 /* HeaderView.swift */; };
 		5B4E1D132CB421EB002FAC2E /* DepositStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4E1D122CB421E3002FAC2E /* DepositStatus.swift */; };
-		5B4E1D1F2CB7FE8E002FAC2E /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = 5B4E1D1E2CB7FE8E002FAC2E /* Sargon */; };
 		5B526ADB2C876E7C00AF8B72 /* AccountLockerClaimDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B526ADA2C876E7C00AF8B72 /* AccountLockerClaimDetails.swift */; };
 		5B526AEC2C89C3C200AF8B72 /* ResourcesVisibilityClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B526AE82C89C3C200AF8B72 /* ResourcesVisibilityClient+Interface.swift */; };
 		5B526AED2C89C3C200AF8B72 /* ResourcesVisibilityClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B526AE92C89C3C200AF8B72 /* ResourcesVisibilityClient+Live.swift */; };
@@ -813,7 +809,6 @@
 		830EA9E52AEB9088004C8051 /* DefaultValueDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830EA9E42AEB9088004C8051 /* DefaultValueDecodable.swift */; };
 		830EA9E72AEBA793004C8051 /* EntitiesVisibilityClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830EA9E62AEBA793004C8051 /* EntitiesVisibilityClient+Live.swift */; };
 		830EA9E92AEBA7C5004C8051 /* EntitiesVisibilityClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830EA9E82AEBA7C5004C8051 /* EntitiesVisibilityClient+Test.swift */; };
-		831F0CED2C21819000D6F5BF /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = 831F0CEC2C21819000D6F5BF /* Sargon */; };
 		831F0CEF2C25728E00D6F5BF /* RadixConnectMobileSessionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831F0CEE2C25728E00D6F5BF /* RadixConnectMobileSessionStorage.swift */; };
 		831F0CF22C25897500D6F5BF /* DappInteractionOriginVerification+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831F0CF12C25897500D6F5BF /* DappInteractionOriginVerification+View.swift */; };
 		831F0CF42C294BAA00D6F5BF /* DeepLinkHandlerClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831F0CF32C294BAA00D6F5BF /* DeepLinkHandlerClient+Live.swift */; };
@@ -839,7 +834,6 @@
 		8397D82D2B46ACB50016365A /* StakeUnitList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8397D82B2B46ACB50016365A /* StakeUnitList.swift */; };
 		839B6C542B21D28400402651 /* ExpandableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B6C532B21D28400402651 /* ExpandableTextView.swift */; };
 		83AAAC6D2B483D1B00222B64 /* StakeSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AAAC6B2B483D1B00222B64 /* StakeSummaryView.swift */; };
-		83B783562C1764AE00AA7930 /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = 83B783552C1764AE00AA7930 /* Sargon */; };
 		83D663B02B271D0100D1AB9E /* TruncationMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D663AF2B271D0100D1AB9E /* TruncationMask.swift */; };
 		83D908AD2C931A7100822CC4 /* SargonSecureStorageDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D908AC2C931A7100822CC4 /* SargonSecureStorageDriver.swift */; };
 		83DFAF2E2B4E8A51008B70CE /* View+Extra.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DFAF2D2B4E8A51008B70CE /* View+Extra.swift */; };
@@ -1190,7 +1184,9 @@
 		A4ECE27A2BEEB01800468BF6 /* CloudBackupClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4ECE2762BEEB01800468BF6 /* CloudBackupClient+Live.swift */; };
 		A4ECE27B2BEEB01800468BF6 /* CloudBackupClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4ECE2772BEEB01800468BF6 /* CloudBackupClient+Test.swift */; };
 		A4F30C942C7CA71400F983D6 /* WithNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F30C932C7CA71400F983D6 /* WithNavigationBar.swift */; };
-		E60D5E1F2C2EFAA2008BCF1F /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = E60D5E1E2C2EFAA2008BCF1F /* Sargon */; };
+		E6027F1E2CE7887A0094139A /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = E6027F1D2CE7887A0094139A /* Sargon */; };
+		E622FF902CE7984B00489BA5 /* DebugFactorInstancesCacheContents+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = E622FF8F2CE7984B00489BA5 /* DebugFactorInstancesCacheContents+View.swift */; };
+		E622FF912CE7984B00489BA5 /* DebugFactorInstancesCacheContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E622FF8E2CE7984B00489BA5 /* DebugFactorInstancesCacheContents.swift */; };
 		E62449D52AFBA61100272C67 /* Home+AccountRow+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62449D32AFBA61100272C67 /* Home+AccountRow+Reducer.swift */; };
 		E62449D62AFBA61100272C67 /* Home+AccountRow+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62449D42AFBA61100272C67 /* Home+AccountRow+View.swift */; };
 		E62BB7632AEA856300D46DAC /* ImportMnemonicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62BB7622AEA856300D46DAC /* ImportMnemonicTests.swift */; };
@@ -1264,7 +1260,6 @@
 		E7A5AC982C09F44C006CB6EC /* ResetWalletClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A5AC972C09F44C006CB6EC /* ResetWalletClient+Live.swift */; };
 		E7A5AC9A2C09F453006CB6EC /* ResetWalletClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A5AC992C09F453006CB6EC /* ResetWalletClient+Test.swift */; };
 		E7A5AC9D2C108F2F006CB6EC /* WalletInteraction+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A5AC9C2C108F2F006CB6EC /* WalletInteraction+Extensions.swift */; };
-		E7AE2D052BF7844300830BAA /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = E695F2DD2BECDD7C00761ACE /* Sargon */; };
 		E7AE2D0A2C05F39800830BAA /* ClaimWallet+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE2D092C05F39800830BAA /* ClaimWallet+Reducer.swift */; };
 		E7AE2D0C2C05F39E00830BAA /* ClaimWallet+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE2D0B2C05F39E00830BAA /* ClaimWallet+View.swift */; };
 		E7AE2D0E2C07359500830BAA /* FullScreenOverlayCoordinator+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE2D0D2C07359500830BAA /* FullScreenOverlayCoordinator+Reducer.swift */; };
@@ -2430,6 +2425,8 @@
 		A4ECE2762BEEB01800468BF6 /* CloudBackupClient+Live.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CloudBackupClient+Live.swift"; sourceTree = "<group>"; };
 		A4ECE2772BEEB01800468BF6 /* CloudBackupClient+Test.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CloudBackupClient+Test.swift"; sourceTree = "<group>"; };
 		A4F30C932C7CA71400F983D6 /* WithNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithNavigationBar.swift; sourceTree = "<group>"; };
+		E622FF8E2CE7984B00489BA5 /* DebugFactorInstancesCacheContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFactorInstancesCacheContents.swift; sourceTree = "<group>"; };
+		E622FF8F2CE7984B00489BA5 /* DebugFactorInstancesCacheContents+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DebugFactorInstancesCacheContents+View.swift"; sourceTree = "<group>"; };
 		E62449D32AFBA61100272C67 /* Home+AccountRow+Reducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Home+AccountRow+Reducer.swift"; sourceTree = "<group>"; };
 		E62449D42AFBA61100272C67 /* Home+AccountRow+View.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Home+AccountRow+View.swift"; sourceTree = "<group>"; };
 		E62BB7622AEA856300D46DAC /* ImportMnemonicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportMnemonicTests.swift; sourceTree = "<group>"; };
@@ -2534,13 +2531,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7AE2D052BF7844300830BAA /* Sargon in Frameworks */,
 				48FFFABE2ADC209100B2B213 /* NukeUI in Frameworks */,
 				48FFFAE72ADC223300B2B213 /* Overture in Frameworks */,
 				48FFFA9F2ADC1F2700B2B213 /* KeychainAccess in Frameworks */,
 				48FFFAF72ADC241A00B2B213 /* Collections in Frameworks */,
 				48FFFAF92ADC241A00B2B213 /* DequeModule in Frameworks */,
-				489FEF912BDD0B80003EC10D /* Sargon in Frameworks */,
 				48FFFAAB2ADC1FE900B2B213 /* DependenciesAdditions in Frameworks */,
 				48FFFAA22ADC1F5D00B2B213 /* Algorithms in Frameworks */,
 				48FFFAC12ADC20C400B2B213 /* JSONPreview in Frameworks */,
@@ -2548,10 +2543,7 @@
 				48FFFADE2ADC21F500B2B213 /* FileLogging in Frameworks */,
 				48FFFACF2ADC216400B2B213 /* CollectionConcurrencyKit in Frameworks */,
 				48FFFAB12ADC203700B2B213 /* WebRTC in Frameworks */,
-				5B4E1D1F2CB7FE8E002FAC2E /* Sargon in Frameworks */,
-				831F0CED2C21819000D6F5BF /* Sargon in Frameworks */,
 				48FFFB0D2ADC744700B2B213 /* TextBuilder in Frameworks */,
-				5B447E0B2CAAFC2D0063AE39 /* Sargon in Frameworks */,
 				48FFFB0A2ADC721800B2B213 /* Atomics in Frameworks */,
 				48FFFB002ADC25A200B2B213 /* BigInt in Frameworks */,
 				A47571FF2B29B0860059A95D /* IOSSecuritySuite in Frameworks */,
@@ -2563,15 +2555,13 @@
 				48FFFAB72ADC207B00B2B213 /* NavigationTransitions in Frameworks */,
 				5B634A942C91D2A0004B2FBC /* ScreenshotPreventing in Frameworks */,
 				48FFFA992ADC1EEC00B2B213 /* AsyncExtensions in Frameworks */,
-				83B783562C1764AE00AA7930 /* Sargon in Frameworks */,
 				E63D123D2ADD1FC00001CBB1 /* SwiftUIIntrospect in Frameworks */,
 				E6A0B04B2BF23C7000617DAC /* IdentifiedCollections in Frameworks */,
 				48FFFABC2ADC209100B2B213 /* NukeExtensions in Frameworks */,
 				A41557502B757C5E0040AD4E /* ComposableArchitecture in Frameworks */,
+				E6027F1E2CE7887A0094139A /* Sargon in Frameworks */,
 				48FFFAFD2ADC241A00B2B213 /* HeapModule in Frameworks */,
-				48C845C72BEA6DC600F74DA7 /* Sargon in Frameworks */,
 				48FFFAD52ADC21B900B2B213 /* LegibleError in Frameworks */,
-				E60D5E1F2C2EFAA2008BCF1F /* Sargon in Frameworks */,
 				48FFFB082ADC6FD300B2B213 /* SwiftUINavigationCore in Frameworks */,
 				48FFFAD82ADC21D200B2B213 /* NonEmpty in Frameworks */,
 				48FFFAE12ADC220F00B2B213 /* Tagged in Frameworks */,
@@ -5401,6 +5391,7 @@
 		48D5F3852BD8DDB9000DE964 /* Children */ = {
 			isa = PBXGroup;
 			children = (
+				E6027F1F2CE797500094139A /* DebugFactorInstancesCacheContents */,
 				48D5F37B2BD8DDB9000DE964 /* DebugKeychainContents */,
 				48D5F37E2BD8DDB9000DE964 /* DebugKeychainTest */,
 				48D5F3812BD8DDB9000DE964 /* DebugManageFactorSourcesFeature */,
@@ -6363,6 +6354,15 @@
 			path = CloudBackupClient;
 			sourceTree = "<group>";
 		};
+		E6027F1F2CE797500094139A /* DebugFactorInstancesCacheContents */ = {
+			isa = PBXGroup;
+			children = (
+				E622FF8E2CE7984B00489BA5 /* DebugFactorInstancesCacheContents.swift */,
+				E622FF8F2CE7984B00489BA5 /* DebugFactorInstancesCacheContents+View.swift */,
+			);
+			path = DebugFactorInstancesCacheContents;
+			sourceTree = "<group>";
+		};
 		E634CA2C2AFD259000C43DB7 /* DebugKeychainContents */ = {
 			isa = PBXGroup;
 			children = (
@@ -7039,14 +7039,9 @@
 				A47571FE2B29B0860059A95D /* IOSSecuritySuite */,
 				A415574F2B757C5E0040AD4E /* ComposableArchitecture */,
 				5B1C4FD42BBB0B0C00B9436F /* AppsFlyerLib-Strict */,
-				E695F2DD2BECDD7C00761ACE /* Sargon */,
 				E6A0B04A2BF23C7000617DAC /* IdentifiedCollections */,
-				83B783552C1764AE00AA7930 /* Sargon */,
-				831F0CEC2C21819000D6F5BF /* Sargon */,
-				E60D5E1E2C2EFAA2008BCF1F /* Sargon */,
 				5B634A932C91D2A0004B2FBC /* ScreenshotPreventing */,
-				5B447E0A2CAAFC2D0063AE39 /* Sargon */,
-				5B4E1D1E2CB7FE8E002FAC2E /* Sargon */,
+				E6027F1D2CE7887A0094139A /* Sargon */,
 			);
 			productName = RadixWallet;
 			productReference = 48CFBC4F2ADC106300E77A5C /* Radix Wallet Dev.app */;
@@ -7117,7 +7112,7 @@
 				8318BB172BC8403800057BCB /* XCRemoteSwiftPackageReference "swift-custom-dump" */,
 				E6A0B0492BF23C7000617DAC /* XCRemoteSwiftPackageReference "swift-identified-collections" */,
 				5B634A922C91D2A0004B2FBC /* XCRemoteSwiftPackageReference "ScreenshotPreventing-iOS" */,
-				8322256C2CD3B9F8004A1CF4 /* XCRemoteSwiftPackageReference "sargon" */,
+				E6027F1C2CE7887A0094139A /* XCLocalSwiftPackageReference "../Sargon" */,
 			);
 			productRefGroup = 48CFBC502ADC106300E77A5C /* Products */;
 			projectDirPath = "";
@@ -7593,6 +7588,8 @@
 				48CFC3142ADC10D900E77A5C /* CompletionMigrateOlympiaAccountsToBabylon.swift in Sources */,
 				8308184E2B9F16AD002D8351 /* TokenPriceClient+Mock.swift in Sources */,
 				48CFC2852ADC10D900E77A5C /* SubmitTransaction+View.swift in Sources */,
+				E622FF902CE7984B00489BA5 /* DebugFactorInstancesCacheContents+View.swift in Sources */,
+				E622FF912CE7984B00489BA5 /* DebugFactorInstancesCacheContents.swift in Sources */,
 				A40815632C7E0D08005E65B9 /* AccountLockerVaultCollectionItemType.swift in Sources */,
 				48CFC47C2ADC10DA00E77A5C /* TransportProfileClient+Test.swift in Sources */,
 				48CFC2C92ADC10D900E77A5C /* FungibleResourceAsset+View.swift in Sources */,
@@ -8945,6 +8942,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		E6027F1C2CE7887A0094139A /* XCLocalSwiftPackageReference "../Sargon" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../Sargon;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		48FFFA972ADC1EEC00B2B213 /* XCRemoteSwiftPackageReference "AsyncExtensions" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -9194,14 +9198,6 @@
 				version = 1.3.0;
 			};
 		};
-		8322256C2CD3B9F8004A1CF4 /* XCRemoteSwiftPackageReference "sargon" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/radixdlt/sargon";
-			requirement = {
-				kind = exactVersion;
-				version = 1.1.50;
-			};
-		};
 		A415574E2B757C5E0040AD4E /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture";
@@ -9229,14 +9225,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		489FEF902BDD0B80003EC10D /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Sargon;
-		};
-		48C845C62BEA6DC600F74DA7 /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Sargon;
-		};
 		48FFFA982ADC1EEC00B2B213 /* AsyncExtensions */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 48FFFA972ADC1EEC00B2B213 /* XCRemoteSwiftPackageReference "AsyncExtensions" */;
@@ -9417,26 +9405,10 @@
 			package = 5B1C4FD32BBB0B0C00B9436F /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Strict" */;
 			productName = "AppsFlyerLib-Strict";
 		};
-		5B447E0A2CAAFC2D0063AE39 /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Sargon;
-		};
-		5B4E1D1E2CB7FE8E002FAC2E /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Sargon;
-		};
 		5B634A932C91D2A0004B2FBC /* ScreenshotPreventing */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5B634A922C91D2A0004B2FBC /* XCRemoteSwiftPackageReference "ScreenshotPreventing-iOS" */;
 			productName = ScreenshotPreventing;
-		};
-		831F0CEC2C21819000D6F5BF /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Sargon;
-		};
-		83B783552C1764AE00AA7930 /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Sargon;
 		};
 		A415574F2B757C5E0040AD4E /* ComposableArchitecture */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -9448,7 +9420,7 @@
 			package = A47571FD2B29B0860059A95D /* XCRemoteSwiftPackageReference "IOSSecuritySuite" */;
 			productName = IOSSecuritySuite;
 		};
-		E60D5E1E2C2EFAA2008BCF1F /* Sargon */ = {
+		E6027F1D2CE7887A0094139A /* Sargon */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Sargon;
 		};
@@ -9456,10 +9428,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 48FFFAB22ADC206300B2B213 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = SwiftUIIntrospect;
-		};
-		E695F2DD2BECDD7C00761ACE /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Sargon;
 		};
 		E6A0B04A2BF23C7000617DAC /* IdentifiedCollections */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7d3590b225945abb1bc0ab6c684b005c28c64bdc204afcc2d34c3e379ef8a3c8",
+  "originHash" : "60b889ccc513476448aa6483246b773f242561a612324e9d081205fc3041851f",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -107,15 +107,6 @@
       "state" : {
         "revision" : "33f7e93be5d4ec027d42af77a8ec4680d1862ad2",
         "version" : "11.6.4"
-      }
-    },
-    {
-      "identity" : "sargon",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/radixdlt/sargon",
-      "state" : {
-        "revision" : "6af408a3252888560a9c401bf3be61512dba1035",
-        "version" : "1.1.50"
       }
     },
     {

--- a/RadixWallet/Clients/ProfileStore/ProfileStore.swift
+++ b/RadixWallet/Clients/ProfileStore/ProfileStore.swift
@@ -37,7 +37,13 @@ extension ProfileStore {
 
 extension ProfileStore {
 	func createNewProfile() async throws {
-		try await SargonOS.shared.newWallet()
+		let shouldPrederiveInstances: Bool
+		#if DEBUG
+		shouldPrederiveInstances = true
+		#else
+		shouldPrederiveInstances = false
+		#endif
+		return try await SargonOS.shared.newWallet(shouldPrederiveInstances: shouldPrederiveInstances)
 	}
 
 	func finishOnboarding(

--- a/RadixWallet/Features/InteractionReview/Sections/Sections+ExecutionSummary.swift
+++ b/RadixWallet/Features/InteractionReview/Sections/Sections+ExecutionSummary.swift
@@ -273,6 +273,8 @@ extension InteractionReview.Sections {
 				accountDepositSetting: accountDepositSetting,
 				accountDepositExceptions: accountDepositExceptions
 			)
+		case .some(.deleteAccounts(accountAddresses: let accountAddresses)):
+			fatalError()
 		}
 	}
 

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents+View.swift
@@ -9,6 +9,10 @@ extension DebugFactorInstancesCacheContents {
         var body: some SwiftUI.View {
             WithPerceptionTracking {
                 VStack(spacing: .small2) {
+					Button("Delete Cache File") {
+						store.send(.view(.deleteButtonTapped))
+					}
+					.buttonStyle(.primaryRectangular(isDestructive: true))
                     loadable(store.factorInstances) {
                         ProgressView()
                     } successContent: { instances in

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents+View.swift
@@ -1,94 +1,74 @@
-import SwiftUI
 import Sargon
+import SwiftUI
 
 // MARK: - DebugFactorInstancesCacheContents.View
 extension DebugFactorInstancesCacheContents {
-    struct View: SwiftUI.View {
-        let store: StoreOf<DebugFactorInstancesCacheContents>
-        
-        var body: some SwiftUI.View {
-            WithPerceptionTracking {
-                VStack(spacing: .small2) {
+	struct View: SwiftUI.View {
+		let store: StoreOf<DebugFactorInstancesCacheContents>
+
+		var body: some SwiftUI.View {
+			WithPerceptionTracking {
+				VStack(spacing: .small2) {
 					Button("Delete Cache File") {
 						store.send(.view(.deleteButtonTapped))
 					}
 					.buttonStyle(.primaryRectangular(isDestructive: true))
-                    loadable(store.factorInstances) {
-                        ProgressView()
-                    } successContent: { instances in
+					loadable(store.factorInstances) {
+						ProgressView()
+					} successContent: { instances in
 						content(instances: instances)
-                    }
-                }
-            }.task {
-                store.send(.view(.task))
-            }
-        }
-		
+					}
+				}
+				.padding()
+				.navigationTitle("FactorInstances cache")
+			}.task {
+				store.send(.view(.task))
+			}
+		}
+
 		@ViewBuilder
 		private func content(instances: Instances) -> some SwiftUI.View {
 			ScrollView {
 				VStack(alignment: .leading) {
 					ForEach(Array(instances.keys), id: \.self) { (key: FactorSourceIDFromHash) in
-						Section("Source `\(key.idPrefix())`") {
-							let listOfList: [[HierarchicalDeterministicFactorInstance]] = instances[key]!
-							ForEach(listOfList, id: \.self) { (instancesForFactorForPath: [HierarchicalDeterministicFactorInstance]) in
+						Section {
+							let listOfList: [[FactorInstanceForDebugPurposes]] = instances[key]!
+							ForEach(listOfList, id: \.self) { (instancesForFactorForPath: [FactorInstanceForDebugPurposes]) in
 								if let firstInstance = instancesForFactorForPath.first {
-									Section(firstInstance.indexAgnosticPath()) {
-										ForEach(instancesForFactorForPath, id: \.self) { (instance: HierarchicalDeterministicFactorInstance) in
+									Section {
+										ForEach(instancesForFactorForPath, id: \.self) { (instance: FactorInstanceForDebugPurposes) in
 											VStack(alignment: .leading) {
-												Text("Index `\(instance.derivationEntityIndex())`")
-												
-												Text("PublicKey `\(instance.publicKeySuffix())`")
+												Text("Index `\(instance.derivationEntityIndex)`")
+
+												Text("PublicKey `\(String(reflecting: instance.publicKeyHex.prefix(8)))`")
 											}
-											.border(Color.gray, width: 2)
-											.padding()
+											.frame(maxWidth: .infinity)
+											.padding(.horizontal, .medium3)
+											.padding(.vertical, .small2)
+											.border(Color.gray, width: 1)
 										}
+									} header: {
+										VStack {
+											Text("Agnostic `\(firstInstance.indexAgnosticDerivationPath)`").font(.title)
+											Text("#\(instancesForFactorForPath.count) instances")
+										}
+										.padding()
 									}
-									.padding()
 								}
-								
 							}
+						} header: {
+							Text("Source `\(key.idPrefix())`")
+								.font(.largeTitle)
 						}
-						.padding()
 					}
 				}
 			}
 		}
-    }
+	}
 }
+
 extension FactorSourceIDFromHash {
 	fileprivate func idPrefix() -> String {
 		String(toString().prefix(10))
-	}
-}
-extension HierarchicalDeterministicFactorInstance {
-	fileprivate func indexAgnosticPath() -> String {
-		publicKey.derivationPath.indexAgnosticPath()
-	}
-	fileprivate func derivationEntityIndex() -> String {
-		let index = publicKey.derivationPath.lastPathComponent.indexInLocalKeySpace()
-		return String(reflecting: index)
-	}
-	fileprivate func publicKeySuffix() -> String {
-		String(publicKey().suffix(6))
-	}
-	fileprivate func publicKey() -> String {
-		publicKey.publicKey.hex
-	}
-}
-extension DerivationPath {
-	fileprivate func indexAgnosticPath() -> String {
-		let components = self.path.components
-		let network = components[2]
-		let entityKind = components[3]
-		let keyKind = components[4]
-		let entityIndex = components[5]
-		let keySpace = entityIndex.keySpace
-		let keySpaceStr = switch keySpace {
-		case .securified: "S"
-		case let .unsecurified(isHardened): isHardened ? "H" : ""
-		}
-		return "\(network)/\(entityKind)/\(keyKind)/\(keySpaceStr)?"
-		
 	}
 }

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents+View.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Sargon
 
 // MARK: - DebugFactorInstancesCacheContents.View
 extension DebugFactorInstancesCacheContents {
@@ -10,18 +11,80 @@ extension DebugFactorInstancesCacheContents {
                 VStack(spacing: .small2) {
                     loadable(store.factorInstances) {
                         ProgressView()
-                    } successContent: { factorInstances in
-                        VStack {
-//                            ForEach(factorInstances) { (factorSourceID, instancesForPresetsOfFactor) in
-//                                Text("factorSourceID \(factorSourceID), #\(instancesForPresetsOfFactor.count)derivation presets")
-//                            }
-                            Text("Loaded 🐶🎉🐁 #\(factorInstances.count)")
-                        }
+                    } successContent: { instances in
+						content(instances: instances)
                     }
                 }
             }.task {
                 store.send(.view(.task))
             }
         }
+		
+		@ViewBuilder
+		private func content(instances: Instances) -> some SwiftUI.View {
+			ScrollView {
+				VStack(alignment: .leading) {
+					ForEach(Array(instances.keys), id: \.self) { (key: FactorSourceIDFromHash) in
+						Section("Source `\(key.idPrefix())`") {
+							let listOfList: [[HierarchicalDeterministicFactorInstance]] = instances[key]!
+							ForEach(listOfList, id: \.self) { (instancesForFactorForPath: [HierarchicalDeterministicFactorInstance]) in
+								if let firstInstance = instancesForFactorForPath.first {
+									Section(firstInstance.indexAgnosticPath()) {
+										ForEach(instancesForFactorForPath, id: \.self) { (instance: HierarchicalDeterministicFactorInstance) in
+											VStack(alignment: .leading) {
+												Text("Index `\(instance.derivationEntityIndex())`")
+												
+												Text("PublicKey `\(instance.publicKeySuffix())`")
+											}
+											.border(Color.gray, width: 2)
+											.padding()
+										}
+									}
+									.padding()
+								}
+								
+							}
+						}
+						.padding()
+					}
+				}
+			}
+		}
     }
+}
+extension FactorSourceIDFromHash {
+	fileprivate func idPrefix() -> String {
+		String(toString().prefix(10))
+	}
+}
+extension HierarchicalDeterministicFactorInstance {
+	fileprivate func indexAgnosticPath() -> String {
+		publicKey.derivationPath.indexAgnosticPath()
+	}
+	fileprivate func derivationEntityIndex() -> String {
+		let index = publicKey.derivationPath.lastPathComponent.indexInLocalKeySpace()
+		return String(reflecting: index)
+	}
+	fileprivate func publicKeySuffix() -> String {
+		String(publicKey().suffix(6))
+	}
+	fileprivate func publicKey() -> String {
+		publicKey.publicKey.hex
+	}
+}
+extension DerivationPath {
+	fileprivate func indexAgnosticPath() -> String {
+		let components = self.path.components
+		let network = components[2]
+		let entityKind = components[3]
+		let keyKind = components[4]
+		let entityIndex = components[5]
+		let keySpace = entityIndex.keySpace
+		let keySpaceStr = switch keySpace {
+		case .securified: "S"
+		case let .unsecurified(isHardened): isHardened ? "H" : ""
+		}
+		return "\(network)/\(entityKind)/\(keyKind)/\(keySpaceStr)?"
+		
+	}
 }

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents+View.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+// MARK: - DebugFactorInstancesCacheContents.View
+extension DebugFactorInstancesCacheContents {
+    struct View: SwiftUI.View {
+        let store: StoreOf<DebugFactorInstancesCacheContents>
+        
+        var body: some SwiftUI.View {
+            WithPerceptionTracking {
+                VStack(spacing: .small2) {
+                    loadable(store.factorInstances) {
+                        ProgressView()
+                    } successContent: { factorInstances in
+                        VStack {
+//                            ForEach(factorInstances) { (factorSourceID, instancesForPresetsOfFactor) in
+//                                Text("factorSourceID \(factorSourceID), #\(instancesForPresetsOfFactor.count)derivation presets")
+//                            }
+                            Text("Loaded 🐶🎉🐁 #\(factorInstances.count)")
+                        }
+                    }
+                }
+            }.task {
+                store.send(.view(.task))
+            }
+        }
+    }
+}

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents.swift
@@ -1,0 +1,47 @@
+import Sargon
+
+public typealias Instances = [FactorSourceIDFromHash: [[HierarchicalDeterministicFactorInstance]]]
+
+// MARK: - DebugFactorInstancesCacheContents
+@Reducer
+struct DebugFactorInstancesCacheContents: Sendable, FeatureReducer {
+	@ObservableState
+	struct State: Sendable, Hashable {
+        var factorInstances: Loadable<Instances> = .idle
+		init() {}
+	}
+
+	typealias Action = FeatureAction<Self>
+
+	enum ViewAction: Sendable, Equatable {
+		case task
+	}
+    
+    enum InternalAction: Sendable, Equatable {
+        case loadedInstances(Instances)
+    }
+
+	var body: some ReducerOf<Self> {
+		Reduce(core)
+	}
+    
+    func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
+        switch internalAction {
+        case let .loadedInstances(instances):
+            state.factorInstances = .success(instances)
+            return .none
+        }
+    }
+
+	func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
+		switch viewAction {
+		case .task:
+            state.factorInstances = .loading
+                return .run { send in
+                    
+                    let instances = await SargonOS.shared.factorInstancesInCache()
+                    await send(.internal(.loadedInstances(instances)))
+                }
+		}
+	}
+}

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Children/DebugFactorInstancesCacheContents/DebugFactorInstancesCacheContents.swift
@@ -1,13 +1,13 @@
 import Sargon
 
-public typealias Instances = [FactorSourceIDFromHash: [[HierarchicalDeterministicFactorInstance]]]
+public typealias Instances = [FactorSourceIDFromHash: [[FactorInstanceForDebugPurposes]]]
 
 // MARK: - DebugFactorInstancesCacheContents
 @Reducer
 struct DebugFactorInstancesCacheContents: Sendable, FeatureReducer {
 	@ObservableState
 	struct State: Sendable, Hashable {
-        var factorInstances: Loadable<Instances> = .idle
+		var factorInstances: Loadable<Instances> = .idle
 		init() {}
 	}
 
@@ -17,29 +17,29 @@ struct DebugFactorInstancesCacheContents: Sendable, FeatureReducer {
 		case task
 		case deleteButtonTapped
 	}
-    
-    enum InternalAction: Sendable, Equatable {
-        case loadedInstances(Instances)
+
+	enum InternalAction: Sendable, Equatable {
+		case loadedInstances(Instances)
 		case failedToDelete(String)
-    }
+	}
 
 	var body: some ReducerOf<Self> {
 		Reduce(core)
 	}
-    
-    func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
-        switch internalAction {
+
+	func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
+		switch internalAction {
 		case let .failedToDelete(error):
 			struct Err: LocalizedError {
 				let localizedDescription: String
 			}
 			state.factorInstances = .failure(Err(localizedDescription: error))
 			return .none
-        case let .loadedInstances(instances):
-            state.factorInstances = .success(instances)
-            return .none
-        }
-    }
+		case let .loadedInstances(instances):
+			state.factorInstances = .success(instances)
+			return .none
+		}
+	}
 
 	func reduce(into state: inout State, viewAction: ViewAction) -> Effect<Action> {
 		switch viewAction {
@@ -51,12 +51,11 @@ struct DebugFactorInstancesCacheContents: Sendable, FeatureReducer {
 				await send(.internal(.failedToDelete(error.localizedDescription)))
 			}
 		case .task:
-            state.factorInstances = .loading
-                return .run { send in
-                    
-                    let instances = await SargonOS.shared.factorInstancesInCache()
-                    await send(.internal(.loadedInstances(instances)))
-                }
+			state.factorInstances = .loading
+			return .run { send in
+				let instances = await SargonOS.shared.debugFactorInstancesInCache()
+				await send(.internal(.loadedInstances(instances)))
+			}
 		}
 	}
 }

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+Reducer.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+Reducer.swift
@@ -23,6 +23,7 @@ struct DebugSettingsCoordinator: Sendable, FeatureReducer {
 		case debugUserDefaultsContentsButtonTapped
 		case debugTestKeychainButtonTapped
 		case debugKeychainContentsButtonTapped
+        case debugFactorInstancesCacheContentsButtonTapped
 	}
 
 	enum InternalAction: Sendable, Equatable {
@@ -36,7 +37,8 @@ struct DebugSettingsCoordinator: Sendable, FeatureReducer {
 			case debugManageFactorSources(DebugManageFactorSources.State)
 			#if DEBUG
 			case debugKeychainTest(DebugKeychainTest.State)
-			case debugKeychainContents(DebugKeychainContents.State)
+            case debugKeychainContents(DebugKeychainContents.State)
+			case debugFactorInstancesCacheContents(DebugFactorInstancesCacheContents.State)
 			#endif // DEBUG
 		}
 
@@ -45,7 +47,8 @@ struct DebugSettingsCoordinator: Sendable, FeatureReducer {
 			case debugInspectProfile(DebugInspectProfile.Action)
 			#if DEBUG
 			case debugKeychainTest(DebugKeychainTest.Action)
-			case debugKeychainContents(DebugKeychainContents.Action)
+            case debugKeychainContents(DebugKeychainContents.Action)
+			case debugFactorInstancesCacheContents(DebugFactorInstancesCacheContents.Action)
 			#endif // DEBUG
 			case debugManageFactorSources(DebugManageFactorSources.Action)
 		}
@@ -64,6 +67,9 @@ struct DebugSettingsCoordinator: Sendable, FeatureReducer {
 			Scope(state: /State.debugKeychainContents, action: /Action.debugKeychainContents) {
 				DebugKeychainContents()
 			}
+            Scope(state: /State.debugFactorInstancesCacheContents, action: /Action.debugFactorInstancesCacheContents) {
+                DebugFactorInstancesCacheContents()
+            }
 			#endif // DEBUG
 			Scope(state: /State.debugManageFactorSources, action: /Action.debugManageFactorSources) {
 				DebugManageFactorSources()
@@ -110,6 +116,12 @@ struct DebugSettingsCoordinator: Sendable, FeatureReducer {
 			#endif // DEBUG
 			return .none
 
+        case .debugFactorInstancesCacheContentsButtonTapped:
+            #if DEBUG
+            state.destination = .debugFactorInstancesCacheContents(.init())
+            #endif // DEBUG
+            return .none
+            
 		case .debugUserDefaultsContentsButtonTapped:
 			state.destination = .debugUserDefaultsContents(.init())
 			return .none

--- a/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+View.swift
+++ b/RadixWallet/Features/SettingsFeature/DebugSettings/Coordinator/DebugSettingsCoordinator+View.swift
@@ -65,6 +65,12 @@ extension DebugSettingsCoordinator.View {
 				icon: .systemImage("key"),
 				action: .debugKeychainContentsButtonTapped
 			),
+            // ONLY DEBUG EVER
+            .model(
+                title: "FactorInstances Cache",
+                icon: .systemImage("key"),
+                action: .debugFactorInstancesCacheContentsButtonTapped
+            ),
 		]
 	}
 }
@@ -88,7 +94,8 @@ private extension View {
 			.debugUserDefaultsContents(with: destinationStore)
 		#if DEBUG
 			.debugKeychainTest(with: destinationStore)
-			.debugKeychainContents(with: destinationStore)
+            .debugKeychainContents(with: destinationStore)
+			.debugFactorInstancesCacheContents(with: destinationStore)
 		#endif
 			.debugInspectProfile(with: destinationStore)
 	}
@@ -126,6 +133,18 @@ private extension View {
 			destination: { DebugKeychainContents.View(store: $0) }
 		)
 	}
+    
+    
+    private func debugFactorInstancesCacheContents(
+        with destinationStore: PresentationStoreOf<DebugSettingsCoordinator.Destination>
+    ) -> some View {
+        navigationDestination(
+            store: destinationStore,
+            state: /DebugSettingsCoordinator.Destination.State.debugFactorInstancesCacheContents,
+            action: DebugSettingsCoordinator.Destination.Action.debugFactorInstancesCacheContents,
+            destination: { DebugFactorInstancesCacheContents.View(store: $0) }
+        )
+    }
 	#endif // DEBUG
 
 	private func factorSources(

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+Account.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+Account.swift
@@ -42,11 +42,11 @@ extension Account {
 	}
 
 	mutating func hide() {
-		flags.append(.deletedByUser)
+		flags.append(.hiddenByUser)
 	}
 
 	mutating func unhide() {
-		entityFlags.remove(.deletedByUser)
+		entityFlags.remove(.hiddenByUser)
 	}
 }
 

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Persona.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage2/Atoms/Stage2MigrateToSargon+Persona.swift
@@ -3,11 +3,11 @@ import Sargon
 
 extension Persona {
 	mutating func hide() {
-		entityFlags.append(.deletedByUser)
+		entityFlags.append(.hiddenByUser)
 	}
 
 	mutating func unhide() {
-		entityFlags.remove(.deletedByUser)
+		entityFlags.remove(.hiddenByUser)
 	}
 }
 


### PR DESCRIPTION
> [!INFO]
> Blocked by https://github.com/radixdlt/sargon/pull/254 

Update `newWallet` to for DEBUG builds pre-derive factor instances for the BDFS (I have not modified any other Add Factor Source code to  pre-derive, since we are not yet using SargonOS to add FactorSources - we are though, using SargonOS for `newWallet` so we can pre-derive instances for the BDFS).

# Screenshot

![IMG_0952](https://github.com/user-attachments/assets/97463a64-4303-4661-a0a4-bca76a2744e5)



# Demo (video)

https://github.com/user-attachments/assets/3328be5f-5cd3-464e-985c-efc3ac0b4995

