### PR TITLE
Fix crash caused by early profile access

### DIFF
--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Interface.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Interface.swift
@@ -43,6 +43,8 @@ struct RadixConnectClient: DependencyKey, Sendable {
 	var sendRequest: SendRequest
 
 	var handleDappDeepLink: HandleDappDeepLink
+
+	var startNotifyingConnectorWithAccounts: StartNotifyingConnectorWithAccounts
 }
 
 extension RadixConnectClient {
@@ -70,4 +72,6 @@ extension RadixConnectClient {
 
 	typealias ConnectToP2PLinks = @Sendable (P2PLinks) async throws -> Void
 	typealias HandleDappDeepLink = @Sendable (URL) async throws -> Void
+
+	typealias StartNotifyingConnectorWithAccounts = @Sendable () async throws -> Void
 }

--- a/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Test.swift
+++ b/RadixWallet/Clients/RadixConnectClient/RadixConnectClient+Test.swift
@@ -18,7 +18,8 @@ extension RadixConnectClient: TestDependencyKey {
 		receiveMessages: unimplemented("\(Self.self).receiveMessages"),
 		sendResponse: unimplemented("\(Self.self).sendResponse"),
 		sendRequest: unimplemented("\(Self.self).sendRequest"),
-		handleDappDeepLink: unimplemented("\(Self.self).sendRequest")
+		handleDappDeepLink: unimplemented("\(Self.self).sendRequest"),
+		startNotifyingConnectorWithAccounts: unimplemented("\(Self.self).startNotifyingConnectorWithAccounts")
 	)
 }
 
@@ -37,7 +38,8 @@ extension RadixConnectClient {
 		receiveMessages: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
 		sendResponse: { _, _ in },
 		sendRequest: { _, _ in 0 },
-		handleDappDeepLink: { _ in }
+		handleDappDeepLink: { _ in },
+		startNotifyingConnectorWithAccounts: {}
 	)
 }
 #endif // DEBUG

--- a/RadixWallet/Features/AccountRecoveryScan/Children/AccountRecoveryScanInProgress/AccountRecoveryScanInProgress+View.swift
+++ b/RadixWallet/Features/AccountRecoveryScan/Children/AccountRecoveryScanInProgress/AccountRecoveryScanInProgress+View.swift
@@ -13,9 +13,9 @@ extension AccountRecoveryScanInProgress.State {
 
 	private var isManualScan: Bool {
 		switch mode {
-		case .privateHD:
+		case .createProfile:
 			false
-		case .factorSourceWithID:
+		case .addAccounts:
 			true
 		}
 	}

--- a/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
+++ b/RadixWallet/Features/AccountRecoveryScan/Coordinator/AccountRecoveryScanCoordinator.swift
@@ -37,13 +37,13 @@ struct AccountRecoveryScanCoordinator: Sendable, FeatureReducer {
 			switch purpose {
 			case let .addAccounts(id, forOlympiaAccounts):
 				AccountRecoveryScanInProgress.State(
-					mode: .factorSourceWithID(id: id),
+					mode: .addAccounts(factorSourceId: id),
 					forOlympiaAccounts: forOlympiaAccounts
 				)
 
 			case let .createProfile(privateHDFactorSource):
 				AccountRecoveryScanInProgress.State(
-					mode: .privateHD(privateHDFactorSource),
+					mode: .createProfile(privateHDFactorSource),
 					forOlympiaAccounts: false
 				)
 			}

--- a/RadixWalletTests/Features/MainFeatureTests/MainFeatureTests.swift
+++ b/RadixWalletTests/Features/MainFeatureTests/MainFeatureTests.swift
@@ -35,6 +35,7 @@ final class MainFeatureTests: TestCase {
 				.dependency(\.securityCenterClient, .noop)
 				.dependency(\.deepLinkHandlerClient, .noop)
 				.dependency(\.accountLockersClient, .noop)
+				.dependency(\.radixConnectClient, .noop)
 		}
 
 		XCTAssertFalse(store.state.showIsUsingTestnetBanner)


### PR DESCRIPTION
https://radixdlt.atlassian.net/browse/ABW-4004

Fix the places that did access the profile when it was not present yet:
- RadixConnectClient notifying CE with updated right after a profile is selected for import.
- Account recovery scan from the onboarding trying to get appearance id from the Profile