### PR TITLE
Proper custom gateway support

### DIFF
--- a/RadixWallet.xcodeproj/project.pbxproj
+++ b/RadixWallet.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		477F2B8D3DBE6C40B19BEA26 /* SignalingServersSettings+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4019A6B9E4F6D77A74801C1C /* SignalingServersSettings+View.swift */; };
 		47B4C8D13A2E4F4B8C100001 /* SignalingServerDetails+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B4C8D13A2E4F4B8C200001 /* SignalingServerDetails+Reducer.swift */; };
 		47B4C8D13A2E4F4B8C100002 /* SignalingServerDetails+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B4C8D13A2E4F4B8C200002 /* SignalingServerDetails+View.swift */; };
-		47B4C8D13A2E4F4B8C100003 /* SignalingServersSettingsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B4C8D13A2E4F4B8C200003 /* SignalingServersSettingsFeatureTests.swift */; };
+		47B4C8D13A2E4F4B8C100003 /* ../SignalingServersSettingsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B4C8D13A2E4F4B8C200003 /* ../SignalingServersSettingsFeatureTests.swift */; };
 		48076E402B14F5CA004575F8 /* OnFirstAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48076E3F2B14F5CA004575F8 /* OnFirstAppearViewModifier.swift */; };
 		480E50D52B0C881000FC21D5 /* RecoverWalletWithoutProfileCoordinator+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480E50D32B0C881000FC21D5 /* RecoverWalletWithoutProfileCoordinator+View.swift */; };
 		4813AFE22BC9A9AD0046BCAD /* Stage1MigrateToSargon+NetworkDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4813AFE12BC9A9AD0046BCAD /* Stage1MigrateToSargon+NetworkDefinition.swift */; };
@@ -807,13 +807,6 @@
 		5BEB9CD52C6F6CC9001FD9D4 /* ConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEB9CD42C6F6CC9001FD9D4 /* ConfirmationView.swift */; };
 		5BFA4FBA2C736B740030B517 /* HiddenAssets+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFA4FB82C736B740030B517 /* HiddenAssets+View.swift */; };
 		5BFA4FBB2C736B740030B517 /* HiddenAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFA4FB92C736B740030B517 /* HiddenAssets.swift */; };
-		A0ADBC001AD00000ADBC0005 /* AddressBookClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0002 /* AddressBookClient+Interface.swift */; };
-		A0ADBC001AD00000ADBC0006 /* AddressBookClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0003 /* AddressBookClient+Live.swift */; };
-		A0ADBC001AD00000ADBC0007 /* AddressBookClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0004 /* AddressBookClient+Test.swift */; };
-		A0ADBC001AD00000ADBC000D /* AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0009 /* AddressBook.swift */; };
-		A0ADBC001AD00000ADBC000E /* AddressBook+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC000A /* AddressBook+View.swift */; };
-		A0ADBC001AD00000ADBC000F /* AddressBookEntryForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC000B /* AddressBookEntryForm.swift */; };
-		A0ADBC001AD00000ADBC0010 /* AddressBookEntryForm+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC000C /* AddressBookEntryForm+View.swift */; };
 		5BFED68B2D4A8C6D00380E7D /* PasswordFactorSourceAccess+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFED68A2D4A8C6D00380E7D /* PasswordFactorSourceAccess+View.swift */; };
 		5BFED68C2D4A8C6D00380E7D /* PasswordFactorSourceAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFED6892D4A8C6D00380E7D /* PasswordFactorSourceAccess.swift */; };
 		830818482B9F1621002D8351 /* HTTPClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830818472B9F1621002D8351 /* HTTPClient+Live.swift */; };
@@ -906,6 +899,7 @@
 		A06323EA2DFC308200963A1F /* LearnAbout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06323E72DFC308200963A1F /* LearnAbout.swift */; };
 		A06A0B622F2BBE2F009004C5 /* SargonLoggingDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06A0B612F2BBE2F009004C5 /* SargonLoggingDriver.swift */; };
 		A06A0B632F2BBE2F009004C5 /* SargonDriversFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06A0B602F2BBE2F009004C5 /* SargonDriversFactory.swift */; };
+		A077F8332FD414340096267F /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A077F8322FD414340096267F /* Sargon */; };
 		A07B8C462ED8A9A7001D084A /* InteractionReview-StopTimedRecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07B8C442ED8A9A7001D084A /* InteractionReview-StopTimedRecoveryView.swift */; };
 		A089D42F2E34F80600866A47 /* ArculusFactorSourceAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = A089D42D2E34F80600866A47 /* ArculusFactorSourceAccess.swift */; };
 		A089D4302E34F80600866A47 /* ArculusFactorSourceAccess+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A089D42E2E34F80600866A47 /* ArculusFactorSourceAccess+View.swift */; };
@@ -930,6 +924,13 @@
 		A09F8FDF2DF6E4C300DB5614 /* Discover.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09F8FDC2DF6E4C300DB5614 /* Discover.swift */; };
 		A0A556152ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A556132ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery.swift */; };
 		A0A556162ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A556142ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery+View.swift */; };
+		A0ADBC001AD00000ADBC0005 /* AddressBookClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0002 /* AddressBookClient+Interface.swift */; };
+		A0ADBC001AD00000ADBC0006 /* AddressBookClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0003 /* AddressBookClient+Live.swift */; };
+		A0ADBC001AD00000ADBC0007 /* AddressBookClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0004 /* AddressBookClient+Test.swift */; };
+		A0ADBC001AD00000ADBC000D /* AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0009 /* AddressBook.swift */; };
+		A0ADBC001AD00000ADBC000E /* AddressBook+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC000A /* AddressBook+View.swift */; };
+		A0ADBC001AD00000ADBC000F /* AddressBookEntryForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC000B /* AddressBookEntryForm.swift */; };
+		A0ADBC001AD00000ADBC0010 /* AddressBookEntryForm+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC000C /* AddressBookEntryForm+View.swift */; };
 		A0B566E92ED75F96002655C0 /* AccessControllerClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B566E52ED75F96002655C0 /* AccessControllerClient+Interface.swift */; };
 		A0B566EA2ED75F96002655C0 /* AccessControllerClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B566E62ED75F96002655C0 /* AccessControllerClient+Live.swift */; };
 		A0B566EB2ED75F96002655C0 /* AccessControllerClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B566E72ED75F96002655C0 /* AccessControllerClient+Test.swift */; };
@@ -938,9 +939,10 @@
 		A0BA44512E7F085D00ED76E8 /* SecurityStructureOfFactorSourcesView+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BA444F2E7F085D00ED76E8 /* SecurityStructureOfFactorSourcesView+View.swift */; };
 		A0BA90432E8167E000ED76E8 /* EditSecurityShieldCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BA90422E8167E000ED76E8 /* EditSecurityShieldCoordinator.swift */; };
 		A0BA90452E8167E600ED76E8 /* EditSecurityShieldCoordinator+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BA90442E8167E600ED76E8 /* EditSecurityShieldCoordinator+View.swift */; };
+		A0C31A002EDB8C7B00E00001 /* MfaFactorInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C31A022EDB8C7B00E00001 /* MfaFactorInstance.swift */; };
+		A0C31A012EDB8C7B00E00001 /* MfaFactorInstance+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C31A032EDB8C7B00E00001 /* MfaFactorInstance+View.swift */; };
 		A0C673052DA6BD7F0071606B /* ScreenshotPreventing in Frameworks */ = {isa = PBXBuildFile; productRef = A0C673042DA6BD7F0071606B /* ScreenshotPreventing */; };
 		A0C673072DA6BD7F0071606B /* ScreenshotPreventingSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = A0C673062DA6BD7F0071606B /* ScreenshotPreventingSwiftUI */; };
-		A0CB3BDA2F59D640004D904F /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A0CB3BD92F59D640004D904F /* Sargon */; };
 		A0D201662E01489A009DA055 /* BlogPostCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D201652E014893009DA055 /* BlogPostCard.swift */; };
 		A0D201692E029394009DA055 /* BlogPostsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D201672E029394009DA055 /* BlogPostsCarousel.swift */; };
 		A0D2016A2E029394009DA055 /* BlogPostsCarousel+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D201682E029394009DA055 /* BlogPostsCarousel+View.swift */; };
