### PR TITLE
Wait until first account creation to create Profile

### DIFF
--- a/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Models.swift
+++ b/RadixWallet/Features/CreateAccount/Coordinator/CreateAccountCoordinator+Models.swift
@@ -5,15 +5,18 @@ import SwiftUI
 struct CreateAccountConfig: Sendable, Hashable {
 	let specificNetworkID: NetworkID?
 	let isFirstAccount: Bool
+	let isNewProfile: Bool
 	let navigationButtonCTA: CreateAccountNavigationButtonCTA
 
 	fileprivate init(
 		isFirstAccount: Bool,
+		isNewProfile: Bool = false,
 		navigationButtonCTA: CreateAccountNavigationButtonCTA,
 		specificNetworkID: NetworkID? = nil
 	) {
 		self.specificNetworkID = specificNetworkID
 		self.isFirstAccount = isFirstAccount
+		self.isNewProfile = isNewProfile
 		self.navigationButtonCTA = navigationButtonCTA
 	}
 }
@@ -31,6 +34,7 @@ extension CreateAccountConfig {
 		case .firstAccountForNewProfile:
 			self.init(
 				isFirstAccount: true,
+				isNewProfile: true,
 				navigationButtonCTA: .goHome
 			)
 		case let .firstAccountOnNewNetwork(specificNetworkID):

--- a/RadixWallet/Features/OnboardingFeature/Coordinator/OnboardingCoordinator+Reducer.swift
+++ b/RadixWallet/Features/OnboardingFeature/Coordinator/OnboardingCoordinator+Reducer.swift
@@ -14,10 +14,6 @@ struct OnboardingCoordinator: Sendable, FeatureReducer {
 		}
 	}
 
-	public enum InternalAction: Sendable, Equatable {
-		case newProfileCreated
-	}
-
 	@CasePathable
 	enum ChildAction: Sendable, Equatable {
 		case startup(OnboardingStartup.Action)
@@ -45,7 +41,6 @@ struct OnboardingCoordinator: Sendable, FeatureReducer {
 		}
 	}
 
-	@Dependency(\.onboardingClient) var onboardingClient
 	@Dependency(\.radixConnectClient) var radixConnectClient
 	@Dependency(\.appEventsClient) var appEventsClient
 	@Dependency(\.errorQueue) var errorQueue
@@ -65,27 +60,15 @@ struct OnboardingCoordinator: Sendable, FeatureReducer {
 
 	private let destinationPath: WritableKeyPath<State, PresentationState<Destination.State>> = \.$destination
 
-	func reduce(into state: inout State, internalAction: InternalAction) -> Effect<Action> {
-		switch internalAction {
-		case .newProfileCreated:
+	func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
+		switch childAction {
+		case .startup(.delegate(.setupNewUser)):
 			state.destination = .createAccount(
 				.init(
 					config: .init(purpose: .firstAccountForNewProfile)
 				)
 			)
 			return .none
-		}
-	}
-
-	func reduce(into state: inout State, childAction: ChildAction) -> Effect<Action> {
-		switch childAction {
-		case .startup(.delegate(.setupNewUser)):
-			return .run { send in
-				try await onboardingClient.createNewProfile()
-				await send(.internal(.newProfileCreated))
-			} catch: { error, _ in
-				errorQueue.schedule(error)
-			}
 
 		case .startup(.delegate(.profileCreatedFromImportedBDFS)):
 			appEventsClient.handleEvent(.walletRestored)


### PR DESCRIPTION
Fixes bug where users wouldn't be able to create a Profile if they cancelled the creation flow in the middle.

[Reference](https://rdxworks.slack.com/archives/C031A0V1A1W/p1733932355719239)