### PR TITLE
Hotfix for delete account with hidden assets only

### DIFF
--- a/Aux/Config/Common.xcconfig
+++ b/Aux/Config/Common.xcconfig
@@ -1,7 +1,7 @@
 // MARK: - Custom flags
 
 /// Application version shared across all targets and flavours
-APP_VERSION = 1.11.0
+APP_VERSION = 1.11.1
 
 /// App Icon base name
 APP_ICON = AppIcon

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
@@ -51,6 +51,11 @@ extension AccountPortfoliosClient {
 
 			return modified
 		}
+
+		/// Returns if the original account (which doesn't remove the hidden resources) contains any asset
+		var containsAnyAsset: Bool {
+			originalAccount.containsAnyAsset
+		}
 	}
 
 	/// Internal state that holds all loaded portfolios.

--- a/RadixWallet/Features/AccountPreferencesFeature/Children/DeleteAccount/DeleteAccountConfirmation+Reducer.swift
+++ b/RadixWallet/Features/AccountPreferencesFeature/Children/DeleteAccount/DeleteAccountConfirmation+Reducer.swift
@@ -16,7 +16,7 @@ struct DeleteAccountConfirmation: Sendable, FeatureReducer {
 
 	@CasePathable
 	enum InternalAction: Sendable, Equatable {
-		case fetchAccountPortfolioResult(TaskResult<OnLedgerEntity.OnLedgerAccount>)
+		case fetchAccountPortfolioResult(TaskResult<AccountPortfoliosClient.AccountPortfolio>)
 		case fetchReceivingAccounts
 		case fetchReceivingAccountsResult(TaskResult<[State.ReceivingAccountCandidate]>)
 	}
@@ -44,7 +44,7 @@ struct DeleteAccountConfirmation: Sendable, FeatureReducer {
 			state.footerButtonState = .loading(.local)
 			return .run { [address = state.account.address] send in
 				let result = await TaskResult {
-					try await accountPortfoliosClient.fetchAccountPortfolio(address, true).account
+					try await accountPortfoliosClient.fetchAccountPortfolio(address, true)
 				}
 				await send(.internal(.fetchAccountPortfolioResult(result)))
 			}
@@ -53,9 +53,9 @@ struct DeleteAccountConfirmation: Sendable, FeatureReducer {
 
 	func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
 		switch internalAction {
-		case let .fetchAccountPortfolioResult(.success(account)):
+		case let .fetchAccountPortfolioResult(.success(portfolio)):
 			state.footerButtonState = .enabled
-			return account.containsAnyAsset ? .send(.internal(.fetchReceivingAccounts)) : .send(.delegate(.deleteAccount))
+			return portfolio.containsAnyAsset ? .send(.internal(.fetchReceivingAccounts)) : .send(.delegate(.deleteAccount))
 
 		case .fetchReceivingAccounts:
 			return .run { send in

--- a/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Models.swift
+++ b/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Models.swift
@@ -5,15 +5,18 @@ import SwiftUI
 struct CreateAccountConfig: Sendable, Hashable {
 	let specificNetworkID: NetworkID?
 	let isFirstAccount: Bool
+	let isNewProfile: Bool
 	let navigationButtonCTA: CreateAccountNavigationButtonCTA
 
 	fileprivate init(
 		isFirstAccount: Bool,
+		isNewProfile: Bool = false,
 		navigationButtonCTA: CreateAccountNavigationButtonCTA,
 		specificNetworkID: NetworkID? = nil
 	) {
 		self.specificNetworkID = specificNetworkID
 		self.isFirstAccount = isFirstAccount
+		self.isNewProfile = isNewProfile
 		self.navigationButtonCTA = navigationButtonCTA
 	}
 }
@@ -31,6 +34,7 @@ extension CreateAccountConfig {
 		case .firstAccountForNewProfile:
 			self.init(
 				isFirstAccount: true,
+				isNewProfile: true,
 				navigationButtonCTA: .goHome
 			)
 		case let .firstAccountOnNewNetwork(specificNetworkID):

--- a/RadixWallet/Features/OnboardingFeature/Coordinator/OnboardingCoordinator+Reducer.swift
+++ b/RadixWallet/Features/OnboardingFeature/Coordinator/OnboardingCoordinator+Reducer.swift
@@ -14,10 +14,6 @@ struct OnboardingCoordinator: Sendable, FeatureReducer {
 		}
 	}
 
-	public enum InternalAction: Sendable, Equatable {
-		case newProfileCreated
-	}
-
 	@CasePathable
 	enum ChildAction: Sendable, Equatable {
 		case startup(OnboardingStartup.Action)
@@ -45,7 +41,6 @@ struct OnboardingCoordinator: Sendable, FeatureReducer {
 		}
 	}
 
-	@Dependency(\.onboardingClient) var onboardingClient
 	@Dependency(\.radixConnectClient) var radixConnectClient
 	@Dependency(\.appEventsClient) var appEventsClient
 	@Dependency(\.errorQueue) var errorQueue
@@ -65,27 +60,15 @@ struct OnboardingCoordinator: Sendable, FeatureReducer {
 
 	private let destinationPath: WritableKeyPath<State, PresentationState<Destination.State>> = \.$destination
 
-	func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
-		switch internalAction {
-		case .newProfileCreated:
+	func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
+		switch childAction {
+		case .startup(.delegate(.setupNewUser)):
 			state.destination = .createAccount(
 				.init(
 					config: .init(purpose: .firstAccountForNewProfile)
 				)
 			)
 			return .none
-		}
-	}
-
-	func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
-		switch childAction {
-		case .startup(.delegate(.setupNewUser)):
-			return .run { send in
-				try await onboardingClient.createNewProfile()
-				await send(.internal(.newProfileCreated))
-			} catch: { error, _ in
-				errorQueue.schedule(error)
-			}
 
 		case .startup(.delegate(.profileCreatedFromImportedBDFS)):
 			appEventsClient.handleEvent(.walletRestored)


### PR DESCRIPTION
## Changelog
As described in [Slack](https://rdxworks.slack.com/archives/C031A0V1A1W/p1733852936003809), when doing an account deletion, the wallet isn't paying attention to hidden assets when checking to see if the account has anything in it to move. This only happens if the mentioned account only has assets that are hidden.

This hotfix solves this issue by checking for hidden assets as well.