@@ -967,7 +969,9 @@
 		A0F636CA2E3BA9720003B4C0 /* ArculusChangePIN-EnterNewPIN.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F636C72E3BA9720003B4C0 /* ArculusChangePIN-EnterNewPIN.swift */; };
 		A0F63EF62E3F9DDF0003B4C0 /* ArculusForgotPIN-InputSeedPhrase+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F63EF52E3F9DDF0003B4C0 /* ArculusForgotPIN-InputSeedPhrase+View.swift */; };
 		A0F63EF72E3F9DDF0003B4C0 /* ArculusForgotPIN-InputSeedPhrase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F63EF42E3F9DDF0003B4C0 /* ArculusForgotPIN-InputSeedPhrase.swift */; };
+		A0FEAF862FD712AF00882FE0 /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A0FEAF852FD712AF00882FE0 /* Sargon */; };
 		A0FFCE392E2B7D5E00C29802 /* NFCSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FFCE382E2B7D5700C29802 /* NFCSessionClient.swift */; };
+		A1B2C3D42F0A000100112233 /* ../AddressBookFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32F0A000100112233 /* ../AddressBookFeatureTests.swift */; };
 		A1B2C3D42F4B100100AAA001 /* RelayServicesSettings+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F4B100100BBB001 /* RelayServicesSettings+Reducer.swift */; };
 		A1B2C3D42F4B100100AAA002 /* RelayServicesSettings+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F4B100100BBB002 /* RelayServicesSettings+View.swift */; };
 		A408154C2C7E0D08005E65B9 /* CodableHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40814312C7E0D08005E65B9 /* CodableHelper.swift */; };
@@ -1261,8 +1265,6 @@
 		A43F1E232BC72884001DD3FA /* AnyRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43F1E222BC72884001DD3FA /* AnyRange.swift */; };
 		A43F1E262BC96F18001DD3FA /* SecurityCenter+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43F1E252BC96F18001DD3FA /* SecurityCenter+Reducer.swift */; };
 		A43F1E282BC96F27001DD3FA /* SecurityCenter+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43F1E272BC96F27001DD3FA /* SecurityCenter+View.swift */; };
-		A0C31A002EDB8C7B00E00001 /* MfaFactorInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C31A022EDB8C7B00E00001 /* MfaFactorInstance.swift */; };
-		A0C31A012EDB8C7B00E00001 /* MfaFactorInstance+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C31A032EDB8C7B00E00001 /* MfaFactorInstance+View.swift */; };
 		A462B5792B8210A400C26D20 /* TransactionHistoryClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A462B5782B820D2300C26D20 /* TransactionHistoryClient+Interface.swift */; };
 		A462B57A2B8210A600C26D20 /* TransactionHistoryClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = A462B5762B820D2200C26D20 /* TransactionHistoryClient+Live.swift */; };
 		A462B57B2B8210A900C26D20 /* TransactionHistoryClient+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A462B5772B820D2300C26D20 /* TransactionHistoryClient+Mock.swift */; };
@@ -1351,7 +1353,6 @@
 		E6DBA32B2ADEBFB300A38425 /* JSON+Sendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DBA2722ADEBFB200A38425 /* JSON+Sendable.swift */; };
 		E6DBA32E2ADEBFB300A38425 /* SettingsViewStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DBA2792ADEBFB200A38425 /* SettingsViewStateTests.swift */; };
 		E6DBA3312ADEBFB300A38425 /* AccountDetailsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DBA27E2ADEBFB200A38425 /* AccountDetailsFeatureTests.swift */; };
-		A1B2C3D42F0A000100112233 /* AddressBookFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32F0A000100112233 /* AddressBookFeatureTests.swift */; };
 		E6DBA3332ADEBFB300A38425 /* TransactionSigningFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DBA2812ADEBFB200A38425 /* TransactionSigningFeatureTests.swift */; };
 		E6DBA33B2ADEBFB300A38425 /* MainFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DBA28E2ADEBFB300A38425 /* MainFeatureTests.swift */; };
 		E6DBA33E2ADEBFB300A38425 /* DappInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DBA2942ADEBFB300A38425 /* DappInteractorTests.swift */; };
