### PR TITLE
Fix RNS custom gateway usage

### DIFF
--- a/RadixWallet/Clients/RadixNameServiceClient/RadixNameService+Live.swift
+++ b/RadixWallet/Clients/RadixNameServiceClient/RadixNameService+Live.swift
@@ -6,11 +6,11 @@ extension RadixNameServiceClient: DependencyKey {
 
 		return Self(
 			resolveReceiverAccountForDomain: { domain in
-				let network = await gatewaysClient.getCurrentNetworkID()
+				let gateway = await gatewaysClient.getCurrentGateway()
 
 				let rns = try RadixNameService(
 					networkingDriver: URLSession.shared,
-					networkId: network
+					gateway: gateway
 				)
 
 				return try await rns.resolveReceiverAccountForDomain(domain: domain)


### PR DESCRIPTION
## Summary

- Pass the full current `Gateway` into `RadixNameService` instead of only the current network id.
- Ensures RNS lookups honor custom gateway URLs configured by the user.

## Requires simultaneous Sargon merge

This PR depends on a breaking public UniFFI API change in Sargon: `RadixNameService` now takes `gateway` instead of `networkId`.

Do not merge this PR independently. It must be merged and consumed together with the Sargon PR below, otherwise this wallet branch will not compile against the old Sargon API.

Required companion PRs:

- Sargon: https://github.com/radixdlt/sargon/pull/450
- Android: https://github.com/radixdlt/babylon-wallet-android/pull/1443

## Validation

- [x] SwiftFormat ran from the commit hook.
- [ ] Full iOS build not run.
