### PR TITLE
[ABW-3984] Fix NFT collection hidden warning on Pre Authorization

### DIFF
--- a/RadixWallet/Features/InteractionReview/Sections/Sections+ManifestSummary.swift
+++ b/RadixWallet/Features/InteractionReview/Sections/Sections+ManifestSummary.swift
@@ -133,7 +133,9 @@ extension InteractionReview.Sections {
 						networkID: networkID
 					))]
 				} else {
-					return [.known(.init(resource: resource, details: .nonFungible(.amount(amount: .exact(amount)))))]
+					@Dependency(\.resourcesVisibilityClient) var resourcesVisibilityClient
+					let isHidden = try await resourcesVisibilityClient.isHidden(.nonFungible(resourceAddress))
+					return [.known(.init(resource: resource, details: .nonFungible(.amount(amount: .exact(amount))), isHidden: isHidden))]
 				}
 			case .right:
 				return []


### PR DESCRIPTION
Jira ticket: [ABW-3984](https://radixdlt.atlassian.net/browse/ABW-3984)

## Description
Solves an issue where we weren't checking for NFT visibility under Manifest Summary.

## How to test
1. Connect to [sample dApp](https://d1vuj67scmz8qj.cloudfront.net/)
2. Send a Pre Authorization with the instructions detailed below
3. Hide the `Abandon` collection
4. Close the Pre Authorization and send it again
5. You should see the expected warning under the collection

![Screenshot 2024-12-06 at 10 48 07](https://github.com/user-attachments/assets/dcb94f9d-2d4a-41c8-a767-f2208766b0f1)

## Instructions
```
CALL_METHOD
  Address("account_tdx_2_129nje53m7dn405snw9e8sl72ej334r7dudl6zwvx6cn92efueqyjsd")
  "withdraw"
  Address("resource_tdx_2_1n2lj0rk7pye8h2cxs347lf70ksyzwaez0mjkssccfthp6m408hfny7")
  Decimal("5")
;

CALL_METHOD
  Address("account_tdx_2_129rfcz44zxflyaf6d65fdvaqtk5rlvdu8nzek2nz435zknhqure2xl")
  "deposit_batch"
  Expression("ENTIRE_WORKTOP")
;

YIELD_TO_PARENT;
```

[ABW-3984]: https://radixdlt.atlassian.net/browse/ABW-3984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