@@ -1457,7 +1458,7 @@
 		4019A6B9E4F6D77A74801C1C /* SignalingServersSettings+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SignalingServersSettings+View.swift"; sourceTree = "<group>"; };
 		47B4C8D13A2E4F4B8C200001 /* SignalingServerDetails+Reducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SignalingServerDetails+Reducer.swift"; sourceTree = "<group>"; };
 		47B4C8D13A2E4F4B8C200002 /* SignalingServerDetails+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SignalingServerDetails+View.swift"; sourceTree = "<group>"; };
-		47B4C8D13A2E4F4B8C200003 /* SignalingServersSettingsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../SignalingServersSettingsFeatureTests.swift; sourceTree = "<group>"; };
+		47B4C8D13A2E4F4B8C200003 /* ../SignalingServersSettingsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../SignalingServersSettingsFeatureTests.swift; sourceTree = "<group>"; };
 		48076E3F2B14F5CA004575F8 /* OnFirstAppearViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnFirstAppearViewModifier.swift; sourceTree = "<group>"; };
 		480E50D32B0C881000FC21D5 /* RecoverWalletWithoutProfileCoordinator+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecoverWalletWithoutProfileCoordinator+View.swift"; sourceTree = "<group>"; };
 		4813AFE12BC9A9AD0046BCAD /* Stage1MigrateToSargon+NetworkDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stage1MigrateToSargon+NetworkDefinition.swift"; sourceTree = "<group>"; };
@@ -2227,13 +2228,6 @@
 		5BEB9CD42C6F6CC9001FD9D4 /* ConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationView.swift; sourceTree = "<group>"; };
 		5BFA4FB82C736B740030B517 /* HiddenAssets+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HiddenAssets+View.swift"; sourceTree = "<group>"; };
 		5BFA4FB92C736B740030B517 /* HiddenAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenAssets.swift; sourceTree = "<group>"; };
-		A0ADBC001AD00000ADBC0002 /* AddressBookClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookClient+Interface.swift"; sourceTree = "<group>"; };
-		A0ADBC001AD00000ADBC0003 /* AddressBookClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookClient+Live.swift"; sourceTree = "<group>"; };
-		A0ADBC001AD00000ADBC0004 /* AddressBookClient+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookClient+Test.swift"; sourceTree = "<group>"; };
-		A0ADBC001AD00000ADBC0009 /* AddressBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBook.swift; sourceTree = "<group>"; };
-		A0ADBC001AD00000ADBC000A /* AddressBook+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBook+View.swift"; sourceTree = "<group>"; };
-		A0ADBC001AD00000ADBC000B /* AddressBookEntryForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEntryForm.swift; sourceTree = "<group>"; };
-		A0ADBC001AD00000ADBC000C /* AddressBookEntryForm+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookEntryForm+View.swift"; sourceTree = "<group>"; };
 		5BFED6892D4A8C6D00380E7D /* PasswordFactorSourceAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordFactorSourceAccess.swift; sourceTree = "<group>"; };
 		5BFED68A2D4A8C6D00380E7D /* PasswordFactorSourceAccess+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PasswordFactorSourceAccess+View.swift"; sourceTree = "<group>"; };
 		830818472B9F1621002D8351 /* HTTPClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPClient+Live.swift"; sourceTree = "<group>"; };
@@ -2335,6 +2329,13 @@
 		A09F8FDD2DF6E4C300DB5614 /* Discover+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Discover+View.swift"; sourceTree = "<group>"; };
 		A0A556132ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningConfirmShieldTimedRecovery.swift; sourceTree = "<group>"; };
 		A0A556142ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SigningConfirmShieldTimedRecovery+View.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC0002 /* AddressBookClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookClient+Interface.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC0003 /* AddressBookClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookClient+Live.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC0004 /* AddressBookClient+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookClient+Test.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC0009 /* AddressBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBook.swift; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC000A /* AddressBook+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBook+View.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC000B /* AddressBookEntryForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEntryForm.swift; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC000C /* AddressBookEntryForm+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookEntryForm+View.swift"; sourceTree = "<group>"; };
 		A0B566E52ED75F96002655C0 /* AccessControllerClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccessControllerClient+Interface.swift"; sourceTree = "<group>"; };
 		A0B566E62ED75F96002655C0 /* AccessControllerClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccessControllerClient+Live.swift"; sourceTree = "<group>"; };
 		A0B566E72ED75F96002655C0 /* AccessControllerClient+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccessControllerClient+Test.swift"; sourceTree = "<group>"; };
@@ -2343,6 +2344,8 @@
 		A0BA444F2E7F085D00ED76E8 /* SecurityStructureOfFactorSourcesView+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecurityStructureOfFactorSourcesView+View.swift"; sourceTree = "<group>"; };
 		A0BA90422E8167E000ED76E8 /* EditSecurityShieldCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSecurityShieldCoordinator.swift; sourceTree = "<group>"; };
 		A0BA90442E8167E600ED76E8 /* EditSecurityShieldCoordinator+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditSecurityShieldCoordinator+View.swift"; sourceTree = "<group>"; };
+		A0C31A022EDB8C7B00E00001 /* MfaFactorInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MfaFactorInstance.swift; sourceTree = "<group>"; };
+		A0C31A032EDB8C7B00E00001 /* MfaFactorInstance+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MfaFactorInstance+View.swift"; sourceTree = "<group>"; };
 		A0D201652E014893009DA055 /* BlogPostCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogPostCard.swift; sourceTree = "<group>"; };
 		A0D201672E029394009DA055 /* BlogPostsCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogPostsCarousel.swift; sourceTree = "<group>"; };
 		A0D201682E029394009DA055 /* BlogPostsCarousel+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogPostsCarousel+View.swift"; sourceTree = "<group>"; };
@@ -2370,6 +2373,7 @@
 		A0F63EF42E3F9DDF0003B4C0 /* ArculusForgotPIN-InputSeedPhrase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArculusForgotPIN-InputSeedPhrase.swift"; sourceTree = "<group>"; };
 		A0F63EF52E3F9DDF0003B4C0 /* ArculusForgotPIN-InputSeedPhrase+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArculusForgotPIN-InputSeedPhrase+View.swift"; sourceTree = "<group>"; };
 		A0FFCE382E2B7D5700C29802 /* NFCSessionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCSessionClient.swift; sourceTree = "<group>"; };
+		A1B2C3D32F0A000100112233 /* ../AddressBookFeatureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ../AddressBookFeatureTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42F4B100100BBB001 /* RelayServicesSettings+Reducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelayServicesSettings+Reducer.swift"; sourceTree = "<group>"; };
 		A1B2C3D42F4B100100BBB002 /* RelayServicesSettings+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelayServicesSettings+View.swift"; sourceTree = "<group>"; };
 		A40814312C7E0D08005E65B9 /* CodableHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodableHelper.swift; sourceTree = "<group>"; };
@@ -2663,8 +2667,6 @@
 		A43F1E222BC72884001DD3FA /* AnyRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRange.swift; sourceTree = "<group>"; };
 		A43F1E252BC96F18001DD3FA /* SecurityCenter+Reducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecurityCenter+Reducer.swift"; sourceTree = "<group>"; };
 		A43F1E272BC96F27001DD3FA /* SecurityCenter+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecurityCenter+View.swift"; sourceTree = "<group>"; };
-		A0C31A022EDB8C7B00E00001 /* MfaFactorInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MfaFactorInstance.swift; sourceTree = "<group>"; };
-		A0C31A032EDB8C7B00E00001 /* MfaFactorInstance+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MfaFactorInstance+View.swift"; sourceTree = "<group>"; };
 		A462B5762B820D2200C26D20 /* TransactionHistoryClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistoryClient+Live.swift"; sourceTree = "<group>"; };
 		A462B5772B820D2300C26D20 /* TransactionHistoryClient+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistoryClient+Mock.swift"; sourceTree = "<group>"; };
 		A462B5782B820D2300C26D20 /* TransactionHistoryClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionHistoryClient+Interface.swift"; sourceTree = "<group>"; };
@@ -2756,7 +2758,6 @@
 		E6DBA2792ADEBFB200A38425 /* SettingsViewStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewStateTests.swift; sourceTree = "<group>"; };
 		E6DBA27C2ADEBFB200A38425 /* AppFeatureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppFeatureTests.swift; sourceTree = "<group>"; };
 		E6DBA27E2ADEBFB200A38425 /* AccountDetailsFeatureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountDetailsFeatureTests.swift; sourceTree = "<group>"; };
-		A1B2C3D32F0A000100112233 /* AddressBookFeatureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ../AddressBookFeatureTests.swift; sourceTree = "<group>"; };
 		E6DBA2812ADEBFB200A38425 /* TransactionSigningFeatureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionSigningFeatureTests.swift; sourceTree = "<group>"; };
 		E6DBA2832ADEBFB200A38425 /* GatewaySettingsFeatureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewaySettingsFeatureTests.swift; sourceTree = "<group>"; };
 		E6DBA2892ADEBFB200A38425 /* CustomizeFeePayerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomizeFeePayerTests.swift; sourceTree = "<group>"; };
@@ -2881,9 +2882,10 @@
 				A0596FC02F4A016300BE7543 /* Sargon in Frameworks */,
 				A0596FBF2F4A016300BE7543 /* Sargon in Frameworks */,
 				48FFFABE2ADC209100B2B213 /* NukeUI in Frameworks */,
+				A0FEAF862FD712AF00882FE0 /* Sargon in Frameworks */,
 				A00B33422E5A4E7500528171 /* ArculusCSDK in Frameworks */,
 				A0323FD02DC0DCEB00CA31CE /* FirebaseCrashlytics in Frameworks */,
-				A0CB3BDA2F59D640004D904F /* Sargon in Frameworks */,
+				A077F8332FD414340096267F /* Sargon in Frameworks */,
 				48FFFA9F2ADC1F2700B2B213 /* KeychainAccess in Frameworks */,
 				48FFFAF72ADC241A00B2B213 /* Collections in Frameworks */,
 				48FFFAF92ADC241A00B2B213 /* DequeModule in Frameworks */,
@@ -2935,7 +2937,7 @@
 		47B4C8D13A2E4F4B8C300001 /* SignalingServersSettingsFeatureTests */ = {
 			isa = PBXGroup;
 			children = (
-				47B4C8D13A2E4F4B8C200003 /* SignalingServersSettingsFeatureTests.swift */,
+				47B4C8D13A2E4F4B8C200003 /* ../SignalingServersSettingsFeatureTests.swift */,
 			);
 			path = SignalingServersSettingsFeatureTests;
 			sourceTree = "<group>";
@@ -6228,17 +6230,6 @@
 			path = HiddenAssets;
 			sourceTree = "<group>";
 		};
