### PR TITLE
Fix import encrypted profile hang

### DIFF
--- a/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+Reducer.swift
+++ b/RadixWallet/Features/ProfileBackupsFeature/RestoreProfileFromBackup/Children/SelectBackup/SelectBackup+Reducer.swift
@@ -215,7 +215,7 @@ struct SelectBackup: Sendable, FeatureReducer {
 		case let .inputEncryptionPassword(.delegate(.successfullyDecrypted(_, decrypted, containsP2PLinks))):
 			state.destination = nil
 			overlayWindowClient.scheduleHUD(.decryptedProfile)
-			return .send(.delegate(.selectedProfile(decrypted, containsLegacyP2PLinks: containsP2PLinks)))
+			return delayedShortEffect(for: .delegate(.selectedProfile(decrypted, containsLegacyP2PLinks: containsP2PLinks)))
 
 		case .inputEncryptionPassword(.delegate(.successfullyEncrypted)):
 			preconditionFailure("Incorrect implementation, expected decryption")


### PR DESCRIPTION
The Wallet did hang indefinitely when importing an encrypted profile. 

Could not find a strong reason as to why the bug is happening. Seems to be caused by SwiftUI issue of cancelling the view task, in this case ImportMnemonicsFlowCoordinator's view, when the previews view is not yet fully dismissed.

Add a small delay fixes the issue.

## Bug

https://github.com/user-attachments/assets/a72b3100-12f6-4096-959f-4bba13022049