-		A0ADBC001AD00000ADBC0008 /* AddressBook */ = {
-			isa = PBXGroup;
-			children = (
-				A0ADBC001AD00000ADBC0009 /* AddressBook.swift */,
-				A0ADBC001AD00000ADBC000A /* AddressBook+View.swift */,
-				A0ADBC001AD00000ADBC000B /* AddressBookEntryForm.swift */,
-				A0ADBC001AD00000ADBC000C /* AddressBookEntryForm+View.swift */,
-			);
-			path = AddressBook;
-			sourceTree = "<group>";
-		};
 		5BFED6882D4A8C4E00380E7D /* Password */ = {
 			isa = PBXGroup;
 			children = (
@@ -6468,16 +6459,6 @@
 			path = P2PTransportProfilesClient;
 			sourceTree = "<group>";
 		};
-		A0ADBC001AD00000ADBC0001 /* AddressBookClient */ = {
-			isa = PBXGroup;
-			children = (
-				A0ADBC001AD00000ADBC0002 /* AddressBookClient+Interface.swift */,
-				A0ADBC001AD00000ADBC0003 /* AddressBookClient+Live.swift */,
-				A0ADBC001AD00000ADBC0004 /* AddressBookClient+Test.swift */,
-			);
-			path = AddressBookClient;
-			sourceTree = "<group>";
-		};
 		A05AA1482E0AE07600316B83 /* Filtering */ = {
 			isa = PBXGroup;
 			children = (
@@ -6596,6 +6577,27 @@
 			path = Discover;
 			sourceTree = "<group>";
 		};
+		A0ADBC001AD00000ADBC0001 /* AddressBookClient */ = {
+			isa = PBXGroup;
+			children = (
+				A0ADBC001AD00000ADBC0002 /* AddressBookClient+Interface.swift */,
+				A0ADBC001AD00000ADBC0003 /* AddressBookClient+Live.swift */,
+				A0ADBC001AD00000ADBC0004 /* AddressBookClient+Test.swift */,
+			);
+			path = AddressBookClient;
+			sourceTree = "<group>";
+		};
+		A0ADBC001AD00000ADBC0008 /* AddressBook */ = {
+			isa = PBXGroup;
+			children = (
+				A0ADBC001AD00000ADBC0009 /* AddressBook.swift */,
+				A0ADBC001AD00000ADBC000A /* AddressBook+View.swift */,
+				A0ADBC001AD00000ADBC000B /* AddressBookEntryForm.swift */,
+				A0ADBC001AD00000ADBC000C /* AddressBookEntryForm+View.swift */,
+			);
+			path = AddressBook;
+			sourceTree = "<group>";
+		};
 		A0B566E82ED75F96002655C0 /* AccessControllerClient */ = {
 			isa = PBXGroup;
 			children = (
@@ -6604,6 +6606,15 @@
 				A0B566E72ED75F96002655C0 /* AccessControllerClient+Test.swift */,
 			);
 			path = AccessControllerClient;
+			sourceTree = "<group>";
+		};
+		A0C31A042EDB8C7B00E00001 /* MfaFactorInstance */ = {
+			isa = PBXGroup;
+			children = (
+				A0C31A022EDB8C7B00E00001 /* MfaFactorInstance.swift */,
+				A0C31A032EDB8C7B00E00001 /* MfaFactorInstance+View.swift */,
+			);
+			path = MfaFactorInstance;
 			sourceTree = "<group>";
 		};
 		A0D742A62DD478BD0062DB01 /* ThemeSelection */ = {
@@ -6673,6 +6684,14 @@
 				A03194202E411A640015C231 /* ArculusForgotPIN-EnterNewPIN+View.swift */,
 			);
 			path = ForgotPIN;
+			sourceTree = "<group>";
+		};
+		A1B2C3D22F0A000100112233 /* AddressBookFeatureTests */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D32F0A000100112233 /* ../AddressBookFeatureTests.swift */,
+			);
+			path = AddressBookFeatureTests;
 			sourceTree = "<group>";
 		};
 		A1B2C3D42F4B100100CCC001 /* RelayServicesSettingsFeature */ = {
@@ -7013,15 +7032,6 @@
 			path = SecurityCenterFeature;
 			sourceTree = "<group>";
 		};
-		A0C31A042EDB8C7B00E00001 /* MfaFactorInstance */ = {
-			isa = PBXGroup;
-			children = (
-				A0C31A022EDB8C7B00E00001 /* MfaFactorInstance.swift */,
-				A0C31A032EDB8C7B00E00001 /* MfaFactorInstance+View.swift */,
-			);
-			path = MfaFactorInstance;
-			sourceTree = "<group>";
-		};
 		A462B5752B820D1200C26D20 /* TransactionHistoryClient */ = {
 			isa = PBXGroup;
 			children = (
@@ -7339,14 +7349,6 @@
 				E62BB7622AEA856300D46DAC /* ImportMnemonicGridTests.swift */,
 			);
 			path = Features;
-			sourceTree = "<group>";
-		};
-		A1B2C3D22F0A000100112233 /* AddressBookFeatureTests */ = {
-			isa = PBXGroup;
-			children = (
-				A1B2C3D32F0A000100112233 /* AddressBookFeatureTests.swift */,
-			);
-			path = AddressBookFeatureTests;
 			sourceTree = "<group>";
 		};
 		E6DBA2782ADEBFB200A38425 /* SettingsFeatureTests */ = {
@@ -8043,7 +8045,8 @@
 				A0DA89132E96A2CF005254CB /* Sargon */,
 				A06AD20D2F2A5403009004C5 /* Sargon */,
 				A0596FCE2F4A01F700BE7543 /* Sargon */,
-				A0CB3BD92F59D640004D904F /* Sargon */,
+				A077F8322FD414340096267F /* Sargon */,
+				A0FEAF852FD712AF00882FE0 /* Sargon */,
 			);
 			productName = RadixWallet;
 			productReference = 48CFBC4F2ADC106300E77A5C /* Radix Wallet Dev.app */;
@@ -8107,7 +8110,7 @@
 				A0C673032DA6BD7F0071606B /* XCRemoteSwiftPackageReference "ScreenshotPreventing-iOS" */,
 				A0323FCE2DC0DCEB00CA31CE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				A00B33402E5A4E7500528171 /* XCLocalSwiftPackageReference "arculus-ios-csdk" */,
-				A0CB3BD82F59D640004D904F /* XCRemoteSwiftPackageReference "sargon" */,
+				A0FEAF842FD712AF00882FE0 /* XCRemoteSwiftPackageReference "sargon" */,
 			);
 			productRefGroup = 48CFBC502ADC106300E77A5C /* Products */;
 			projectDirPath = "";
@@ -8248,7 +8251,7 @@
 				E6DBA31E2ADEBFB300A38425 /* DataChannelMocks.swift in Sources */,
 				E6DBA3412ADEBFB300A38425 /* ValidationTests.swift in Sources */,
 				4827520C2BDA5CA5007854E0 /* GatewaySettingsFeatureTests.swift in Sources */,
-				47B4C8D13A2E4F4B8C100003 /* SignalingServersSettingsFeatureTests.swift in Sources */,
+				47B4C8D13A2E4F4B8C100003 /* ../SignalingServersSettingsFeatureTests.swift in Sources */,
 				4827520E2BDA5E50007854E0 /* TransactionClientTests.swift in Sources */,
 				E6DBA32A2ADEBFB300A38425 /* TestCase.swift in Sources */,
 				E6DBA3732ADEBFB300A38425 /* ROLAClientTests.swift in Sources */,
@@ -8282,7 +8285,7 @@
 				E6DBA3332ADEBFB300A38425 /* TransactionSigningFeatureTests.swift in Sources */,
 				E6DBA36D2ADEBFB300A38425 /* KeychainHolderTests.swift in Sources */,
 				E6DBA3872ADEBFB300A38425 /* LedgerModelTests.swift in Sources */,
-				A1B2C3D42F0A000100112233 /* AddressBookFeatureTests.swift in Sources */,
+				A1B2C3D42F0A000100112233 /* ../AddressBookFeatureTests.swift in Sources */,
 				E6DBA3312ADEBFB300A38425 /* AccountDetailsFeatureTests.swift in Sources */,
 				E6DBA32E2ADEBFB300A38425 /* SettingsViewStateTests.swift in Sources */,
 				E6DBA36F2ADEBFB300A38425 /* OnLedgerEntitiesClientTests.swift in Sources */,
@@ -10332,12 +10335,12 @@
 				revision = 783b968ed2c6a6318896589d108de1141d434939;
 			};
 		};
-		A0CB3BD82F59D640004D904F /* XCRemoteSwiftPackageReference "sargon" */ = {
+		A0FEAF842FD712AF00882FE0 /* XCRemoteSwiftPackageReference "sargon" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/radixdlt/sargon";
 			requirement = {
 				kind = exactVersion;
-				version = 1.2.57;
+				version = 1.2.58;
 			};
 		};
 		A415574E2B757C5E0040AD4E /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
@@ -10530,6 +10533,10 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = Sargon;
 		};
+		A077F8322FD414340096267F /* Sargon */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Sargon;
+		};
 		A0830CCD2E428E8700DF1F08 /* Sargon */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Sargon;
@@ -10552,11 +10559,6 @@
 			package = A0C673032DA6BD7F0071606B /* XCRemoteSwiftPackageReference "ScreenshotPreventing-iOS" */;
 			productName = ScreenshotPreventingSwiftUI;
 		};
-		A0CB3BD92F59D640004D904F /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A0CB3BD82F59D640004D904F /* XCRemoteSwiftPackageReference "sargon" */;
-			productName = Sargon;
-		};
 		A0DA89132E96A2CF005254CB /* Sargon */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Sargon;
@@ -10567,6 +10569,11 @@
 		};
 		A0FDC0152DB7BAE900F571BA /* Sargon */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = Sargon;
+		};
+		A0FEAF852FD712AF00882FE0 /* Sargon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A0FEAF842FD712AF00882FE0 /* XCRemoteSwiftPackageReference "sargon" */;
 			productName = Sargon;
 		};
 		A415574F2B757C5E0040AD4E /* ComposableArchitecture */ = {

--- a/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e1d8aa048762e747fd82643b4cc07705f45d75e9bbf12a39bace092889e6a597",
+  "originHash" : "5762f6f6c436cd6d2efdb40ba9c96997a9a366e46431a5b3db5e68f0bf09772a",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/radixdlt/sargon",
       "state" : {
-        "revision" : "2112e0f3f61260896ca9b08f7d6cecb54ae4a28e",
-        "version" : "1.2.57"
+        "revision" : "3638bd01fcc0d4073bc938f7eca06995c8d70712",
+        "version" : "1.2.58"
       }
     },
     {

--- a/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
+++ b/RadixWallet/Clients/AccountPortfoliosClient/AccountPortfoliosClient+State.swift
@@ -401,7 +401,10 @@ extension AccountPortfoliosClient.AccountPortfolio {
 			stakeUnitDetails,
 			nonFungibleIds.errorFallback([])
 		).map { poolUnitDetails, stakeUnitDetails, nonFungibleValues in
-			let totalFiatWorth = account.fungibleResources.fiatWorth + stakeUnitDetails.fiatWorth + poolUnitDetails.fiatWorth + nonFungibleValues.fiatWorth
+			let totalFiatWorth = account.fungibleResources.fiatWorth +
+				stakeUnitDetails.fiatWorth +
+				poolUnitDetails.fiatWorth +
+				nonFungibleValues.fiatWorth.unknownFallback()
 			return .init(isVisible: isCurrencyAmountVisible, worth: totalFiatWorth, currency: fiatCurrency)
 		}
 		.errorFallback(.unknownWorth(isVisible: isCurrencyAmountVisible, currency: fiatCurrency))

--- a/RadixWallet/Clients/GatewaysClient/GatewaysClient+Test.swift
+++ b/RadixWallet/Clients/GatewaysClient/GatewaysClient+Test.swift
@@ -24,8 +24,8 @@ extension GatewaysClient: TestDependencyKey {
 	static let noop = Self(
 		currentGatewayValues: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
 		gatewaysValues: { AsyncLazySequence([]).eraseToAnyAsyncSequence() },
-		getAllGateways: { [.nebunet] },
-		getCurrentGateway: { .nebunet },
+		getAllGateways: { [Gateway.mainnet] },
+		getCurrentGateway: { .mainnet },
 		addGateway: { _ in },
 		removeGateway: { _ in },
 		changeGateway: { _ in },

--- a/RadixWallet/Clients/HomeCardsClient/HomeCardsClient+Live.swift
+++ b/RadixWallet/Clients/HomeCardsClient/HomeCardsClient+Live.swift
@@ -9,7 +9,7 @@ extension HomeCardsClient: DependencyKey {
 
 		// We are hardcoding to `.mainnet` because the cards are currently gateway agnostic. In the future, when Profile is integrated into Sargon, it will be Sargon
 		// observing the current gateway and defining the networkId to use.
-		let manager = HomeCardsManager(networkingDriver: URLSession.shared, networkId: .mainnet, cardsStorage: HomeCardsStorage(), observer: observer)
+		let manager = HomeCardsManager(networkingDriver: URLSession.shared, gateway: Gateway.mainnet, cardsStorage: HomeCardsStorage(), observer: observer)
 
 		Task {
 			for try await event in appEventsClient.events() {

--- a/RadixWallet/Clients/RadixNameServiceClient/RadixNameService+Live.swift
+++ b/RadixWallet/Clients/RadixNameServiceClient/RadixNameService+Live.swift
@@ -6,11 +6,11 @@ extension RadixNameServiceClient: DependencyKey {
 
 		return Self(
 			resolveReceiverAccountForDomain: { domain in
-				let network = await gatewaysClient.getCurrentNetworkID()
+				let gateway = await gatewaysClient.getCurrentGateway()
 
 				let rns = try RadixNameService(
 					networkingDriver: URLSession.shared,
-					networkId: network
+					gateway: gateway
 				)
 
 				return try await rns.resolveReceiverAccountForDomain(domain: domain)

--- a/RadixWallet/Core/FeaturePrelude/Loadable.swift
+++ b/RadixWallet/Core/FeaturePrelude/Loadable.swift
@@ -188,7 +188,7 @@ extension Loadable {
 
     func errorFallback(_ fallback: Value) -> Loadable<Value> {
         if case let .failure(error) = self {
-            assertionFailure("error")
+            assertionFailure("error \(error)")
             return .success(fallback)
         }
         return self

--- a/RadixWallet/Core/SharedModels/Assets/FiatWorth.swift
+++ b/RadixWallet/Core/SharedModels/Assets/FiatWorth.swift
@@ -16,6 +16,10 @@ struct FiatWorth: Hashable {
 	enum Worth: Hashable {
 		case known(Decimal192)
 		case unknown
+
+		func unknownFallback(_ value: Decimal192 = .zero) -> Self {
+			.known(value)
+		}
 	}
 
 	var isVisible: Bool

--- a/RadixWallet/Features/AccountRecoveryScan/Children/AccountRecoveryScanInProgress/AccountRecoveryScanInProgress.swift
+++ b/RadixWallet/Features/AccountRecoveryScan/Children/AccountRecoveryScanInProgress/AccountRecoveryScanInProgress.swift
@@ -307,10 +307,9 @@ extension AccountRecoveryScanInProgress {
 		assert(accounts.count == batchSize)
 		state.status = .scanningNetworkForActiveAccounts
 		loggerGlobal.debug("Scanning ledger with accounts with addresses: \(accounts.map(\.address))")
-		return .run { [networkID = state.networkID] send in
+		return .run { send in
 			let deletedAccountAddresses: [AccountAddress] = try await SargonOS.shared
 				.checkAccountsDeletedOnLedger(
-					networkId: networkID,
 					accountAddresses: accounts.map(\.address)
 				)
 				.compactMap { accountAddress, isDeleted in

--- a/RadixWallet/Features/AssetTransferFeature/Components/ChooseRecipient/ChooseTransferRecipient+View.swift
+++ b/RadixWallet/Features/AssetTransferFeature/Components/ChooseRecipient/ChooseTransferRecipient+View.swift
@@ -63,7 +63,7 @@ extension ChooseTransferRecipient.State {
 		guard let address = validatedManualAccountAddress else {
 			return nil
 		}
-		return addressBookEntries.first(where: { $0.address == address })
+		return addressBookEntries.first(where: { $0.address == address.asGeneral })
 	}
 
 	var canStoreValidatedManualRecipientInAddressBook: Bool {

--- a/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
+++ b/RadixWallet/Features/DappInteractionFeature/Interactor/DappInteractor.swift
@@ -503,7 +503,7 @@ extension DappInteractionClient.ValidatedDappRequest.InvalidRequestReason {
 	}
 
 	private func networkName(for networkID: NetworkID) -> String {
-		Gateway.forNetwork(id: networkID).network.displayDescription
+		try! NetworkDefinition.lookupBy(id: networkID).displayDescription
 	}
 }
 

--- a/RadixWallet/Features/GatewaySettingsFeature/Components/GatewayList/GatewayList+View.swift
+++ b/RadixWallet/Features/GatewaySettingsFeature/Components/GatewayList/GatewayList+View.swift
@@ -53,7 +53,7 @@ struct GatewayList_Preview: PreviewProvider {
 extension GatewayList.State {
 	static let previewValue = Self(
 		gateways: [
-			.previewValue1, .previewValue2, .previewValue3,
+			.previewValue1, .previewValue2,
 		].asIdentified()
 	)
 }

--- a/RadixWallet/Features/GatewaySettingsFeature/Components/GatewayRow/GatewayRow+View.swift
+++ b/RadixWallet/Features/GatewaySettingsFeature/Components/GatewayRow/GatewayRow+View.swift
@@ -89,19 +89,13 @@ struct GatewayRow_Preview: PreviewProvider {
 
 extension GatewayRow.State {
 	static let previewValue1 = Self(
-		gateway: .nebunet,
+		gateway: .mainnet,
 		isSelected: true,
 		canBeDeleted: false
 	)
 
 	static let previewValue2 = Self(
-		gateway: .hammunet,
-		isSelected: false,
-		canBeDeleted: true
-	)
-
-	static let previewValue3 = Self(
-		gateway: .enkinet,
+		gateway: .stokenet,
 		isSelected: false,
 		canBeDeleted: true
 	)

--- a/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+NetworkDefinition.swift
+++ b/RadixWallet/MIGRATE_TO_SARGON/Stage1/Stage1MigrateToSargon+NetworkDefinition.swift
@@ -1,10 +1,15 @@
 import Foundation
 import Sargon
+import SargonUniFFI
 import Tagged
 
 extension NetworkDefinition {
 	typealias Name = Tagged<Self, String>
 	static func lookupBy(name: Name) throws -> Self {
 		try lookupBy(logicalName: name.rawValue)
+	}
+
+	static func lookupBy(id: NetworkID) throws -> Self {
+		try lookupBy(networkId: id)
 	}
 }

--- a/RadixWalletLight.xcodeproj/project.pbxproj
+++ b/RadixWalletLight.xcodeproj/project.pbxproj
@@ -846,7 +846,6 @@
 		A00697CB2DB8D3A900810D36 /* DisplayMnemonic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00697C92DB8D3A900810D36 /* DisplayMnemonic.swift */; };
 		A00697CC2DB8D3A900810D36 /* DisplayMnemonic+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00697CA2DB8D3A900810D36 /* DisplayMnemonic+View.swift */; };
 		A00697CF2DBA304F00810D36 /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A00697CE2DBA304F00810D36 /* Sargon */; };
-		A008463B2EE98F4600676898 /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A008463A2EE98F4600676898 /* Sargon */; };
 		A00CC6D92E157978005278AE /* AddFactorSource-SelectKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00CC6D72E157978005278AE /* AddFactorSource-SelectKind.swift */; };
 		A00CC6DA2E157978005278AE /* AddFactorSoruce-SelectKind+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00CC6D82E157978005278AE /* AddFactorSoruce-SelectKind+View.swift */; };
 		A00CC6DD2E166043005278AE /* AddFactorSourceIntro+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00CC6DC2E166043005278AE /* AddFactorSourceIntro+View.swift */; };
@@ -878,6 +877,7 @@
 		A05AA1472E0AC13600316B83 /* DAppDirectory+Filtering.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05AA1442E0AC13600316B83 /* DAppDirectory+Filtering.swift */; };
 		A0600D372DCE02E000A2ADD3 /* AssetListSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0600D362DCE02D300A2ADD3 /* AssetListSeparator.swift */; };
 		A0600D392DD35B2A00A2ADD3 /* DarkModeTintedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0600D382DD35B2200A2ADD3 /* DarkModeTintedImage.swift */; };
+		A06155412FD34FE5005EB121 /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A06155402FD34FE5005EB121 /* Sargon */; };
 		A06323E52DFAC29B00963A1F /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A06323E42DFAC29B00963A1F /* Sargon */; };
 		A06323E92DFC308200963A1F /* LearnAbout+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06323E82DFC308200963A1F /* LearnAbout+View.swift */; };
 		A06323EA2DFC308200963A1F /* LearnAbout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06323E72DFC308200963A1F /* LearnAbout.swift */; };
@@ -909,6 +909,13 @@
 		A0A53EBA2E54DAA500BE36FE /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A0A53EB92E54DAA500BE36FE /* Sargon */; };
 		A0A556152ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A556132ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery.swift */; };
 		A0A556162ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A556142ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery+View.swift */; };
+		A0ADBC001AD00000ADBC0005 /* AddressBookClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0002 /* AddressBookClient+Interface.swift */; };
+		A0ADBC001AD00000ADBC0006 /* AddressBookClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0003 /* AddressBookClient+Live.swift */; };
+		A0ADBC001AD00000ADBC0007 /* AddressBookClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0004 /* AddressBookClient+Test.swift */; };
+		A0ADBC001AD00000ADBC000D /* AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC0009 /* AddressBook.swift */; };
+		A0ADBC001AD00000ADBC000E /* AddressBook+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC000A /* AddressBook+View.swift */; };
+		A0ADBC001AD00000ADBC000F /* AddressBookEntryForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC000B /* AddressBookEntryForm.swift */; };
+		A0ADBC001AD00000ADBC0010 /* AddressBookEntryForm+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ADBC001AD00000ADBC000C /* AddressBookEntryForm+View.swift */; };
 		A0B566E92ED75F96002655C0 /* AccessControllerClient+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B566E52ED75F96002655C0 /* AccessControllerClient+Interface.swift */; };
 		A0B566EA2ED75F96002655C0 /* AccessControllerClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B566E62ED75F96002655C0 /* AccessControllerClient+Live.swift */; };
 		A0B566EB2ED75F96002655C0 /* AccessControllerClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B566E72ED75F96002655C0 /* AccessControllerClient+Test.swift */; };
@@ -917,6 +924,8 @@
 		A0BA44512E7F085D00ED76E8 /* SecurityStructureOfFactorSourcesView+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BA444F2E7F085D00ED76E8 /* SecurityStructureOfFactorSourcesView+View.swift */; };
 		A0BA90432E8167E000ED76E8 /* EditSecurityShieldCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BA90422E8167E000ED76E8 /* EditSecurityShieldCoordinator.swift */; };
 		A0BA90452E8167E600ED76E8 /* EditSecurityShieldCoordinator+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BA90442E8167E600ED76E8 /* EditSecurityShieldCoordinator+View.swift */; };
+		A0C31A002EDB8C7B00E00001 /* MfaFactorInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C31A022EDB8C7B00E00001 /* MfaFactorInstance.swift */; };
+		A0C31A012EDB8C7B00E00001 /* MfaFactorInstance+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C31A032EDB8C7B00E00001 /* MfaFactorInstance+View.swift */; };
 		A0C673052DA6BD7F0071606B /* ScreenshotPreventing in Frameworks */ = {isa = PBXBuildFile; productRef = A0C673042DA6BD7F0071606B /* ScreenshotPreventing */; };
 		A0C673072DA6BD7F0071606B /* ScreenshotPreventingSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = A0C673062DA6BD7F0071606B /* ScreenshotPreventingSwiftUI */; };
 		A0CBEFF62F5B1F8D004D904F /* P2PTransportProfilesClient+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0CBEFF42F5B1F8D004D904F /* P2PTransportProfilesClient+Test.swift */; };
@@ -946,6 +955,7 @@
 		A0DA89142E96A2CF005254CB /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A0DA89132E96A2CF005254CB /* Sargon */; };
 		A0E77D7F2ED091A00092D8DA /* HandleAccessControllerTimedRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0E77D7D2ED091A00092D8DA /* HandleAccessControllerTimedRecovery.swift */; };
 		A0E77D802ED091A00092D8DA /* HandleAccessControllerTimedRecovery+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0E77D7E2ED091A00092D8DA /* HandleAccessControllerTimedRecovery+View.swift */; };
+		A0ED332B2FD8260600E1C2AC /* Sargon in Frameworks */ = {isa = PBXBuildFile; productRef = A0ED332A2FD8260600E1C2AC /* Sargon */; };
 		A0F223762DDC6C3600035389 /* DAppsDirectory+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F223752DDC6C3600035389 /* DAppsDirectory+View.swift */; };
 		A0F223772DDC6C3600035389 /* DAppsDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F223742DDC6C3600035389 /* DAppsDirectory.swift */; };
 		A0F2237C2DDC6D1C00035389 /* DAppsDirectoryClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F2237A2DDC6D1C00035389 /* DAppsDirectoryClient+Live.swift */; };
@@ -2304,6 +2314,13 @@
 		A09F8FDD2DF6E4C300DB5614 /* Discover+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Discover+View.swift"; sourceTree = "<group>"; };
 		A0A556132ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningConfirmShieldTimedRecovery.swift; sourceTree = "<group>"; };
 		A0A556142ECD99FE0097B7FA /* SigningConfirmShieldTimedRecovery+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SigningConfirmShieldTimedRecovery+View.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC0002 /* AddressBookClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookClient+Interface.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC0003 /* AddressBookClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookClient+Live.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC0004 /* AddressBookClient+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookClient+Test.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC0009 /* AddressBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBook.swift; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC000A /* AddressBook+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBook+View.swift"; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC000B /* AddressBookEntryForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookEntryForm.swift; sourceTree = "<group>"; };
+		A0ADBC001AD00000ADBC000C /* AddressBookEntryForm+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressBookEntryForm+View.swift"; sourceTree = "<group>"; };
 		A0B566E52ED75F96002655C0 /* AccessControllerClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccessControllerClient+Interface.swift"; sourceTree = "<group>"; };
 		A0B566E62ED75F96002655C0 /* AccessControllerClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccessControllerClient+Live.swift"; sourceTree = "<group>"; };
 		A0B566E72ED75F96002655C0 /* AccessControllerClient+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccessControllerClient+Test.swift"; sourceTree = "<group>"; };
@@ -2312,6 +2329,8 @@
 		A0BA444F2E7F085D00ED76E8 /* SecurityStructureOfFactorSourcesView+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecurityStructureOfFactorSourcesView+View.swift"; sourceTree = "<group>"; };
 		A0BA90422E8167E000ED76E8 /* EditSecurityShieldCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSecurityShieldCoordinator.swift; sourceTree = "<group>"; };
 		A0BA90442E8167E600ED76E8 /* EditSecurityShieldCoordinator+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditSecurityShieldCoordinator+View.swift"; sourceTree = "<group>"; };
+		A0C31A022EDB8C7B00E00001 /* MfaFactorInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MfaFactorInstance.swift; sourceTree = "<group>"; };
+		A0C31A032EDB8C7B00E00001 /* MfaFactorInstance+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MfaFactorInstance+View.swift"; sourceTree = "<group>"; };
 		A0CBEFF22F5B1F8D004D904F /* P2PTransportProfilesClient+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "P2PTransportProfilesClient+Interface.swift"; sourceTree = "<group>"; };
 		A0CBEFF32F5B1F8D004D904F /* P2PTransportProfilesClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "P2PTransportProfilesClient+Live.swift"; sourceTree = "<group>"; };
 		A0CBEFF42F5B1F8D004D904F /* P2PTransportProfilesClient+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "P2PTransportProfilesClient+Test.swift"; sourceTree = "<group>"; };
@@ -2843,7 +2862,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A008463B2EE98F4600676898 /* Sargon in Frameworks */,
 				A00697CF2DBA304F00810D36 /* Sargon in Frameworks */,
 				48FFFABE2ADC209100B2B213 /* NukeUI in Frameworks */,
 				A0323FD02DC0DCEB00CA31CE /* FirebaseCrashlytics in Frameworks */,
@@ -2858,6 +2876,7 @@
 				48FFFADB2ADC21E400B2B213 /* SwiftLogConsoleColors in Frameworks */,
 				48FFFADE2ADC21F500B2B213 /* FileLogging in Frameworks */,
 				48FFFACF2ADC216400B2B213 /* CollectionConcurrencyKit in Frameworks */,
+				A06155412FD34FE5005EB121 /* Sargon in Frameworks */,
 				A070FA332E58482400CB9566 /* Sargon in Frameworks */,
 				A0F636BC2E3BA6890003B4C0 /* Sargon in Frameworks */,
 				48FFFAB12ADC203700B2B213 /* WebRTC in Frameworks */,
@@ -2877,6 +2896,7 @@
 				48FFFAFD2ADC241A00B2B213 /* HeapModule in Frameworks */,
 				48FFFAD52ADC21B900B2B213 /* LegibleError in Frameworks */,
 				A0830CCE2E428E8700DF1F08 /* Sargon in Frameworks */,
+				A0ED332B2FD8260600E1C2AC /* Sargon in Frameworks */,
 				48FFFAD82ADC21D200B2B213 /* NonEmpty in Frameworks */,
 				48FFFAE12ADC220F00B2B213 /* Tagged in Frameworks */,
 				48FFFAD22ADC218400B2B213 /* Either in Frameworks */,
@@ -4686,6 +4706,7 @@
 			isa = PBXGroup;
 			children = (
 				A0CBEFF52F5B1F8D004D904F /* P2PTransportProfilesClient */,
+				A0ADBC001AD00000ADBC0001 /* AddressBookClient */,
 				A0B566E82ED75F96002655C0 /* AccessControllerClient */,
 				A089D4342E35342F00866A47 /* ArculusCardClient */,
 				A09F8FD22DEF4D8500DB5614 /* RadixNameServiceClient */,
@@ -5944,6 +5965,7 @@
 			children = (
 				5B758D552BCE7AEC00348722 /* Preferences+View.swift */,
 				5B758D562BCE7AEC00348722 /* Preferences.swift */,
+				A0ADBC001AD00000ADBC0008 /* AddressBook */,
 				48CFBD8F2ADC10D800E77A5C /* DefaultDepositGuarantees */,
 				5B135B372C7636B6004AAD2E /* HiddenEntities */,
 				5BFA4FB72C736B500030B517 /* HiddenAssets */,
@@ -6511,6 +6533,27 @@
 			path = Discover;
 			sourceTree = "<group>";
 		};
+		A0ADBC001AD00000ADBC0001 /* AddressBookClient */ = {
+			isa = PBXGroup;
+			children = (
+				A0ADBC001AD00000ADBC0002 /* AddressBookClient+Interface.swift */,
+				A0ADBC001AD00000ADBC0003 /* AddressBookClient+Live.swift */,
+				A0ADBC001AD00000ADBC0004 /* AddressBookClient+Test.swift */,
+			);
+			path = AddressBookClient;
+			sourceTree = "<group>";
+		};
+		A0ADBC001AD00000ADBC0008 /* AddressBook */ = {
+			isa = PBXGroup;
+			children = (
+				A0ADBC001AD00000ADBC0009 /* AddressBook.swift */,
+				A0ADBC001AD00000ADBC000A /* AddressBook+View.swift */,
+				A0ADBC001AD00000ADBC000B /* AddressBookEntryForm.swift */,
+				A0ADBC001AD00000ADBC000C /* AddressBookEntryForm+View.swift */,
+			);
+			path = AddressBook;
+			sourceTree = "<group>";
+		};
 		A0B566E82ED75F96002655C0 /* AccessControllerClient */ = {
 			isa = PBXGroup;
 			children = (
@@ -6519,6 +6562,15 @@
 				A0B566E72ED75F96002655C0 /* AccessControllerClient+Test.swift */,
 			);
 			path = AccessControllerClient;
+			sourceTree = "<group>";
+		};
+		A0C31A042EDB8C7B00E00001 /* MfaFactorInstance */ = {
+			isa = PBXGroup;
+			children = (
+				A0C31A022EDB8C7B00E00001 /* MfaFactorInstance.swift */,
+				A0C31A032EDB8C7B00E00001 /* MfaFactorInstance+View.swift */,
+			);
+			path = MfaFactorInstance;
 			sourceTree = "<group>";
 		};
 		A0CBEFF52F5B1F8D004D904F /* P2PTransportProfilesClient */ = {
@@ -6943,6 +6995,7 @@
 				A43F1E252BC96F18001DD3FA /* SecurityCenter+Reducer.swift */,
 				A43F1E272BC96F27001DD3FA /* SecurityCenter+View.swift */,
 				E775A1BF2D004FBC00E72DB9 /* ConfigurationBackup */,
+				A0C31A042EDB8C7B00E00001 /* MfaFactorInstance */,
 				5B6499B42BCFD0C7000F2176 /* SecurityFactors */,
 			);
 			path = SecurityCenterFeature;
@@ -7955,7 +8008,8 @@
 				A070FA322E58482400CB9566 /* Sargon */,
 				A029CF032E79492700F7F325 /* Sargon */,
 				A0DA89132E96A2CF005254CB /* Sargon */,
-				A008463A2EE98F4600676898 /* Sargon */,
+				A06155402FD34FE5005EB121 /* Sargon */,
+				A0ED332A2FD8260600E1C2AC /* Sargon */,
 			);
 			productName = RadixWallet;
 			productReference = 48CFBC4F2ADC106300E77A5C /* Radix Wallet Dev.app */;
@@ -8018,7 +8072,7 @@
 				8318BB172BC8403800057BCB /* XCRemoteSwiftPackageReference "swift-custom-dump" */,
 				A0C673032DA6BD7F0071606B /* XCRemoteSwiftPackageReference "ScreenshotPreventing-iOS" */,
 				A0323FCE2DC0DCEB00CA31CE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
-				A00846392EE98F4600676898 /* XCRemoteSwiftPackageReference "sargon" */,
+				A0ED33292FD8260600E1C2AC /* XCRemoteSwiftPackageReference "sargon" */,
 			);
 			productRefGroup = 48CFBC502ADC106300E77A5C /* Products */;
 			projectDirPath = "";
@@ -8298,6 +8352,13 @@
 				E79DD1C02CE756C400B1EB86 /* DeleteAccountCoordinator+View.swift in Sources */,
 				5BFA4FBA2C736B740030B517 /* HiddenAssets+View.swift in Sources */,
 				5BFA4FBB2C736B740030B517 /* HiddenAssets.swift in Sources */,
+				A0ADBC001AD00000ADBC0005 /* AddressBookClient+Interface.swift in Sources */,
+				A0ADBC001AD00000ADBC0006 /* AddressBookClient+Live.swift in Sources */,
+				A0ADBC001AD00000ADBC0007 /* AddressBookClient+Test.swift in Sources */,
+				A0ADBC001AD00000ADBC000D /* AddressBook.swift in Sources */,
+				A0ADBC001AD00000ADBC000E /* AddressBook+View.swift in Sources */,
+				A0ADBC001AD00000ADBC000F /* AddressBookEntryForm.swift in Sources */,
+				A0ADBC001AD00000ADBC0010 /* AddressBookEntryForm+View.swift in Sources */,
 				A4DCCC502C2DA32C00438A7B /* HomeCardsClient+Interface.swift in Sources */,
 				48CFC4162ADC10DA00E77A5C /* PasteboardClient+Test.swift in Sources */,
 				A40815BF2C7E0D08005E65B9 /* NetworkConfigurationResponse.swift in Sources */,
@@ -9285,6 +9346,7 @@
 				A40815DB2C7E0D08005E65B9 /* ProgrammaticScryptoSborValueMap.swift in Sources */,
 				A408161B2C7E0D08005E65B9 /* StateEntityNonFungibleResourceVaultsPageResponse.swift in Sources */,
 				A43F1E262BC96F18001DD3FA /* SecurityCenter+Reducer.swift in Sources */,
+				A0C31A002EDB8C7B00E00001 /* MfaFactorInstance.swift in Sources */,
 				A0E77D7F2ED091A00092D8DA /* HandleAccessControllerTimedRecovery.swift in Sources */,
 				A0E77D802ED091A00092D8DA /* HandleAccessControllerTimedRecovery+View.swift in Sources */,
 				48CFC43D2ADC10DA00E77A5C /* FactorSourcesClient+Test.swift in Sources */,
@@ -9322,6 +9384,7 @@
 				48CFC6912ADC10DB00E77A5C /* MigratedAccount.swift in Sources */,
 				A41557552B7645F70040AD4E /* TransactionHistory+View.swift in Sources */,
 				48CFC47D2ADC10DA00E77A5C /* TransportProfileClient+Interface.swift in Sources */,
+				A0C31A012EDB8C7B00E00001 /* MfaFactorInstance+View.swift in Sources */,
 				A40815ED2C7E0D08005E65B9 /* PublicKeyType.swift in Sources */,
 				48CFC5792ADC10DA00E77A5C /* FungibleResourcesCollectionItem.swift in Sources */,
 				48CFC3FE2ADC10D900E77A5C /* RTCDataChannel+Delegate.swift in Sources */,
@@ -10204,14 +10267,6 @@
 				version = 1.3.2;
 			};
 		};
-		A00846392EE98F4600676898 /* XCRemoteSwiftPackageReference "sargon" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/radixdlt/sargon";
-			requirement = {
-				kind = exactVersion;
-				version = 1.2.52;
-			};
-		};
 		A0323FCE2DC0DCEB00CA31CE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -10226,6 +10281,14 @@
 			requirement = {
 				kind = revision;
 				revision = 783b968ed2c6a6318896589d108de1141d434939;
+			};
+		};
+		A0ED33292FD8260600E1C2AC /* XCRemoteSwiftPackageReference "sargon" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/radixdlt/sargon";
+			requirement = {
+				kind = exactVersion;
+				version = 1.2.58;
 			};
 		};
 		A415574E2B757C5E0040AD4E /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
@@ -10385,11 +10448,6 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = Sargon;
 		};
-		A008463A2EE98F4600676898 /* Sargon */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A00846392EE98F4600676898 /* XCRemoteSwiftPackageReference "sargon" */;
-			productName = Sargon;
-		};
 		A029CF032E79492700F7F325 /* Sargon */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Sargon;
@@ -10400,6 +10458,10 @@
 			productName = FirebaseCrashlytics;
 		};
 		A04207F32DE9DDB600FE2947 /* Sargon */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Sargon;
+		};
+		A06155402FD34FE5005EB121 /* Sargon */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Sargon;
 		};
@@ -10439,6 +10501,11 @@
 		};
 		A0DA89132E96A2CF005254CB /* Sargon */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = Sargon;
+		};
+		A0ED332A2FD8260600E1C2AC /* Sargon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A0ED33292FD8260600E1C2AC /* XCRemoteSwiftPackageReference "sargon" */;
 			productName = Sargon;
 		};
 		A0F636BB2E3BA6890003B4C0 /* Sargon */ = {

--- a/RadixWalletLight.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RadixWalletLight.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9077ba61641c81a4c04a78f678440d797344c26b6576f1bcb258d5d3d2974d27",
+  "originHash" : "9c4630445f950250a16e52fdea45a763bbca5202e3993163fd772f8dd101fd2d",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/radixdlt/sargon",
       "state" : {
-        "revision" : "be5a80f9ec53620eeb3b7e9044331a843933f099",
-        "version" : "1.2.52"
+        "revision" : "3638bd01fcc0d4073bc938f7eca06995c8d70712",
+        "version" : "1.2.58"
       }
     },
     {


### PR DESCRIPTION
**PR Summary**

Updates wallet code for the newer Sargon gateway APIs and custom gateway support.

**Changes**
- Bumps Sargon to `1.2.58` in both normal and light projects.
- Switches gateway-dependent clients to pass full `Gateway` values instead of just `NetworkID`.
- Updates RNS resolution, home cards, account recovery scan, and dApp network-name display for the new Sargon API shape.
- Adds `NetworkDefinition.lookupBy(id:)` helper.
- Fixes address-book account matching by comparing against `address.asGeneral`.
- Improves `Loadable.errorFallback` assertion logging with the underlying error.
- Handles unknown NFT fiat worth as zero when calculating total account portfolio fiat worth.
- Updates gateway previews/test defaults from old test networks to mainnet/stokenet.